### PR TITLE
update CORS Middleware origins to wildcard for production staging

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -36,7 +36,7 @@ app = FastAPI(lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000"],
+    allow_origins=["*"],
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
# Temporary update CORS origins setting to wildcard "*" to allow testing of different deployments of client side