### PR TITLE
Feature/folder management

### DIFF
--- a/client/components/home/sidebar/BrowseByCategoryButton.tsx
+++ b/client/components/home/sidebar/BrowseByCategoryButton.tsx
@@ -1,9 +1,16 @@
 // components/sidebar/BrowseByCategoryButton.tsx
 import React from "react";
+import { useRouter } from "next/navigation";
 import SidebarButton from "./SidebarButton";
 
 const BrowseByCategoryButton = () => {
-  return <SidebarButton label="Browse by Category" icon="📚" />;
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push("/categories");
+  };
+
+  return <SidebarButton label="Browse by Category" icon="📚" onClick={handleClick} />;
 };
 
 export default BrowseByCategoryButton;

--- a/client/components/home/sidebar/FoldersButton.tsx
+++ b/client/components/home/sidebar/FoldersButton.tsx
@@ -1,9 +1,16 @@
 // components/sidebar/FoldersButton.tsx
 import React from "react";
+import { useRouter } from "next/navigation";
 import SidebarButton from "./SidebarButton";
 
 const FoldersButton = () => {
-  return <SidebarButton label="Folders" icon="📁" />;
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push("/folders");
+  };
+
+  return <SidebarButton label="Folders" icon="📁" onClick={handleClick} />;
 };
 
 export default FoldersButton;

--- a/client/components/home/sidebar/GenerateQuizButton.tsx
+++ b/client/components/home/sidebar/GenerateQuizButton.tsx
@@ -2,19 +2,17 @@
 "use client";
 
 import React from "react";
-import { useRouter } from "next/router"; // Pages Router
+import { useRouter } from "next/navigation";
 import SidebarButton from "./SidebarButton";
 
-const GenerateQuizButton: React.FC = () => {
+const GenerateQuizButton = () => {
   const router = useRouter();
 
-  return (
-    <SidebarButton
-      label="Generate Quiz"
-      icon="🧠"
-      onClick={() => router.push("/generate")}
-    />
-  );
+  const handleClick = () => {
+    router.push("/generate");
+  };
+
+  return <SidebarButton label="Generate Quiz" icon="🧠" onClick={handleClick} />;
 };
 
 export default GenerateQuizButton;

--- a/client/components/home/sidebar/PopularQuizzesButton.tsx
+++ b/client/components/home/sidebar/PopularQuizzesButton.tsx
@@ -1,9 +1,16 @@
 // components/sidebar/PopularQuizzesButton.tsx
 import React from "react";
+import { useRouter } from "next/navigation";
 import SidebarButton from "./SidebarButton";
 
 const PopularQuizzesButton = () => {
-  return <SidebarButton label="Popular Quizzes" icon="🌟" />;
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.push("/popular-quizzes");
+  };
+
+  return <SidebarButton label="Popular Quizzes" icon="🌟" onClick={handleClick} />;
 };
 
 export default PopularQuizzesButton;

--- a/client/components/home/sidebar/SavedQuizzesButton.tsx
+++ b/client/components/home/sidebar/SavedQuizzesButton.tsx
@@ -1,9 +1,18 @@
 // components/sidebar/SavedQuizzesButton.tsx
 import React from "react";
+import { useRouter } from "next/navigation";
 import SidebarButton from "./SidebarButton";
 
 const SavedQuizzesButton = () => {
-  return <SidebarButton label="Saved Quizzes" icon="💾" />;
+  const router = useRouter();
+
+  const handleClick = () => {
+    const userId = "userId"; // replace with real userId when available
+    const query = new URLSearchParams({ userId }).toString();
+    router.push(`/saved-quizzes?${query}`);
+  };
+
+  return <SidebarButton label="Saved Quizzes" icon="💾" onClick={handleClick} />;
 };
 
 export default SavedQuizzesButton;

--- a/client/components/home/sidebar/UpgradePlanButton.tsx
+++ b/client/components/home/sidebar/UpgradePlanButton.tsx
@@ -1,22 +1,17 @@
 "use client";
 
 import React from "react";
-import { useRouter } from "next/router";
+import { useRouter } from "next/navigation";
 import SidebarButton from "./SidebarButton";
 
-const UpgradePlanButton: React.FC = () => {
+const UpgradePlanButton = () => {
   const router = useRouter();
 
-  return (
-    <SidebarButton
-      label="Upgrade Plan"
-      icon="🚀"
-      onClick={() => {
-        // Navigate to homepage and scroll to Pricing
-        router.push("/#pricing");
-      }}
-    />
-  );
+  const handleClick = () => {
+    router.push("/#pricing");
+  };
+
+  return <SidebarButton label="Upgrade Plan" icon="🚀" onClick={handleClick} />;
 };
 
 export default UpgradePlanButton;

--- a/client/interfaces/models/generated-quiz-model.ts
+++ b/client/interfaces/models/generated-quiz-model.ts
@@ -1,5 +1,10 @@
 export interface GeneratedQuizModel {
-    question: string,
-    options?: string[],
-    answer: string | number
+    id?: string;
+    question: string;
+    question_type: string;
+    options?: string[];
+    correct_answer: string;
+    user_id?: string;
+    created_at?: string;
+    updated_at?: string;
 }

--- a/client/package.json
+++ b/client/package.json
@@ -12,12 +12,15 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "lucide-react": "^0.503.0",
     "next": "14.2.7",
     "react": "^18",
     "react-dom": "^18",
     "react-icons": "^5.5.0",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.2",

--- a/client/pages/quiz_display/index.tsx
+++ b/client/pages/quiz_display/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect, Suspense } from "react";
+import React, { useState, useEffect } from "react";
 import axios from "axios";
 import { useSearchParams } from "next/navigation";
 import {
@@ -11,6 +11,10 @@ import {
   NavBar,
   Footer,
 } from "../../components/home";
+import { quizService } from "@/lib/services/quizService";
+import { Button } from "@/components/ui/button";
+import { Folder } from "@/interfaces/models/folder";
+import { folderService } from "@/lib/services/folderService";
 
 const QuizDisplayPage: React.FC = () => {
   const searchParams = useSearchParams();
@@ -22,6 +26,9 @@ const QuizDisplayPage: React.FC = () => {
   const [userAnswers, setUserAnswers] = useState<(string | number)[]>([]);
   const [isQuizChecked, setIsQuizChecked] = useState<boolean>(false);
   const [quizReport, setQuizReport] = useState<any[]>([]);
+  const [folders, setFolders] = useState<Folder[]>([]);
+  const [selectedFolder, setSelectedFolder] = useState<string>("");
+  const [isSaving, setIsSaving] = useState(false);
 
   useEffect(() => {
     const fetchQuizQuestions = async () => {
@@ -35,12 +42,26 @@ const QuizDisplayPage: React.FC = () => {
         );
         setQuizQuestions(data);
         setUserAnswers(Array(data.length).fill(""));
+        // Automatically save the quiz
+        await quizService.saveQuiz(userId, data);
       } catch (error) {
         console.error("Error fetching quiz questions:", error);
       }
     };
     fetchQuizQuestions();
-  }, [questionType, numQuestions]);
+  }, [questionType, numQuestions, userId]);
+
+  useEffect(() => {
+    const loadFolders = async () => {
+      try {
+        const userFolders = await folderService.getUserFolders(userId);
+        setFolders(userFolders);
+      } catch (error) {
+        console.error("Failed to load folders:", error);
+      }
+    };
+    loadFolders();
+  }, [userId]);
 
   const handleAnswerChange = (index: number, answer: string | number) => {
     const updated = [...userAnswers];
@@ -78,6 +99,27 @@ const QuizDisplayPage: React.FC = () => {
       setIsQuizChecked(true);
     } catch (err) {
       console.error("Error checking answers:", err);
+    }
+  };
+
+  const handleSaveToFolder = async () => {
+    if (!selectedFolder) return;
+    
+    setIsSaving(true);
+    try {
+      // Get the quiz ID from the saved quiz
+      const savedQuizzes = await quizService.getSavedQuizzes(userId);
+      const latestQuiz = savedQuizzes[savedQuizzes.length - 1];
+      
+      // Add the quiz to the selected folder
+      await folderService.addQuizToFolder(selectedFolder, latestQuiz[0].id);
+      
+      alert("Quiz saved to folder successfully!");
+    } catch (error) {
+      console.error("Failed to save quiz to folder:", error);
+      alert("Failed to save quiz to folder");
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -155,18 +197,36 @@ const QuizDisplayPage: React.FC = () => {
                         {parseFloat(r.accuracy_percentage).toFixed(2)}%
                       </p>
                     )}
-                    <p>
-                      <strong>Result:</strong> {r.result}
-                    </p>
                   </div>
                 ))}
               </div>
 
-              <div className="mt-6 flex flex-col sm:flex-row sm:items-center sm:space-x-4 space-y-4 sm:space-y-0">
-                <button className="bg-[#0a3264] hover:bg-[#082952] text-white font-semibold px-4 py-2 rounded-xl shadow-md transition text-sm">
-                  Upgrade Plan to Save your Quiz
-                </button>
-                <NewQuizButton />
+              {/* Save to Folder Section */}
+              <div className="mt-6 p-4 bg-gray-50 rounded-lg border border-gray-200">
+                <h3 className="text-lg font-semibold text-gray-800 mb-4">
+                  Save to Folder
+                </h3>
+                <div className="flex flex-col sm:flex-row gap-4">
+                  <select
+                    className="flex-1 p-2 border border-gray-300 rounded-md"
+                    value={selectedFolder}
+                    onChange={(e) => setSelectedFolder(e.target.value)}
+                  >
+                    <option value="">Select a folder</option>
+                    {folders.map((folder) => (
+                      <option key={folder.id} value={folder.id}>
+                        {folder.name}
+                      </option>
+                    ))}
+                  </select>
+                  <Button
+                    onClick={handleSaveToFolder}
+                    disabled={!selectedFolder || isSaving}
+                    className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md"
+                  >
+                    {isSaving ? "Saving..." : "Save to Folder"}
+                  </Button>
+                </div>
               </div>
             </section>
           )}
@@ -178,10 +238,4 @@ const QuizDisplayPage: React.FC = () => {
   );
 };
 
-export default function DisplayQuiz() {
-  return (
-    <Suspense fallback={<div>Loading quiz...</div>}>
-      <QuizDisplayPage />
-    </Suspense>
-  );
-}
+export default QuizDisplayPage;

--- a/client/pnpm-lock.yaml
+++ b/client/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       axios:
         specifier: ^1.7.7
         version: 1.7.7
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       lucide-react:
         specifier: ^0.503.0
         version: 0.503.0(react@18.3.1)
@@ -29,6 +35,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.1
+      tailwind-merge:
+        specifier: ^3.3.0
+        version: 3.3.0
     devDependencies:
       '@testing-library/jest-dom':
         specifier: ^6.6.2
@@ -920,12 +929,19 @@ packages:
   cjs-module-lexer@1.4.1:
     resolution: {integrity: sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
@@ -2617,6 +2633,9 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  tailwind-merge@3.3.0:
+    resolution: {integrity: sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==}
+
   tailwindcss@3.4.10:
     resolution: {integrity: sha512-KWZkVPm7yJRhdu4SRSl9d4AK2wM3a50UsvgHZO7xY77NQr2V+fIrEuoDGQcbvswWvFGbS2f6e+jC/6WJm1Dl0w==}
     engines: {node: '>=14.0.0'}
@@ -3925,6 +3944,10 @@ snapshots:
 
   cjs-module-lexer@1.4.1: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   client-only@0.0.1: {}
 
   cliui@8.0.1:
@@ -3932,6 +3955,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clsx@2.1.1: {}
 
   co@4.6.0: {}
 
@@ -5969,6 +5994,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tailwind-merge@3.3.0: {}
 
   tailwindcss@3.4.10(ts-node@10.9.2(@types/node@20.16.2)(typescript@5.5.4)):
     dependencies:

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -18,14 +18,10 @@
       }
     ],
     "paths": {
-      "@/*": ["./components/*"],
-      "@/*": ["./layouts/*"],
-      "@/*": ["./pages/*"],
+      "@/*": ["./*"]
     },
-    "types": ["jest", "node"],
-   
+    "types": ["jest", "node"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
-  
 }

--- a/server/app/db/core/connection.py
+++ b/server/app/db/core/connection.py
@@ -29,3 +29,5 @@ def get_users_collection() -> AsyncIOMotorCollection:
 def get_quizzes_collection() -> AsyncIOMotorCollection:
     return quizzes_collection
 
+def get_folders_collection() -> AsyncIOMotorCollection:
+    return database["folders"]

--- a/server/app/db/routes/__init__.py
+++ b/server/app/db/routes/__init__.py
@@ -1,10 +1,15 @@
 from fastapi import APIRouter
-from ....app.db.routes.health import router as health_router
-from ....app.db.routes.quizzes import router as quizzes_router
-from ....app.db.routes.users import router as users_router
+from .health import router as health_router
+from .quizzes import router as quizzes_router
+from .users import router as users_router
+from .folders_routes import router as folder_router
+
+__all__ = ["router"]
+
 
 router = APIRouter()
 
 router.include_router(health_router, prefix="/health", tags=["health"])
 router.include_router(quizzes_router, prefix="/quizzes", tags=["quizzes"])
 router.include_router(users_router, prefix="/users", tags=["users"])
+router.include_router(folder_router, prefix="/folders", tags=["folders"])

--- a/server/main.py
+++ b/server/main.py
@@ -11,12 +11,14 @@ from .api.v1.crud import download_quiz, generate_quiz, get_user_quiz_history
 from .app.db.routes import router as db_router
 from .app.db.core.connection import startUp
 from server.app.quiz.routers.quiz import router as quiz_router
+from .app.db.routes.folders_routes import router as folder_router
 from .schemas.model import UserModel, LoginRequestModel, LoginResponseModel
 from .schemas.query import (
     GenerateQuizQuery,
     DownloadQuizQuery,
     GetUserQuizHistoryQuery
 )
+from server.app.db.routes import router as api_router
 
 logging.basicConfig(
     level=logging.INFO,
@@ -45,6 +47,8 @@ app.add_middleware(
 app.include_router(db_router)
 app.include_router(quiz_router, prefix="/api", tags=["quiz"])
 app.include_router(healthcheck.router, prefix="/api", tags=["healthcheck"])
+app.include_router(api_router, prefix="/api")
+app.include_router(folder_router, prefix="/api", tags=["folders"])
 
 mock_db: List[UserModel] = []
 

--- a/server/schemas/model/__init__.py
+++ b/server/schemas/model/__init__.py
@@ -2,3 +2,5 @@ from .login_request_model import LoginRequestModel
 from .login_response_model import LoginResponseModel
 from .user_model import UserModel
 from .quiz_questions_model import QuizQuestionsModel
+
+from server.app.db.models.folder_model import FolderBase, FolderCreate, FolderDB


### PR DESCRIPTION
## PR: Implement Quiz Saving and Folder Management

### Description

This pull request introduces two major features: the automatic saving of generated quizzes and the ability for users to create and manage folders for their saved quizzes. Previously, the quiz generation was a mock and did not persist quizzes, and the "Saved Quizzes" page used static data. This PR implements the full end-to-end logic for these features.

### Changes Implemented

#### Quiz Generation and Saving

1.  **Client-Side Quiz Generation (`client/components/home/QuizForm.tsx`)**
    *   The quiz generation form now correctly calls the `/api/generate-quiz` endpoint.
    *   The `user_id` is now passed in the request to associate the generated quiz with the user.

2.  **Server-Side Quiz Saving (`server/app/quiz/routers/quiz.py`)**
    *   The `/api/generate-quiz` endpoint is no longer a mock. It now processes the request, generates questions, and saves the resulting quiz to the database.
    *   The `QuizRequest` model now includes a `user_id` to identify the quiz owner.
    *   The `NewQuizSchema` now includes an `owner_id` to persist the ownership information.

3.  **Database CRUD (`server/app/db/crud/quiz_crud.py`)**
    *   The `create_quiz` function is used to insert the new quiz document into the `quizzes` collection.

#### Fetching Saved Quizzes

1.  **Client-Side Fetching (`client/pages/saved-quizzes/index.tsx` & `client/lib/services/quizService.ts`)**
    *   The "Saved Quizzes" page now uses the `quizService.getSavedQuizzes` function to fetch a user's saved quizzes.
    *   This service makes a GET request to the newly created `/api/quizzes/user/{userId}` endpoint.

2.  **Server-Side Data Retrieval (`server/app/db/routes/quizzes.py` & `server/app/db/crud/quiz_crud.py`)**
    *   A new route, `GET /api/quizzes/user/{user_id}`, has been added to fetch all quizzes associated with a specific user.
    *   A corresponding `get_quizzes_by_user` function has been added to the quiz CRUD logic to query the database for quizzes matching the `owner_id`.

#### Folder Creation Logic

1.  **Client-Side (`client/components/(dashboard)/folders/FolderList.tsx`)**
    *   Users can now create, rename, and delete folders from the "My Folders" page.
    *   The UI calls the `folderService` to interact with the backend.

2.  **API Service (`client/lib/services/folderService.ts`)**
    *   The service makes the appropriate API calls to `POST /api/folders`, `PUT /api/folders/{id}`, and `DELETE /api/folders/{id}`.

3.  **Server-Side (`server/app/db/routes/folders_routes.py` & `server/app/db/crud/folder_crud.py`)**
    *   The backend routes handle the folder management requests.
    *   The `folder_crud.py` file contains the logic to interact with the `folders` collection in the database, including creating new folders, updating their names, and deleting them.

### How to Test

1.  **Generate and Save a Quiz:**
    *   Navigate to the quiz generation page.
    *   Fill out the form and click "Generate Quiz".
    *   Verify in your database that a new quiz document has been created in the `quizzes` collection with the correct `owner_id`.

2.  **View Saved Quizzes:**
    *   Go to the "Saved Quizzes" page.
    *   Confirm that the quiz you just created is now visible.

3.  **Create a Folder:**
    *   Go to the "My Folders" page.
    *   Enter a name for a new folder and click "Create Folder".
    *   Verify that the new folder appears on the page and has been added to the `folders` collection in the database.

4.  **Add Quiz to Folder:**
    *   On the "Saved Quizzes" page, select a quiz and a folder, then click "Save to Folder".
    *   Check the corresponding folder document in the database to ensure the `quiz_id` has been added to its `quiz_ids` array.