### PR TITLE
Feature/reconfigure database4 cutover reads to v2 collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 node_modules/
 
 client/.pnpm-store/*
+server/tmp/

--- a/client/lib/functions/saveQuizToHistory.ts
+++ b/client/lib/functions/saveQuizToHistory.ts
@@ -24,7 +24,7 @@ export async function saveQuizToHistory(
 
   const payload = {
     quiz_id: meta.quiz_id,
-    quiz_name: `${meta.question_type} Quiz`,
+    quiz_name: meta.profession || `${meta.question_type} Quiz`,
     question_type: meta.question_type,
     num_questions: meta.num_questions,
     difficulty_level: meta.difficulty_level,

--- a/server/app/db/core/config.py
+++ b/server/app/db/core/config.py
@@ -20,6 +20,10 @@ class Settings(BaseSettings):
     db_name: str
     mongo_url: str
     QUIZ_V2_WRITE_MODE: Literal["legacy_only", "dual_write"] = "dual_write"
+    QUIZ_V2_SAVED_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
+    QUIZ_V2_HISTORY_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
+    QUIZ_V2_FOLDER_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
+    QUIZ_V2_SHARE_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
     QUIZ_V2_FAIL_OPEN: bool = True
     QUIZ_V2_STRUCTURED_LOGGING: bool = True
     V2_BACKFILL_BATCH_SIZE: int = 200

--- a/server/app/db/core/config.py
+++ b/server/app/db/core/config.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -22,6 +22,13 @@ class Settings(BaseSettings):
     QUIZ_V2_WRITE_MODE: Literal["legacy_only", "dual_write"] = "dual_write"
     QUIZ_V2_FAIL_OPEN: bool = True
     QUIZ_V2_STRUCTURED_LOGGING: bool = True
+    V2_BACKFILL_BATCH_SIZE: int = 200
+    V2_BACKFILL_DRY_RUN: bool = True
+    V2_BACKFILL_START_AFTER_ID: Optional[str] = None
+    V2_BACKFILL_LIMIT: Optional[int] = None
+    V2_BACKFILL_COLLECTIONS: str = "quizzes,saved,history,folders"
+    V2_BACKFILL_RUN_ID: Optional[str] = None
+    V2_BACKFILL_LOCK_LEASE_SECONDS: int = 600
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/server/app/db/core/connection.py
+++ b/server/app/db/core/connection.py
@@ -107,6 +107,11 @@ def get_saved_quizzes_collection() -> AsyncIOMotorCollection:
         raise RuntimeError("[DB Error] saved_quizzes_collection has not been initialized properly.")
     return saved_quizzes_collection
 
+def get_quiz_history_collection() -> AsyncIOMotorCollection:
+    if quiz_history_collection is None:
+        raise RuntimeError("[DB Error] quiz_history_collection has not been initialized properly.")
+    return quiz_history_collection
+
 def get_user_tokens_collection() -> AsyncIOMotorCollection:
     if user_tokens_collection is None:
         raise RuntimeError("[DB Error] user_tokens_collection has not been initialized properly.")

--- a/server/app/db/routes/folder_routes.py
+++ b/server/app/db/routes/folder_routes.py
@@ -36,6 +36,7 @@ from ....app.db.crud.folder_crud import (
 from ....app.db.core.connection import get_saved_quizzes_collection
 
 from ....app.db.models.folder_model import FolderCreate, BulkDeleteFoldersRequest, BulkRemoveRequest
+from ....app.db.services.quiz_user_library_read_service import QuizUserLibraryReadService
 
 from ....app.dependancies import get_current_user
 
@@ -44,6 +45,7 @@ router = APIRouter(tags=["Folders"])
 
 
 saved_quizzes_collection = get_saved_quizzes_collection()
+read_service = QuizUserLibraryReadService()
 
 
 
@@ -87,7 +89,7 @@ async def create_new_folder(folder: FolderCreate, user = Depends(get_current_use
 
 async def get_folders_for_user(user = Depends(get_current_user)):
 
-    folders = await get_user_folders(user.id)
+    folders = await read_service.get_user_folders(user.id)
 
     return folders
 
@@ -96,16 +98,13 @@ async def get_folders_for_user(user = Depends(get_current_user)):
 @router.get("/view/{folder_id}")
 
 async def get_folder_by_id_route(folder_id: str, user = Depends(get_current_user)):
-
-    folder = await get_folder_by_id(folder_id)
+    try:
+        folder = await read_service.get_folder_by_id(folder_id, user.id)
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Unauthorized access to folder")
 
     if not folder:
-
         raise HTTPException(status_code=404, detail="Folder not found")
-
-    if folder["user_id"] != user.id:
-
-        raise HTTPException(status_code=403, detail="Unauthorized access to folder")
 
     return folder
 

--- a/server/app/db/routes/get_quiz_history.py
+++ b/server/app/db/routes/get_quiz_history.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, Depends
 
 from ....app.dependancies import get_current_user
-
-from ....app.db.crud.update_quiz_history import get_quiz_history
+from ....app.db.services.quiz_user_library_read_service import QuizUserLibraryReadService
 
 
 router = APIRouter()
+read_service = QuizUserLibraryReadService()
 
 
 @router.get("/quiz-history")
@@ -19,7 +19,6 @@ async def get_user_quiz_history(current_user=Depends(get_current_user)):
 
     user_id = current_user.id
 
-    quizzes = await get_quiz_history(user_id)
+    quizzes = await read_service.get_quiz_history_for_user(user_id)
 
     return quizzes
-

--- a/server/app/db/routes/saved_quizzes.py
+++ b/server/app/db/routes/saved_quizzes.py
@@ -15,6 +15,7 @@ from ....app.db.crud.saved_quiz_crud import (
 )
 
 from ....app.db.models.saved_quiz_model import SavedQuizModel
+from ....app.db.services.quiz_user_library_read_service import QuizUserLibraryReadService
 
 from ....app.dependancies import get_current_user
 
@@ -22,6 +23,7 @@ from ....app.db.schemas.user_schemas import UserResponseSchema
 
 
 router = APIRouter(prefix="/saved-quizzes", tags=["Saved Quizzes"])
+read_service = QuizUserLibraryReadService()
 
 
 @router.post("/", status_code=status.HTTP_201_CREATED)
@@ -72,7 +74,7 @@ async def list_saved_quizzes(
 
     try:
 
-        quizzes = await get_saved_quizzes(user_id=str(current_user.id))
+        quizzes = await read_service.get_saved_quizzes_for_user(user_id=str(current_user.id))
 
         return quizzes
 
@@ -123,7 +125,7 @@ async def get_saved_quiz(
             raise HTTPException(status_code=400, detail="Invalid quiz ID")
 
 
-        quiz = await get_saved_quiz_by_id(quiz_id, user_id=str(current_user.id))
+        quiz = await read_service.get_saved_quiz_by_id(quiz_id, user_id=str(current_user.id))
 
         if not quiz or quiz.get("user_id") != str(current_user.id):
 

--- a/server/app/db/services/legacy_quiz_resolution_service.py
+++ b/server/app/db/services/legacy_quiz_resolution_service.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from bson import ObjectId
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from server.app.db.crud.quiz_write_service import CanonicalQuizWriteService
+
+
+@dataclass
+class LegacySourceQuizMatch:
+    source_collection: str
+    legacy_quiz_id: str
+    document: dict[str, Any]
+
+
+class LegacyQuizStructureConflictError(ValueError):
+    def __init__(
+        self,
+        *,
+        title: str,
+        quiz_type: str,
+        candidates: list[dict[str, Any]],
+    ):
+        self.title = title
+        self.quiz_type = quiz_type
+        self.candidates = candidates
+        candidate_ids = ", ".join(candidate["legacy_quiz_id"] for candidate in candidates)
+        super().__init__(
+            f"Multiple legacy source matches for '{title}' ({quiz_type}): {candidate_ids}"
+        )
+
+    def to_log_fields(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "quiz_type": self.quiz_type,
+            "candidate_ids": [candidate["legacy_quiz_id"] for candidate in self.candidates],
+            "candidates": self.candidates,
+        }
+
+
+class LegacyQuizResolutionService:
+    def __init__(
+        self,
+        *,
+        canonical_service: CanonicalQuizWriteService,
+        ai_generated_quizzes_collection: AsyncIOMotorCollection,
+        quizzes_collection: AsyncIOMotorCollection,
+    ):
+        self.canonical_service = canonical_service
+        self.ai_generated_quizzes_collection = ai_generated_quizzes_collection
+        self.quizzes_collection = quizzes_collection
+
+    @staticmethod
+    def _coerce_object_id(value: str | None):
+        if not value:
+            return None
+        try:
+            return ObjectId(value)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _normalize_title(value: str | None) -> str:
+        if not value:
+            return ""
+        normalized = re.sub(r"\s+", " ", value.strip().casefold())
+        if normalized.endswith(" quiz"):
+            normalized = normalized[:-5].strip()
+        return normalized
+
+    @staticmethod
+    def _candidate_display_title(document: dict[str, Any]) -> str:
+        return document.get("profession") or document.get("title") or "Untitled Quiz"
+
+    def _build_question_structure_fingerprint(self, *, quiz_type: str, questions: list[Any]) -> str:
+        normalized_questions = self.canonical_service.normalize_questions(questions)
+        structure_payload = {
+            "quiz_type": quiz_type,
+            "questions": [
+                {
+                    "question": question.get("question"),
+                    "options": question.get("options"),
+                }
+                for question in normalized_questions
+            ],
+        }
+        return self.canonical_service.build_content_fingerprint(structure_payload)
+
+    async def resolve_from_canonical_backref(self, canonical_quiz_id: str | None):
+        if not canonical_quiz_id:
+            return None
+        return await self.canonical_service.get_quiz_v2_by_id(canonical_quiz_id)
+
+    async def resolve_from_source_quiz_id(self, source_quiz_id: str | None):
+        if not source_quiz_id:
+            return None
+
+        for collection_name in ("ai_generated_quizzes", "quizzes"):
+            canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
+                collection_name,
+                source_quiz_id,
+            )
+            if canonical_quiz:
+                return canonical_quiz
+
+        object_id = self._coerce_object_id(source_quiz_id)
+
+        legacy_ai = await self.ai_generated_quizzes_collection.find_one(
+            {"_id": object_id if object_id is not None else source_quiz_id}
+        )
+        if legacy_ai and legacy_ai.get("canonical_quiz_id"):
+            canonical_quiz = await self.resolve_from_canonical_backref(legacy_ai["canonical_quiz_id"])
+            if canonical_quiz:
+                return canonical_quiz
+
+        legacy_manual = await self.quizzes_collection.find_one(
+            {"_id": object_id if object_id is not None else source_quiz_id}
+        )
+        if legacy_manual and legacy_manual.get("canonical_quiz_id"):
+            return await self.resolve_from_canonical_backref(legacy_manual["canonical_quiz_id"])
+
+        return None
+
+    async def _find_structure_candidates(
+        self,
+        *,
+        collection_name: str,
+        collection: AsyncIOMotorCollection,
+        target_fingerprint: str,
+        quiz_type: str,
+    ) -> list[LegacySourceQuizMatch]:
+        candidates: list[LegacySourceQuizMatch] = []
+        async for document in collection.find(
+            {"question_type": quiz_type},
+            {
+                "_id": 1,
+                "profession": 1,
+                "title": 1,
+                "question_type": 1,
+                "quiz_type": 1,
+                "questions": 1,
+                "custom_instruction": 1,
+                "description": 1,
+                "user_id": 1,
+                "owner_id": 1,
+                "canonical_quiz_id": 1,
+            },
+        ):
+            candidate_type = document.get("question_type") or document.get("quiz_type") or "multichoice"
+            candidate_fingerprint = self._build_question_structure_fingerprint(
+                quiz_type=candidate_type,
+                questions=document.get("questions", []),
+            )
+            if candidate_fingerprint != target_fingerprint:
+                continue
+            candidates.append(
+                LegacySourceQuizMatch(
+                    source_collection=collection_name,
+                    legacy_quiz_id=str(document["_id"]),
+                    document=document,
+                )
+            )
+        return candidates
+
+    def _candidate_log_payload(self, match: LegacySourceQuizMatch) -> dict[str, Any]:
+        return {
+            "legacy_source_collection": match.source_collection,
+            "legacy_quiz_id": match.legacy_quiz_id,
+            "title": self._candidate_display_title(match.document),
+        }
+
+    def _select_preferred_candidate(
+        self,
+        *,
+        title: str,
+        candidates: list[LegacySourceQuizMatch],
+    ) -> LegacySourceQuizMatch | None:
+        if not candidates:
+            return None
+        if len(candidates) == 1:
+            return candidates[0]
+
+        normalized_title = self._normalize_title(title)
+        if normalized_title:
+            title_matches = [
+                candidate
+                for candidate in candidates
+                if self._normalize_title(self._candidate_display_title(candidate.document)) == normalized_title
+            ]
+            if len(title_matches) == 1:
+                return title_matches[0]
+            if len(title_matches) > 1:
+                raise LegacyQuizStructureConflictError(
+                    title=title,
+                    quiz_type=candidates[0].document.get("question_type")
+                    or candidates[0].document.get("quiz_type")
+                    or "multichoice",
+                    candidates=[self._candidate_log_payload(candidate) for candidate in title_matches],
+                )
+
+        raise LegacyQuizStructureConflictError(
+            title=title,
+            quiz_type=candidates[0].document.get("question_type")
+            or candidates[0].document.get("quiz_type")
+            or "multichoice",
+            candidates=[self._candidate_log_payload(candidate) for candidate in candidates],
+        )
+
+    async def find_legacy_source_match_by_structure(
+        self,
+        *,
+        title: str,
+        quiz_type: str,
+        questions: list[Any],
+    ) -> LegacySourceQuizMatch | None:
+        target_fingerprint = self._build_question_structure_fingerprint(
+            quiz_type=quiz_type,
+            questions=questions,
+        )
+        ai_candidates = await self._find_structure_candidates(
+            collection_name="ai_generated_quizzes",
+            collection=self.ai_generated_quizzes_collection,
+            target_fingerprint=target_fingerprint,
+            quiz_type=quiz_type,
+        )
+        selected = self._select_preferred_candidate(title=title, candidates=ai_candidates)
+        if selected:
+            return selected
+
+        manual_candidates = await self._find_structure_candidates(
+            collection_name="quizzes",
+            collection=self.quizzes_collection,
+            target_fingerprint=target_fingerprint,
+            quiz_type=quiz_type,
+        )
+        return self._select_preferred_candidate(title=title, candidates=manual_candidates)
+
+    async def resolve_or_build_from_legacy_source_match(
+        self,
+        match: LegacySourceQuizMatch,
+        *,
+        allow_create: bool,
+    ):
+        existing = await self.canonical_service.repository.find_by_legacy_mapping(
+            match.source_collection,
+            match.legacy_quiz_id,
+        )
+        if existing:
+            return existing
+
+        if match.document.get("canonical_quiz_id"):
+            canonical_quiz = await self.resolve_from_canonical_backref(match.document["canonical_quiz_id"])
+            if canonical_quiz:
+                return canonical_quiz
+
+        quiz_document = self.canonical_service.build_quiz_document(
+            title=self._candidate_display_title(match.document),
+            description=match.document.get("custom_instruction") or match.document.get("description"),
+            quiz_type=match.document.get("question_type") or match.document.get("quiz_type") or "multichoice",
+            owner_user_id=match.document.get("user_id") or match.document.get("owner_id"),
+            source="ai" if match.source_collection == "ai_generated_quizzes" else "legacy",
+            questions=match.document.get("questions", []),
+            legacy_source_collection=match.source_collection,
+            legacy_quiz_id=match.legacy_quiz_id,
+        )
+        if allow_create:
+            return await self.canonical_service.upsert_quiz_v2_by_legacy_mapping(quiz_document)
+        return quiz_document
+
+    async def resolve_from_legacy_structure(
+        self,
+        *,
+        title: str,
+        quiz_type: str,
+        questions: list[Any],
+        allow_create: bool,
+    ):
+        match = await self.find_legacy_source_match_by_structure(
+            title=title,
+            quiz_type=quiz_type,
+            questions=questions,
+        )
+        if not match:
+            return None
+        return await self.resolve_or_build_from_legacy_source_match(
+            match,
+            allow_create=allow_create,
+        )

--- a/server/app/db/services/legacy_quiz_resolution_service.py
+++ b/server/app/db/services/legacy_quiz_resolution_service.py
@@ -28,7 +28,10 @@ class LegacyQuizStructureConflictError(ValueError):
         self.title = title
         self.quiz_type = quiz_type
         self.candidates = candidates
-        candidate_ids = ", ".join(candidate["legacy_quiz_id"] for candidate in candidates)
+        candidate_ids = ", ".join(
+            candidate.get("legacy_quiz_id") or candidate.get("canonical_quiz_id") or "unknown"
+            for candidate in candidates
+        )
         super().__init__(
             f"Multiple legacy source matches for '{title}' ({quiz_type}): {candidate_ids}"
         )
@@ -37,7 +40,10 @@ class LegacyQuizStructureConflictError(ValueError):
         return {
             "title": self.title,
             "quiz_type": self.quiz_type,
-            "candidate_ids": [candidate["legacy_quiz_id"] for candidate in self.candidates],
+            "candidate_ids": [
+                candidate.get("legacy_quiz_id") or candidate.get("canonical_quiz_id")
+                for candidate in self.candidates
+            ],
             "candidates": self.candidates,
         }
 
@@ -75,6 +81,33 @@ class LegacyQuizResolutionService:
     @staticmethod
     def _candidate_display_title(document: dict[str, Any]) -> str:
         return document.get("profession") or document.get("title") or "Untitled Quiz"
+
+    @classmethod
+    def is_generic_quiz_title(cls, title: str | None, quiz_type: str | None = None) -> bool:
+        normalized_title = cls._normalize_title(title)
+        if not normalized_title:
+            return True
+        generic_titles = {"quiz history"}
+        if quiz_type:
+            generic_titles.add(cls._normalize_title(f"{quiz_type} Quiz"))
+        return normalized_title in generic_titles
+
+    @classmethod
+    def choose_preferred_title(
+        cls,
+        *,
+        title: str | None,
+        fallback_title: str | None = None,
+        quiz_type: str | None = None,
+        default: str = "Untitled Quiz",
+    ) -> str:
+        if title and not cls.is_generic_quiz_title(title, quiz_type):
+            return title.strip()
+        if fallback_title and fallback_title.strip():
+            return fallback_title.strip()
+        if title and title.strip():
+            return title.strip()
+        return default
 
     def _build_question_structure_fingerprint(self, *, quiz_type: str, questions: list[Any]) -> str:
         normalized_questions = self.canonical_service.normalize_questions(questions)
@@ -171,6 +204,12 @@ class LegacyQuizResolutionService:
             "legacy_source_collection": match.source_collection,
             "legacy_quiz_id": match.legacy_quiz_id,
             "title": self._candidate_display_title(match.document),
+        }
+
+    def _v2_candidate_log_payload(self, document: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "canonical_quiz_id": str(document["_id"]),
+            "title": document.get("title"),
         }
 
     def _select_preferred_candidate(
@@ -289,4 +328,55 @@ class LegacyQuizResolutionService:
         return await self.resolve_or_build_from_legacy_source_match(
             match,
             allow_create=allow_create,
+        )
+
+    async def resolve_existing_v2_from_question_structure(
+        self,
+        *,
+        title: str,
+        quiz_type: str,
+        questions: list[Any],
+    ):
+        target_fingerprint = self._build_question_structure_fingerprint(
+            quiz_type=quiz_type,
+            questions=questions,
+        )
+        candidates: list[dict[str, Any]] = []
+        async for document in self.canonical_service.repository.collection.find(
+            {"quiz_type": quiz_type, "status": {"$ne": "deleted"}},
+            {"_id": 1, "title": 1, "quiz_type": 1, "questions": 1},
+        ):
+            candidate_fingerprint = self._build_question_structure_fingerprint(
+                quiz_type=document.get("quiz_type") or "multichoice",
+                questions=document.get("questions", []),
+            )
+            if candidate_fingerprint != target_fingerprint:
+                continue
+            candidates.append(document)
+
+        if not candidates:
+            return None
+        if len(candidates) == 1:
+            return await self.canonical_service.get_quiz_v2_by_id(str(candidates[0]["_id"]))
+
+        normalized_title = self._normalize_title(title)
+        if normalized_title:
+            title_matches = [
+                candidate
+                for candidate in candidates
+                if self._normalize_title(candidate.get("title")) == normalized_title
+            ]
+            if len(title_matches) == 1:
+                return await self.canonical_service.get_quiz_v2_by_id(str(title_matches[0]["_id"]))
+            if len(title_matches) > 1:
+                raise LegacyQuizStructureConflictError(
+                    title=title,
+                    quiz_type=quiz_type,
+                    candidates=[self._v2_candidate_log_payload(candidate) for candidate in title_matches],
+                )
+
+        raise LegacyQuizStructureConflictError(
+            title=title,
+            quiz_type=quiz_type,
+            candidates=[self._v2_candidate_log_payload(candidate) for candidate in candidates],
         )

--- a/server/app/db/services/quiz_dual_write_service.py
+++ b/server/app/db/services/quiz_dual_write_service.py
@@ -236,6 +236,7 @@ class QuizDualWriteService:
                 SavedQuizDocumentV2(
                     user_id=legacy_saved_doc["user_id"],
                     quiz_id=str(canonical_quiz.id),
+                    display_title=legacy_saved_doc.get("title") or canonical_quiz.title,
                     legacy_saved_quiz_id=str(legacy_saved_doc["_id"]),
                     saved_at=legacy_saved_doc.get("created_at", datetime.utcnow()),
                 )
@@ -367,11 +368,20 @@ class QuizDualWriteService:
                         source="legacy",
                     )
                 canonical_quiz_id = str(canonical_quiz.id)
+            position = None
+            for index, item in enumerate(legacy_folder_doc.get("quizzes", [])):
+                if str(item.get("_id")) == str(legacy_folder_item.get("_id")):
+                    position = index
+                    break
             return await self.reference_repository.upsert_folder_item_by_legacy_id(
                 FolderItemDocumentV2(
                     folder_id=str(folder_v2.id),
                     quiz_id=canonical_quiz_id,
                     added_by=legacy_folder_doc.get("user_id"),
+                    position=position,
+                    display_title=legacy_folder_item.get("title")
+                    or quiz_payload.get("title")
+                    or None,
                     legacy_folder_item_id=legacy_folder_item["_id"],
                     created_at=legacy_folder_item.get("added_on", datetime.utcnow()),
                 )
@@ -419,12 +429,18 @@ class QuizDualWriteService:
                         updated_at=target_legacy_folder_doc.get("updated_at", datetime.utcnow()),
                     )
                 )
+            position = None
+            for index, item in enumerate(target_legacy_folder_doc.get("quizzes", [])):
+                if str(item.get("_id")) == str(legacy_folder_item_id):
+                    position = index
+                    break
             return await self.reference_repository.upsert_folder_item_by_legacy_id(
                 FolderItemDocumentV2(
                     folder_id=str(target_folder.id),
                     quiz_id=folder_item.quiz_id,
                     added_by=folder_item.added_by,
-                    position=folder_item.position,
+                    position=position if position is not None else folder_item.position,
+                    display_title=folder_item.display_title,
                     legacy_folder_item_id=legacy_folder_item_id,
                     created_at=folder_item.created_at,
                 )

--- a/server/app/db/services/quiz_dual_write_service.py
+++ b/server/app/db/services/quiz_dual_write_service.py
@@ -16,6 +16,7 @@ from server.app.db.core.connection import (
     get_saved_quizzes_v2_collection,
 )
 from server.app.db.crud.quiz_write_service import CanonicalQuizWriteService
+from server.app.db.services.legacy_quiz_resolution_service import LegacyQuizResolutionService
 from server.app.db.v2.models.reference_models import (
     FolderDocumentV2,
     FolderItemDocumentV2,
@@ -53,6 +54,11 @@ class QuizDualWriteService:
             quizzes_collection
             if quizzes_collection is not None
             else get_quizzes_collection()
+        )
+        self.legacy_resolution_service = LegacyQuizResolutionService(
+            canonical_service=self.canonical_service,
+            ai_generated_quizzes_collection=self.ai_generated_quizzes_collection,
+            quizzes_collection=self.quizzes_collection,
         )
 
     @property
@@ -126,6 +132,14 @@ class QuizDualWriteService:
             )
             if existing:
                 return existing
+            matched_legacy_quiz = await self.legacy_resolution_service.resolve_from_legacy_structure(
+                title=title,
+                quiz_type=quiz_type,
+                questions=questions,
+                allow_create=True,
+            )
+            if matched_legacy_quiz:
+                return matched_legacy_quiz
             raise ValueError("Cannot create canonical quiz without answer data")
         quiz_document = self.canonical_service.build_quiz_document(
             title=title,
@@ -142,41 +156,7 @@ class QuizDualWriteService:
         return await self.canonical_service.find_or_create_quiz_v2_by_fingerprint(quiz_document)
 
     async def _resolve_canonical_from_source_quiz_id(self, source_quiz_id: str | None):
-        if not source_quiz_id:
-            return None
-
-        canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
-            "ai_generated_quizzes",
-            source_quiz_id,
-        )
-        if canonical_quiz:
-            return canonical_quiz
-
-        canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
-            "quizzes",
-            source_quiz_id,
-        )
-        if canonical_quiz:
-            return canonical_quiz
-
-        legacy_ai_quiz = await self.ai_generated_quizzes_collection.find_one({"_id": source_quiz_id})
-        if legacy_ai_quiz and legacy_ai_quiz.get("canonical_quiz_id"):
-            return await self.canonical_service.get_quiz_v2_by_id(legacy_ai_quiz["canonical_quiz_id"])
-
-        try:
-            from bson import ObjectId
-            object_id = ObjectId(source_quiz_id)
-        except Exception:
-            object_id = None
-
-        if object_id is not None:
-            legacy_seeded_quiz = await self.quizzes_collection.find_one({"_id": object_id})
-            if legacy_seeded_quiz and legacy_seeded_quiz.get("canonical_quiz_id"):
-                return await self.canonical_service.get_quiz_v2_by_id(
-                    legacy_seeded_quiz["canonical_quiz_id"]
-                )
-
-        return None
+        return await self.legacy_resolution_service.resolve_from_source_quiz_id(source_quiz_id)
 
 
     async def mirror_legacy_manual_quiz(self, legacy_quiz_id: str, legacy_quiz_doc: dict):
@@ -481,6 +461,7 @@ class QuizDualWriteService:
             )
             return result
         except Exception as exc:
+            extra_fields = exc.to_log_fields() if hasattr(exc, "to_log_fields") else {}
             self._log(
                 "quiz_dual_write_v2_failed",
                 operation=operation,
@@ -488,6 +469,7 @@ class QuizDualWriteService:
                 legacy_id=legacy_id,
                 write_mode=self.write_mode,
                 error=str(exc),
+                **extra_fields,
             )
             if settings.QUIZ_V2_FAIL_OPEN:
                 return None

--- a/server/app/db/services/quiz_dual_write_service.py
+++ b/server/app/db/services/quiz_dual_write_service.py
@@ -140,6 +140,13 @@ class QuizDualWriteService:
             )
             if matched_legacy_quiz:
                 return matched_legacy_quiz
+            existing_v2 = await self.legacy_resolution_service.resolve_existing_v2_from_question_structure(
+                title=title,
+                quiz_type=quiz_type,
+                questions=questions,
+            )
+            if existing_v2:
+                return existing_v2
             raise ValueError("Cannot create canonical quiz without answer data")
         quiz_document = self.canonical_service.build_quiz_document(
             title=title,
@@ -151,6 +158,13 @@ class QuizDualWriteService:
             legacy_source_collection=legacy_source_collection,
             legacy_quiz_id=legacy_quiz_id,
         )
+        existing = await self.legacy_resolution_service.resolve_existing_v2_from_question_structure(
+            title=title,
+            quiz_type=quiz_type,
+            questions=normalized_questions,
+        )
+        if existing:
+            return existing
         if legacy_source_collection and legacy_quiz_id:
             return await self.canonical_service.upsert_quiz_v2_by_legacy_mapping(quiz_document)
         return await self.canonical_service.find_or_create_quiz_v2_by_fingerprint(quiz_document)
@@ -252,9 +266,12 @@ class QuizDualWriteService:
                 )
             if not canonical_quiz:
                 canonical_quiz = await self._mirror_quiz_document(
-                    title=legacy_history_doc.get("quiz_name")
-                    or legacy_history_doc.get("profession")
-                    or "Quiz History",
+                    title=self.legacy_resolution_service.choose_preferred_title(
+                        title=legacy_history_doc.get("quiz_name"),
+                        fallback_title=legacy_history_doc.get("profession"),
+                        quiz_type=legacy_history_doc.get("question_type"),
+                        default="Quiz History",
+                    ),
                     description=legacy_history_doc.get("custom_instruction"),
                     quiz_type=legacy_history_doc["question_type"],
                     owner_user_id=None,

--- a/server/app/db/services/quiz_user_library_read_service.py
+++ b/server/app/db/services/quiz_user_library_read_service.py
@@ -1,0 +1,486 @@
+import logging
+from datetime import datetime
+from typing import Any, Awaitable, Callable, Literal, Optional
+
+from bson import ObjectId
+from bson.errors import InvalidId
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from server.app.db.core.config import settings
+from server.app.db.core.connection import (
+    get_folder_items_v2_collection,
+    get_folders_collection,
+    get_folders_v2_collection,
+    get_quiz_history_collection,
+    get_quiz_history_v2_collection,
+    get_quizzes_v2_collection,
+    get_saved_quizzes_collection,
+    get_saved_quizzes_v2_collection,
+)
+from server.app.db.v2.models.quiz_models import QuizDocumentV2
+from server.app.db.v2.models.reference_models import (
+    FolderDocumentV2,
+    FolderItemDocumentV2,
+    QuizHistoryDocumentV2,
+    SavedQuizDocumentV2,
+)
+from server.app.db.v2.repositories.quiz_repository import QuizV2Repository
+from server.app.db.v2.repositories.reference_repository import ReferenceV2Repository
+
+
+logger = logging.getLogger(__name__)
+
+ReadMode = Literal["legacy_only", "compare", "v2_only"]
+
+
+class QuizUserLibraryReadService:
+    def __init__(
+        self,
+        *,
+        saved_quizzes_collection: Optional[AsyncIOMotorCollection] = None,
+        quiz_history_collection: Optional[AsyncIOMotorCollection] = None,
+        folders_collection: Optional[AsyncIOMotorCollection] = None,
+        quiz_repository: Optional[QuizV2Repository] = None,
+        reference_repository: Optional[ReferenceV2Repository] = None,
+    ):
+        self.saved_quizzes_collection = (
+            saved_quizzes_collection
+            if saved_quizzes_collection is not None
+            else get_saved_quizzes_collection()
+        )
+        self.quiz_history_collection = (
+            quiz_history_collection
+            if quiz_history_collection is not None
+            else get_quiz_history_collection()
+        )
+        self.folders_collection = (
+            folders_collection if folders_collection is not None else get_folders_collection()
+        )
+        self.quiz_repository = (
+            quiz_repository if quiz_repository is not None else QuizV2Repository(get_quizzes_v2_collection())
+        )
+        self.reference_repository = (
+            reference_repository
+            if reference_repository is not None
+            else ReferenceV2Repository(
+                get_folders_v2_collection(),
+                get_folder_items_v2_collection(),
+                get_saved_quizzes_v2_collection(),
+                get_quiz_history_v2_collection(),
+            )
+        )
+
+    def _log(self, event: str, **fields):
+        if not settings.QUIZ_V2_STRUCTURED_LOGGING:
+            return
+        logger.info("%s | %s", event, fields)
+
+    @staticmethod
+    def _isoformat(value: Any) -> Any:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return value
+
+    @classmethod
+    def _serialize_legacy_document(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {key: cls._serialize_legacy_document(val) for key, val in value.items()}
+        if isinstance(value, list):
+            return [cls._serialize_legacy_document(item) for item in value]
+        if isinstance(value, ObjectId):
+            return str(value)
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return value
+
+    @staticmethod
+    def _sort_by_created_desc(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return sorted(items, key=lambda item: item.get("created_at") or "", reverse=True)
+
+    @staticmethod
+    def _sort_folders(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return sorted(items, key=lambda item: (item.get("created_at") or "", item.get("_id") or ""))
+
+    @staticmethod
+    def _sort_folder_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        def sort_key(item: dict[str, Any]):
+            position = item.get("_position")
+            if position is None:
+                position = 10**9
+            return (position, item.get("added_on") or item.get("created_at") or "", item.get("_id") or "")
+
+        return sorted(items, key=sort_key)
+
+    def _normalize_for_compare(self, value: Any) -> Any:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        if isinstance(value, dict):
+            return {key: self._normalize_for_compare(val) for key, val in value.items()}
+        if isinstance(value, list):
+            return [self._normalize_for_compare(item) for item in value]
+        return value
+
+    async def _read_with_mode(
+        self,
+        *,
+        mode: ReadMode,
+        operation: str,
+        user_id: Optional[str],
+        legacy_reader: Callable[[], Awaitable[Any]],
+        v2_reader: Callable[[], Awaitable[Any]],
+        compare_normalizer: Callable[[Any], Any],
+    ):
+        if mode == "legacy_only":
+            data = await legacy_reader()
+            self._log("quiz_read_legacy_served", operation=operation, user_id=user_id, read_mode=mode)
+            return data
+
+        if mode == "v2_only":
+            data = await v2_reader()
+            self._log("quiz_read_v2_served", operation=operation, user_id=user_id, read_mode=mode)
+            return data
+
+        self._log("quiz_read_compare_started", operation=operation, user_id=user_id, read_mode=mode)
+        legacy_data = await legacy_reader()
+        v2_data = await v2_reader()
+        normalized_legacy = compare_normalizer(legacy_data)
+        normalized_v2 = compare_normalizer(v2_data)
+        if normalized_legacy == normalized_v2:
+            self._log("quiz_read_compare_match", operation=operation, user_id=user_id, read_mode=mode)
+        else:
+            self._log(
+                "quiz_read_compare_mismatch",
+                operation=operation,
+                user_id=user_id,
+                read_mode=mode,
+                legacy_shape=normalized_legacy,
+                v2_shape=normalized_v2,
+            )
+        self._log("quiz_read_legacy_served", operation=operation, user_id=user_id, read_mode=mode)
+        return legacy_data
+
+    async def _get_quizzes_by_ids(self, quiz_ids: list[str]) -> dict[str, QuizDocumentV2]:
+        quizzes = await self.quiz_repository.find_many_by_ids(quiz_ids)
+        return {str(quiz.id): quiz for quiz in quizzes}
+
+    @staticmethod
+    def _serialize_saved_questions(quiz: QuizDocumentV2) -> list[dict[str, Any]]:
+        return [
+            {
+                "question": question.question,
+                "options": question.options,
+                "question_type": quiz.quiz_type.value,
+                "correct_answer": question.correct_answer,
+            }
+            for question in quiz.questions
+        ]
+
+    @staticmethod
+    def _serialize_history_questions(quiz: QuizDocumentV2) -> list[dict[str, Any]]:
+        return [
+            {
+                "question": question.question,
+                "options": question.options,
+                "answer": question.correct_answer,
+                "question_type": quiz.quiz_type.value,
+            }
+            for question in quiz.questions
+        ]
+
+    async def _legacy_get_quiz_history(self, user_id: str, limit: int) -> list[dict[str, Any]]:
+        documents = await self.quiz_history_collection.find({"user_id": user_id}).sort("created_at", -1).to_list(limit)
+        return [self._serialize_legacy_document(document) for document in documents]
+
+    async def _v2_get_quiz_history(self, user_id: str, limit: int) -> list[dict[str, Any]]:
+        references = await self.reference_repository.list_quiz_history_for_user(user_id)
+        references = sorted(references, key=lambda reference: reference.created_at, reverse=True)[:limit]
+        quizzes_by_id = await self._get_quizzes_by_ids([reference.quiz_id for reference in references])
+        payload: list[dict[str, Any]] = []
+        for reference in references:
+            quiz = quizzes_by_id.get(reference.quiz_id)
+            if quiz is None:
+                continue
+            payload.append(
+                {
+                    "_id": reference.legacy_history_id or str(reference.id),
+                    "user_id": reference.user_id,
+                    "quiz_id": quiz.legacy_quiz_id,
+                    "canonical_quiz_id": str(quiz.id),
+                    "quiz_name": quiz.title,
+                    "question_type": quiz.quiz_type.value,
+                    "profession": reference.metadata.get("topic") or quiz.title,
+                    "difficulty_level": reference.metadata.get("difficulty_level"),
+                    "audience_type": reference.metadata.get("audience_type"),
+                    "questions": self._serialize_history_questions(quiz),
+                    "created_at": self._isoformat(reference.created_at),
+                }
+            )
+        return payload
+
+    @staticmethod
+    def _normalize_history_compare(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        normalized = [
+            {
+                "_id": item.get("_id"),
+                "created_at": item.get("created_at"),
+                "question_count": len(item.get("questions", [])),
+                "questions": [question.get("question") for question in item.get("questions", [])],
+            }
+            for item in items
+        ]
+        return sorted(normalized, key=lambda item: item["_id"])
+
+    async def get_quiz_history_for_user(self, user_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        mode = settings.QUIZ_V2_HISTORY_READ_MODE
+        return await self._read_with_mode(
+            mode=mode,
+            operation="quiz_history_list",
+            user_id=user_id,
+            legacy_reader=lambda: self._legacy_get_quiz_history(user_id, limit),
+            v2_reader=lambda: self._v2_get_quiz_history(user_id, limit),
+            compare_normalizer=self._normalize_history_compare,
+        )
+
+    async def _legacy_list_saved_quizzes(self, user_id: str, limit: int) -> list[dict[str, Any]]:
+        documents = await self.saved_quizzes_collection.find({"user_id": user_id}).sort("created_at", -1).to_list(limit)
+        return [self._serialize_legacy_document(document) for document in documents]
+
+    async def _legacy_get_saved_quiz(self, saved_quiz_id: str, user_id: str) -> Optional[dict[str, Any]]:
+        try:
+            object_id = ObjectId(saved_quiz_id)
+        except InvalidId:
+            return None
+        document = await self.saved_quizzes_collection.find_one({"_id": object_id, "user_id": user_id})
+        return self._serialize_legacy_document(document) if document else None
+
+    def _build_saved_payload(self, reference: SavedQuizDocumentV2, quiz: QuizDocumentV2) -> dict[str, Any]:
+        return {
+            "_id": reference.legacy_saved_quiz_id or str(reference.id),
+            "user_id": reference.user_id,
+            "quiz_id": quiz.legacy_quiz_id,
+            "canonical_quiz_id": str(quiz.id),
+            "title": reference.display_title or quiz.title,
+            "question_type": quiz.quiz_type.value,
+            "is_deleted": False,
+            "questions": self._serialize_saved_questions(quiz),
+            "created_at": self._isoformat(reference.saved_at),
+        }
+
+    async def _v2_list_saved_quizzes(self, user_id: str, limit: int) -> list[dict[str, Any]]:
+        references = await self.reference_repository.list_saved_quizzes_for_user(user_id)
+        references = sorted(references, key=lambda reference: reference.saved_at, reverse=True)[:limit]
+        quizzes_by_id = await self._get_quizzes_by_ids([reference.quiz_id for reference in references])
+        payload: list[dict[str, Any]] = []
+        for reference in references:
+            quiz = quizzes_by_id.get(reference.quiz_id)
+            if quiz is None:
+                continue
+            payload.append(self._build_saved_payload(reference, quiz))
+        return payload
+
+    async def _v2_get_saved_quiz(self, saved_quiz_id: str, user_id: str) -> Optional[dict[str, Any]]:
+        reference = await self.reference_repository.get_saved_quiz_by_legacy_id(saved_quiz_id, user_id=user_id)
+        if reference is None:
+            return None
+        quiz = await self.quiz_repository.find_by_id(reference.quiz_id)
+        if quiz is None:
+            return None
+        return self._build_saved_payload(reference, quiz)
+
+    @staticmethod
+    def _normalize_saved_compare(items: Any) -> Any:
+        if items is None:
+            return None
+        if isinstance(items, dict):
+            items = [items]
+            unwrap = True
+        else:
+            unwrap = False
+        normalized = [
+            {
+                "_id": item.get("_id"),
+                "title": item.get("title"),
+                "created_at": item.get("created_at"),
+                "question_type": item.get("question_type"),
+                "question_count": len(item.get("questions", [])),
+                "questions": [question.get("question") for question in item.get("questions", [])],
+            }
+            for item in items
+        ]
+        normalized = sorted(normalized, key=lambda item: item["_id"])
+        return normalized[0] if unwrap else normalized
+
+    async def get_saved_quizzes_for_user(self, user_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        mode = settings.QUIZ_V2_SAVED_READ_MODE
+        return await self._read_with_mode(
+            mode=mode,
+            operation="saved_quiz_list",
+            user_id=user_id,
+            legacy_reader=lambda: self._legacy_list_saved_quizzes(user_id, limit),
+            v2_reader=lambda: self._v2_list_saved_quizzes(user_id, limit),
+            compare_normalizer=self._normalize_saved_compare,
+        )
+
+    async def get_saved_quiz_by_id(self, saved_quiz_id: str, user_id: str) -> Optional[dict[str, Any]]:
+        mode = settings.QUIZ_V2_SAVED_READ_MODE
+        return await self._read_with_mode(
+            mode=mode,
+            operation="saved_quiz_detail",
+            user_id=user_id,
+            legacy_reader=lambda: self._legacy_get_saved_quiz(saved_quiz_id, user_id),
+            v2_reader=lambda: self._v2_get_saved_quiz(saved_quiz_id, user_id),
+            compare_normalizer=self._normalize_saved_compare,
+        )
+
+    async def _legacy_list_folders(self, user_id: str) -> list[dict[str, Any]]:
+        documents = await self.folders_collection.find({"user_id": user_id}).to_list(length=500)
+        return self._sort_folders([self._serialize_legacy_document(document) for document in documents])
+
+    async def _legacy_get_folder(self, folder_id: str) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+        try:
+            object_id = ObjectId(folder_id)
+        except InvalidId:
+            return None, None
+        document = await self.folders_collection.find_one({"_id": object_id})
+        if not document:
+            return None, None
+        folder = self._serialize_legacy_document(document)
+        return folder, folder.get("user_id")
+
+    def _build_folder_item_payload(
+        self,
+        *,
+        item: FolderItemDocumentV2,
+        quiz: QuizDocumentV2,
+    ) -> dict[str, Any]:
+        questions = self._serialize_saved_questions(quiz)
+        return {
+            "_id": item.legacy_folder_item_id or str(item.id),
+            "quiz_id": quiz.legacy_quiz_id,
+            "canonical_quiz_id": str(quiz.id),
+            "title": item.display_title or quiz.title,
+            "question_type": quiz.quiz_type.value,
+            "questions": questions,
+            "created_at": self._isoformat(item.created_at),
+            "added_on": self._isoformat(item.created_at),
+            "_position": item.position,
+            "quiz_data": {
+                "_id": item.legacy_folder_item_id or str(item.id),
+                "quiz_id": quiz.legacy_quiz_id,
+                "canonical_quiz_id": str(quiz.id),
+                "title": item.display_title or quiz.title,
+                "question_type": quiz.quiz_type.value,
+                "questions": questions,
+                "created_at": self._isoformat(quiz.created_at),
+            },
+        }
+
+    async def _v2_list_folders(self, user_id: str) -> list[dict[str, Any]]:
+        folders = await self.reference_repository.list_folders_for_user(user_id)
+        folders = sorted(folders, key=lambda folder: (folder.created_at, folder.legacy_folder_id or str(folder.id)))
+        folder_payloads: list[dict[str, Any]] = []
+        for folder in folders:
+            items = await self.reference_repository.list_folder_items_for_folder(str(folder.id))
+            folder_payloads.append(
+                {
+                    "_id": folder.legacy_folder_id or str(folder.id),
+                    "user_id": folder.user_id,
+                    "name": folder.name,
+                    "created_at": self._isoformat(folder.created_at),
+                    "updated_at": self._isoformat(folder.updated_at),
+                    "quizzes": [{"_id": item.legacy_folder_item_id or str(item.id)} for item in items],
+                }
+            )
+        return folder_payloads
+
+    async def _v2_get_folder(self, folder_id: str) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+        folder = await self.reference_repository.get_folder_by_legacy_id(folder_id)
+        if folder is None:
+            return None, None
+        items = await self.reference_repository.list_folder_items_for_folder(str(folder.id))
+        quiz_map = await self._get_quizzes_by_ids([item.quiz_id for item in items])
+        payload_items: list[dict[str, Any]] = []
+        for item in items:
+            quiz = quiz_map.get(item.quiz_id)
+            if quiz is None:
+                continue
+            payload_items.append(self._build_folder_item_payload(item=item, quiz=quiz))
+        payload_items = self._sort_folder_items(payload_items)
+        for payload_item in payload_items:
+            payload_item.pop("_position", None)
+        return (
+            {
+                "_id": folder.legacy_folder_id or str(folder.id),
+                "user_id": folder.user_id,
+                "name": folder.name,
+                "created_at": self._isoformat(folder.created_at),
+                "updated_at": self._isoformat(folder.updated_at),
+                "quizzes": payload_items,
+            },
+            folder.user_id,
+        )
+
+    @staticmethod
+    def _normalize_folder_compare(items: Any) -> Any:
+        if items is None:
+            return None
+        if isinstance(items, dict):
+            quizzes = items.get("quizzes", [])
+            return {
+                "_id": items.get("_id"),
+                "name": items.get("name"),
+                "quiz_ids": [quiz.get("_id") for quiz in quizzes],
+                "quiz_titles": [quiz.get("title") for quiz in quizzes],
+                "question_counts": [
+                    len(quiz.get("questions") or quiz.get("quiz_data", {}).get("questions", []))
+                    for quiz in quizzes
+                ],
+            }
+        normalized = [
+            {
+                "_id": item.get("_id"),
+                "name": item.get("name"),
+                "quiz_count": len(item.get("quizzes", [])),
+            }
+            for item in items
+        ]
+        return sorted(normalized, key=lambda item: item["_id"])
+
+    async def get_user_folders(self, user_id: str) -> list[dict[str, Any]]:
+        mode = settings.QUIZ_V2_FOLDER_READ_MODE
+        return await self._read_with_mode(
+            mode=mode,
+            operation="folder_list",
+            user_id=user_id,
+            legacy_reader=lambda: self._legacy_list_folders(user_id),
+            v2_reader=lambda: self._v2_list_folders(user_id),
+            compare_normalizer=self._normalize_folder_compare,
+        )
+
+    async def get_folder_by_id(self, folder_id: str, user_id: str) -> Optional[dict[str, Any]]:
+        mode = settings.QUIZ_V2_FOLDER_READ_MODE
+
+        async def legacy_reader():
+            folder, owner_id = await self._legacy_get_folder(folder_id)
+            if folder is None:
+                return None
+            if owner_id != user_id:
+                raise PermissionError("Unauthorized access to folder")
+            return folder
+
+        async def v2_reader():
+            folder, owner_id = await self._v2_get_folder(folder_id)
+            if folder is None:
+                return None
+            if owner_id != user_id:
+                raise PermissionError("Unauthorized access to folder")
+            return folder
+
+        return await self._read_with_mode(
+            mode=mode,
+            operation="folder_detail",
+            user_id=user_id,
+            legacy_reader=legacy_reader,
+            v2_reader=v2_reader,
+            compare_normalizer=self._normalize_folder_compare,
+        )

--- a/server/app/db/services/shared_quiz_read_service.py
+++ b/server/app/db/services/shared_quiz_read_service.py
@@ -1,0 +1,202 @@
+import logging
+from typing import Any, Optional
+
+from bson import ObjectId
+from bson.errors import InvalidId
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from server.app.db.core.config import settings
+from server.app.db.core.connection import (
+    get_ai_generated_quizzes_collection,
+    get_quizzes_collection,
+    get_quizzes_v2_collection,
+    get_saved_quizzes_collection,
+    get_saved_quizzes_v2_collection,
+    get_folder_items_v2_collection,
+    get_folders_v2_collection,
+    get_quiz_history_v2_collection,
+)
+from server.app.db.services.quiz_user_library_read_service import ReadMode
+from server.app.db.v2.models.quiz_models import QuizDocumentV2
+from server.app.db.v2.repositories.quiz_repository import QuizV2Repository
+from server.app.db.v2.repositories.reference_repository import ReferenceV2Repository
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_default_description(topic: str) -> str:
+    return f"A quiz to test your knowledge on {topic}"
+
+
+class SharedQuizReadService:
+    def __init__(
+        self,
+        *,
+        quizzes_collection: Optional[AsyncIOMotorCollection] = None,
+        ai_generated_quizzes_collection: Optional[AsyncIOMotorCollection] = None,
+        saved_quizzes_collection: Optional[AsyncIOMotorCollection] = None,
+        quiz_repository: Optional[QuizV2Repository] = None,
+        reference_repository: Optional[ReferenceV2Repository] = None,
+    ):
+        self.quizzes_collection = (
+            quizzes_collection if quizzes_collection is not None else get_quizzes_collection()
+        )
+        self.ai_generated_quizzes_collection = (
+            ai_generated_quizzes_collection
+            if ai_generated_quizzes_collection is not None
+            else get_ai_generated_quizzes_collection()
+        )
+        self.saved_quizzes_collection = (
+            saved_quizzes_collection
+            if saved_quizzes_collection is not None
+            else get_saved_quizzes_collection()
+        )
+        self.quiz_repository = (
+            quiz_repository if quiz_repository is not None else QuizV2Repository(get_quizzes_v2_collection())
+        )
+        self.reference_repository = (
+            reference_repository
+            if reference_repository is not None
+            else ReferenceV2Repository(
+                get_folders_v2_collection(),
+                get_folder_items_v2_collection(),
+                get_saved_quizzes_v2_collection(),
+                get_quiz_history_v2_collection(),
+            )
+        )
+
+    def _log(self, event: str, **fields):
+        if not settings.QUIZ_V2_STRUCTURED_LOGGING:
+            return
+        logger.info("%s | %s", event, fields)
+
+    @staticmethod
+    def _normalize_legacy_quiz(
+        quiz_doc: dict[str, Any],
+        quiz_id: str,
+        source: str,
+    ) -> dict[str, Any]:
+        if source == "quizzes":
+            title = quiz_doc.get("title") or "General Knowledge"
+            description = quiz_doc.get("description") or build_default_description(title)
+            quiz_type = quiz_doc.get("quiz_type") or "multichoice"
+        elif source == "ai_generated_quizzes":
+            profession = quiz_doc.get("profession") or "General Knowledge"
+            title = profession
+            description = quiz_doc.get("description") or build_default_description(profession)
+            quiz_type = quiz_doc.get("question_type") or "multichoice"
+        elif source == "saved_quizzes":
+            title = quiz_doc.get("title") or "General Knowledge"
+            topic = quiz_doc.get("profession") or title
+            description = quiz_doc.get("description") or build_default_description(topic)
+            quiz_type = quiz_doc.get("question_type") or "multichoice"
+        else:
+            raise ValueError(f"Unsupported shared quiz source: {source}")
+
+        return {
+            "id": quiz_id,
+            "title": title,
+            "description": description,
+            "quiz_type": quiz_type,
+            "questions": quiz_doc.get("questions", []),
+        }
+
+    @staticmethod
+    def _normalize_v2_quiz(quiz_doc: QuizDocumentV2, requested_quiz_id: str) -> dict[str, Any]:
+        topic = quiz_doc.title or "General Knowledge"
+        return {
+            "id": requested_quiz_id,
+            "title": quiz_doc.title,
+            "description": quiz_doc.description or build_default_description(topic),
+            "quiz_type": quiz_doc.quiz_type.value,
+            "questions": [
+                {
+                    "question": question.question,
+                    "options": question.options,
+                    "correct_answer": question.correct_answer,
+                }
+                for question in quiz_doc.questions
+            ],
+        }
+
+    async def _legacy_resolve(self, quiz_id: str) -> Optional[dict[str, Any]]:
+        try:
+            object_id = ObjectId(quiz_id)
+        except InvalidId:
+            return None
+
+        regular_quiz = await self.quizzes_collection.find_one({"_id": object_id}, projection={"_id": 0})
+        if regular_quiz:
+            return self._normalize_legacy_quiz(regular_quiz, quiz_id, "quizzes")
+
+        ai_quiz = await self.ai_generated_quizzes_collection.find_one({"_id": object_id}, projection={"_id": 0})
+        if ai_quiz:
+            return self._normalize_legacy_quiz(ai_quiz, quiz_id, "ai_generated_quizzes")
+
+        saved_quiz = await self.saved_quizzes_collection.find_one({"_id": object_id}, projection={"_id": 0})
+        if saved_quiz:
+            return self._normalize_legacy_quiz(saved_quiz, quiz_id, "saved_quizzes")
+        return None
+
+    async def _v2_resolve(self, quiz_id: str) -> Optional[dict[str, Any]]:
+        quiz_doc = await self.quiz_repository.find_by_id(quiz_id)
+        if quiz_doc:
+            return self._normalize_v2_quiz(quiz_doc, quiz_id)
+
+        quiz_doc = await self.quiz_repository.find_by_legacy_mapping("quizzes", quiz_id)
+        if quiz_doc:
+            return self._normalize_v2_quiz(quiz_doc, quiz_id)
+
+        quiz_doc = await self.quiz_repository.find_by_legacy_mapping("ai_generated_quizzes", quiz_id)
+        if quiz_doc:
+            return self._normalize_v2_quiz(quiz_doc, quiz_id)
+
+        saved_reference = await self.reference_repository.get_saved_quiz_by_legacy_id(quiz_id)
+        if saved_reference:
+            quiz_doc = await self.quiz_repository.find_by_id(saved_reference.quiz_id)
+            if quiz_doc:
+                return self._normalize_v2_quiz(quiz_doc, quiz_id)
+        return None
+
+    @staticmethod
+    def _normalize_for_compare(payload: Optional[dict[str, Any]]) -> Any:
+        if payload is None:
+            return None
+        return {
+            "title": payload.get("title"),
+            "description": payload.get("description"),
+            "quiz_type": payload.get("quiz_type"),
+            "question_count": len(payload.get("questions", [])),
+            "questions": [question.get("question") for question in payload.get("questions", [])],
+        }
+
+    async def resolve_shared_quiz(self, quiz_id: str) -> Optional[dict[str, Any]]:
+        mode: ReadMode = settings.QUIZ_V2_SHARE_READ_MODE
+
+        if mode == "legacy_only":
+            payload = await self._legacy_resolve(quiz_id)
+            self._log("quiz_read_legacy_served", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
+            return payload
+
+        if mode == "v2_only":
+            payload = await self._v2_resolve(quiz_id)
+            self._log("quiz_read_v2_served", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
+            return payload
+
+        self._log("quiz_read_compare_started", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
+        legacy_payload = await self._legacy_resolve(quiz_id)
+        v2_payload = await self._v2_resolve(quiz_id)
+        if self._normalize_for_compare(legacy_payload) == self._normalize_for_compare(v2_payload):
+            self._log("quiz_read_compare_match", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
+        else:
+            self._log(
+                "quiz_read_compare_mismatch",
+                operation="shared_quiz_detail",
+                read_mode=mode,
+                quiz_id=quiz_id,
+                legacy_shape=self._normalize_for_compare(legacy_payload),
+                v2_shape=self._normalize_for_compare(v2_payload),
+            )
+        self._log("quiz_read_legacy_served", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
+        return legacy_payload

--- a/server/app/db/v2/migration/__init__.py
+++ b/server/app/db/v2/migration/__init__.py
@@ -1,0 +1,1 @@
+"""Stage 3 backfill and parity tooling for V2 quiz data."""

--- a/server/app/db/v2/migration/backfill_engine.py
+++ b/server/app/db/v2/migration/backfill_engine.py
@@ -1,0 +1,562 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, AsyncIterator, Optional
+
+from bson import ObjectId
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from pydantic import BaseModel
+
+from server.app.db.crud.quiz_write_service import CanonicalQuizWriteService
+from server.app.db.v2.models.reference_models import (
+    FolderDocumentV2,
+    FolderItemDocumentV2,
+    QuizHistoryDocumentV2,
+    SavedQuizDocumentV2,
+)
+from server.app.db.v2.repositories.quiz_repository import QuizV2Repository
+from server.app.db.v2.repositories.reference_repository import ReferenceV2Repository
+
+from .config import BackfillConfig
+from .lock import MigrationLockService
+from .logging import log_migration_event
+from .resolver import LegacyQuizResolver
+from .types import BackfillReport, CollectionMigrationSummary, ParitySummary, utcnow
+
+
+@dataclass
+class MigrationContext:
+    config: BackfillConfig
+    database: AsyncIOMotorDatabase
+    canonical_service: CanonicalQuizWriteService
+    reference_repository: ReferenceV2Repository
+    resolver: LegacyQuizResolver
+    lock_service: MigrationLockService
+    report_dir: Path
+
+
+def _documents_match(existing_document: dict[str, Any] | None, target_document: BaseModel) -> bool:
+    if existing_document is None:
+        return False
+    try:
+        existing_model = target_document.__class__(**existing_document)
+    except Exception:
+        return False
+    return _normalize_for_compare(
+        existing_model.model_dump(exclude={"id"})
+    ) == _normalize_for_compare(target_document.model_dump(exclude={"id"}))
+
+
+def _normalize_for_compare(value: Any) -> Any:
+    if isinstance(value, datetime):
+        if value.tzinfo is not None:
+            value = value.astimezone(timezone.utc).replace(tzinfo=None)
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: _normalize_for_compare(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_normalize_for_compare(item) for item in value]
+    return value
+
+
+def _stable_legacy_timestamp(document: dict[str, Any], *fields: str) -> datetime:
+    for field in fields:
+        value = document.get(field)
+        if value is not None:
+            return value
+    legacy_id = document.get("_id")
+    if isinstance(legacy_id, ObjectId):
+        return legacy_id.generation_time
+    return utcnow()
+
+
+def build_migration_context(
+    *,
+    config: BackfillConfig,
+    database: AsyncIOMotorDatabase,
+    report_dir: Path,
+) -> MigrationContext:
+    quiz_repository = QuizV2Repository(database["quizzes_v2"])
+    canonical_service = CanonicalQuizWriteService(quiz_repository)
+    reference_repository = ReferenceV2Repository(
+        database["folders_v2"],
+        database["folder_items_v2"],
+        database["saved_quizzes_v2"],
+        database["quiz_history_v2"],
+    )
+    resolver = LegacyQuizResolver(
+        canonical_service=canonical_service,
+        ai_generated_quizzes_collection=database["ai_generated_quizzes"],
+        quizzes_collection=database["quizzes"],
+        saved_quizzes_collection=database["saved_quizzes"],
+    )
+    return MigrationContext(
+        config=config,
+        database=database,
+        canonical_service=canonical_service,
+        reference_repository=reference_repository,
+        resolver=resolver,
+        lock_service=MigrationLockService(database),
+        report_dir=report_dir,
+    )
+
+
+async def iterate_batches(
+    collection,
+    *,
+    batch_size: int,
+    start_after_id: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> AsyncIterator[list[dict[str, Any]]]:
+    processed = 0
+    last_id = ObjectId(start_after_id) if start_after_id else None
+    while True:
+        query = {"_id": {"$gt": last_id}} if last_id is not None else {}
+        remaining = None if limit is None else max(limit - processed, 0)
+        if remaining == 0:
+            return
+        current_batch_size = batch_size if remaining is None else min(batch_size, remaining)
+        cursor = collection.find(query).sort("_id", 1).limit(current_batch_size)
+        documents = await cursor.to_list(length=current_batch_size)
+        if not documents:
+            return
+        yield documents
+        processed += len(documents)
+        last_id = documents[-1]["_id"]
+
+
+async def backfill_quizzes(context: MigrationContext) -> CollectionMigrationSummary:
+    summary = CollectionMigrationSummary(
+        collection="quizzes",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+        start_after_id=context.config.start_after_id,
+    )
+
+    async def process_origin_collection(collection_name: str, source_name: str, title_field: str):
+        collection = context.database[collection_name]
+        log_migration_event(
+            "v2_backfill_collection_started",
+            collection=summary.collection,
+            source_collection=collection_name,
+            run_id=context.config.run_id,
+            dry_run=context.config.dry_run,
+        )
+        async for batch in iterate_batches(
+            collection,
+            batch_size=context.config.batch_size,
+            start_after_id=context.config.start_after_id if summary.batches == 0 else None,
+            limit=context.config.limit,
+        ):
+            summary.batches += 1
+            for doc in batch:
+                record_id = str(doc["_id"])
+                summary.scanned += 1
+                summary.last_processed_id = record_id
+                try:
+                    existing = await context.canonical_service.repository.find_by_legacy_mapping(
+                        source_name,
+                        record_id,
+                    )
+                    questions = doc.get("questions", [])
+                    quiz_document = context.canonical_service.build_quiz_document(
+                        title=doc.get(title_field) or "General Knowledge",
+                        description=doc.get("custom_instruction") or doc.get("description"),
+                        quiz_type=doc.get("question_type") or doc.get("quiz_type") or "multichoice",
+                        owner_user_id=doc.get("user_id") or doc.get("owner_id"),
+                        source="ai" if source_name == "ai_generated_quizzes" else "legacy",
+                        questions=questions,
+                        legacy_source_collection=source_name,
+                        legacy_quiz_id=record_id,
+                    )
+                except Exception as exc:
+                    summary.add_malformed(record_id=record_id, reason=str(exc))
+                    continue
+
+                if context.config.dry_run:
+                    if existing:
+                        summary.skipped += 1
+                    else:
+                        summary.inserted += 1
+                    continue
+
+                stored = await context.canonical_service.upsert_quiz_v2_by_legacy_mapping(quiz_document)
+                if existing is None:
+                    summary.inserted += 1
+                elif existing.model_dump(exclude={"updated_at", "created_at"}) != stored.model_dump(
+                    exclude={"updated_at", "created_at"}
+                ):
+                    summary.updated += 1
+                else:
+                    summary.skipped += 1
+
+            await context.lock_service.renew_lock(
+                migration_name="stage_3_backfill",
+                run_id=context.config.run_id,
+                lease_seconds=context.config.lock_lease_seconds,
+            )
+            log_migration_event(
+                "v2_backfill_batch_completed",
+                collection=summary.collection,
+                batch_number=summary.batches,
+                scanned=summary.scanned,
+                inserted=summary.inserted,
+                updated=summary.updated,
+                skipped=summary.skipped,
+                unresolved=summary.unresolved,
+                run_id=context.config.run_id,
+            )
+
+    await process_origin_collection("ai_generated_quizzes", "ai_generated_quizzes", "profession")
+    await process_origin_collection("quizzes", "quizzes", "title")
+    summary.finish()
+    return summary
+
+
+async def backfill_saved_quizzes(context: MigrationContext) -> CollectionMigrationSummary:
+    summary = CollectionMigrationSummary(
+        collection="saved",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+        start_after_id=context.config.start_after_id,
+    )
+    collection = context.database["saved_quizzes"]
+    log_migration_event(
+        "v2_backfill_collection_started",
+        collection=summary.collection,
+        source_collection="saved_quizzes",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+    )
+    async for batch in iterate_batches(
+        collection,
+        batch_size=context.config.batch_size,
+        start_after_id=context.config.start_after_id,
+        limit=context.config.limit,
+    ):
+        summary.batches += 1
+        for doc in batch:
+            record_id = str(doc["_id"])
+            summary.scanned += 1
+            summary.last_processed_id = record_id
+            if doc.get("is_deleted"):
+                summary.skipped += 1
+                continue
+            try:
+                canonical_quiz = await context.resolver.resolve_saved_quiz(doc)
+            except Exception as exc:
+                summary.add_malformed(record_id=record_id, reason=str(exc))
+                continue
+            if not canonical_quiz:
+                summary.add_unresolved(record_id=record_id, reason="No canonical quiz match for saved quiz")
+                continue
+            target_document = SavedQuizDocumentV2(
+                user_id=doc["user_id"],
+                quiz_id=str(canonical_quiz.id),
+                legacy_saved_quiz_id=record_id,
+                saved_at=_stable_legacy_timestamp(doc, "saved_at", "created_at"),
+            )
+            existing = await context.database["saved_quizzes_v2"].find_one(
+                {"user_id": doc["user_id"], "quiz_id": str(canonical_quiz.id)}
+            )
+            if context.config.dry_run:
+                if existing:
+                    summary.skipped += 1
+                else:
+                    summary.inserted += 1
+                continue
+            if existing is None:
+                await context.reference_repository.upsert_saved_quiz(target_document)
+                summary.inserted += 1
+            elif _documents_match(existing, target_document):
+                summary.skipped += 1
+            else:
+                await context.reference_repository.upsert_saved_quiz(target_document)
+                summary.updated += 1
+        await context.lock_service.renew_lock(
+            migration_name="stage_3_backfill",
+            run_id=context.config.run_id,
+            lease_seconds=context.config.lock_lease_seconds,
+        )
+        log_migration_event(
+            "v2_backfill_batch_completed",
+            collection=summary.collection,
+            batch_number=summary.batches,
+            scanned=summary.scanned,
+            inserted=summary.inserted,
+            updated=summary.updated,
+            skipped=summary.skipped,
+            unresolved=summary.unresolved,
+            run_id=context.config.run_id,
+        )
+    summary.finish()
+    return summary
+
+
+async def backfill_quiz_history(context: MigrationContext) -> CollectionMigrationSummary:
+    summary = CollectionMigrationSummary(
+        collection="history",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+        start_after_id=context.config.start_after_id,
+    )
+    collection = context.database["quiz_history"]
+    log_migration_event(
+        "v2_backfill_collection_started",
+        collection=summary.collection,
+        source_collection="quiz_history",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+    )
+    async for batch in iterate_batches(
+        collection,
+        batch_size=context.config.batch_size,
+        start_after_id=context.config.start_after_id,
+        limit=context.config.limit,
+    ):
+        summary.batches += 1
+        for doc in batch:
+            record_id = str(doc["_id"])
+            summary.scanned += 1
+            summary.last_processed_id = record_id
+            try:
+                canonical_quiz = await context.resolver.resolve_quiz_history(
+                    doc,
+                    allow_create=not context.config.dry_run,
+                )
+            except Exception as exc:
+                summary.add_malformed(record_id=record_id, reason=str(exc))
+                continue
+            if not canonical_quiz:
+                summary.add_unresolved(record_id=record_id, reason="No canonical quiz match for history")
+                continue
+            target_document = QuizHistoryDocumentV2(
+                user_id=doc["user_id"],
+                quiz_id=str(canonical_quiz.id),
+                action="generated",
+                metadata={
+                    "source": canonical_quiz.source,
+                    "topic": doc.get("profession") or canonical_quiz.title,
+                    "difficulty_level": doc.get("difficulty_level"),
+                    "audience_type": doc.get("audience_type"),
+                },
+                legacy_history_id=record_id,
+                created_at=_stable_legacy_timestamp(doc, "created_at"),
+            )
+            existing = await context.database["quiz_history_v2"].find_one({"legacy_history_id": record_id})
+            if context.config.dry_run:
+                if existing:
+                    summary.skipped += 1
+                else:
+                    summary.inserted += 1
+                continue
+            if existing is None:
+                await context.reference_repository.upsert_quiz_history(target_document)
+                summary.inserted += 1
+            elif _documents_match(existing, target_document):
+                summary.skipped += 1
+            else:
+                await context.reference_repository.upsert_quiz_history(target_document)
+                summary.updated += 1
+        await context.lock_service.renew_lock(
+            migration_name="stage_3_backfill",
+            run_id=context.config.run_id,
+            lease_seconds=context.config.lock_lease_seconds,
+        )
+        log_migration_event(
+            "v2_backfill_batch_completed",
+            collection=summary.collection,
+            batch_number=summary.batches,
+            scanned=summary.scanned,
+            inserted=summary.inserted,
+            updated=summary.updated,
+            skipped=summary.skipped,
+            unresolved=summary.unresolved,
+            run_id=context.config.run_id,
+        )
+    summary.finish()
+    return summary
+
+
+async def backfill_folders(context: MigrationContext) -> CollectionMigrationSummary:
+    summary = CollectionMigrationSummary(
+        collection="folders",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+        start_after_id=context.config.start_after_id,
+    )
+    folders_collection = context.database["folders"]
+    log_migration_event(
+        "v2_backfill_collection_started",
+        collection=summary.collection,
+        source_collection="folders",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+    )
+    async for batch in iterate_batches(
+        folders_collection,
+        batch_size=context.config.batch_size,
+        start_after_id=context.config.start_after_id,
+        limit=context.config.limit,
+    ):
+        summary.batches += 1
+        for folder in batch:
+            folder_id = str(folder["_id"])
+            summary.scanned += 1
+            summary.last_processed_id = folder_id
+            existing_folder = await context.reference_repository.get_folder_by_legacy_id(folder_id)
+            target_folder_created_at = _stable_legacy_timestamp(folder, "created_at")
+            target_folder = FolderDocumentV2(
+                user_id=folder["user_id"],
+                name=folder["name"],
+                description=folder.get("description"),
+                legacy_folder_id=folder_id,
+                created_at=target_folder_created_at,
+                updated_at=folder.get("updated_at") or target_folder_created_at,
+            )
+            if not context.config.dry_run:
+                if existing_folder is None:
+                    folder_v2 = await context.reference_repository.upsert_folder_by_legacy_id(target_folder)
+                    summary.inserted += 1
+                elif _documents_match(existing_folder.model_dump(by_alias=True), target_folder):
+                    folder_v2 = existing_folder
+                    summary.skipped += 1
+                else:
+                    folder_v2 = await context.reference_repository.upsert_folder_by_legacy_id(target_folder)
+                    summary.updated += 1
+            else:
+                folder_v2 = existing_folder or target_folder
+                if existing_folder:
+                    summary.skipped += 1
+                else:
+                    summary.inserted += 1
+            for item in folder.get("quizzes", []):
+                item_id = str(item.get("_id"))
+                canonical_quiz = await context.resolver.resolve_folder_item(item)
+                if not canonical_quiz:
+                    summary.add_unresolved(record_id=item_id, reason="No canonical quiz match for folder item")
+                    continue
+                target_item = FolderItemDocumentV2(
+                    folder_id=str(folder_v2.id),
+                    quiz_id=str(canonical_quiz.id),
+                    added_by=folder.get("user_id"),
+                    legacy_folder_item_id=item_id,
+                    created_at=item.get("added_on")
+                    or item.get("created_at")
+                    or target_folder.created_at,
+                )
+                existing_item = await context.database["folder_items_v2"].find_one(
+                    {"legacy_folder_item_id": item_id}
+                )
+                if context.config.dry_run:
+                    if existing_item:
+                        summary.skipped += 1
+                    else:
+                        summary.inserted += 1
+                    continue
+                if existing_item is None:
+                    await context.reference_repository.upsert_folder_item_by_legacy_id(target_item)
+                    summary.inserted += 1
+                elif _documents_match(existing_item, target_item):
+                    summary.skipped += 1
+                else:
+                    await context.reference_repository.upsert_folder_item_by_legacy_id(target_item)
+                    summary.updated += 1
+        await context.lock_service.renew_lock(
+            migration_name="stage_3_backfill",
+            run_id=context.config.run_id,
+            lease_seconds=context.config.lock_lease_seconds,
+        )
+        log_migration_event(
+            "v2_backfill_batch_completed",
+            collection=summary.collection,
+            batch_number=summary.batches,
+            scanned=summary.scanned,
+            inserted=summary.inserted,
+            updated=summary.updated,
+            skipped=summary.skipped,
+            unresolved=summary.unresolved,
+            run_id=context.config.run_id,
+        )
+    summary.finish()
+    return summary
+
+
+async def run_backfill(context: MigrationContext) -> BackfillReport:
+    report = BackfillReport(run_id=context.config.run_id, dry_run=context.config.dry_run)
+    backfill_map = {
+        "quizzes": backfill_quizzes,
+        "saved": backfill_saved_quizzes,
+        "history": backfill_quiz_history,
+        "folders": backfill_folders,
+    }
+    for collection_name in context.config.collections:
+        log_migration_event(
+            "v2_backfill_runner_selected",
+            requested_collection=collection_name,
+            run_id=context.config.run_id,
+            dry_run=context.config.dry_run,
+        )
+        runner = backfill_map[collection_name]
+        summary = await runner(context)
+        report.add_summary(summary)
+    report.finish()
+    return report
+
+
+async def run_parity_checks(context: MigrationContext) -> ParitySummary:
+    parity = ParitySummary(run_id=context.config.run_id)
+    quizzes_v2 = context.database["quizzes_v2"]
+    saved_v2 = context.database["saved_quizzes_v2"]
+    history_v2 = context.database["quiz_history_v2"]
+    folders_v2 = context.database["folders_v2"]
+    folder_items_v2 = context.database["folder_items_v2"]
+    legacy_folders = context.database["folders"]
+
+    embedded_folder_items = 0
+    async for folder in legacy_folders.find({}, {"quizzes": 1}):
+        embedded_folder_items += len(folder.get("quizzes", []))
+
+    parity.add_section(
+        "quizzes",
+        {
+            "legacy_ai_generated_count": await context.database["ai_generated_quizzes"].count_documents({}),
+            "legacy_manual_count": await context.database["quizzes"].count_documents({}),
+            "v2_count": await quizzes_v2.count_documents({}),
+        },
+    )
+    parity.add_section(
+        "saved",
+        {
+            "legacy_count": await context.database["saved_quizzes"].count_documents({"is_deleted": {"$ne": True}}),
+            "v2_count": await saved_v2.count_documents({}),
+            "orphaned_quiz_refs": await saved_v2.count_documents(
+                {"quiz_id": {"$nin": [str(doc["_id"]) async for doc in quizzes_v2.find({}, {"_id": 1})]}}
+            ),
+        },
+    )
+    v2_quiz_ids = [str(doc["_id"]) async for doc in quizzes_v2.find({}, {"_id": 1})]
+    v2_folder_ids = [str(doc["_id"]) async for doc in folders_v2.find({}, {"_id": 1})]
+    parity.add_section(
+        "history",
+        {
+            "legacy_count": await context.database["quiz_history"].count_documents({}),
+            "v2_count": await history_v2.count_documents({}),
+            "orphaned_quiz_refs": await history_v2.count_documents({"quiz_id": {"$nin": v2_quiz_ids}}),
+        },
+    )
+    parity.add_section(
+        "folders",
+        {
+            "legacy_folder_count": await legacy_folders.count_documents({}),
+            "legacy_embedded_item_count": embedded_folder_items,
+            "v2_folder_count": await folders_v2.count_documents({}),
+            "v2_folder_item_count": await folder_items_v2.count_documents({}),
+            "orphaned_folder_refs": await folder_items_v2.count_documents({"folder_id": {"$nin": v2_folder_ids}}),
+            "orphaned_quiz_refs": await folder_items_v2.count_documents({"quiz_id": {"$nin": v2_quiz_ids}}),
+        },
+    )
+    parity.finish()
+    return parity

--- a/server/app/db/v2/migration/backfill_engine.py
+++ b/server/app/db/v2/migration/backfill_engine.py
@@ -272,6 +272,7 @@ async def backfill_saved_quizzes(context: MigrationContext) -> CollectionMigrati
             target_document = SavedQuizDocumentV2(
                 user_id=doc["user_id"],
                 quiz_id=str(canonical_quiz.id),
+                display_title=doc.get("title") or canonical_quiz.title,
                 legacy_saved_quiz_id=record_id,
                 saved_at=_stable_legacy_timestamp(doc, "saved_at", "created_at"),
             )
@@ -460,7 +461,7 @@ async def backfill_folders(context: MigrationContext) -> CollectionMigrationSumm
                     summary.skipped += 1
                 else:
                     summary.inserted += 1
-            for item in folder.get("quizzes", []):
+            for position, item in enumerate(folder.get("quizzes", [])):
                 item_id = str(item.get("_id"))
                 try:
                     canonical_quiz = await context.resolver.resolve_folder_item(
@@ -485,6 +486,8 @@ async def backfill_folders(context: MigrationContext) -> CollectionMigrationSumm
                     folder_id=str(folder_v2.id),
                     quiz_id=str(canonical_quiz.id),
                     added_by=folder.get("user_id"),
+                    position=position,
+                    display_title=item.get("title") or None,
                     legacy_folder_item_id=item_id,
                     created_at=item.get("added_on")
                     or item.get("created_at")

--- a/server/app/db/v2/migration/backfill_engine.py
+++ b/server/app/db/v2/migration/backfill_engine.py
@@ -10,6 +10,9 @@ from motor.motor_asyncio import AsyncIOMotorDatabase
 from pydantic import BaseModel
 
 from server.app.db.crud.quiz_write_service import CanonicalQuizWriteService
+from server.app.db.services.legacy_quiz_resolution_service import (
+    LegacyQuizStructureConflictError,
+)
 from server.app.db.v2.models.reference_models import (
     FolderDocumentV2,
     FolderItemDocumentV2,
@@ -245,7 +248,21 @@ async def backfill_saved_quizzes(context: MigrationContext) -> CollectionMigrati
                 summary.skipped += 1
                 continue
             try:
-                canonical_quiz = await context.resolver.resolve_saved_quiz(doc)
+                canonical_quiz = await context.resolver.resolve_saved_quiz(
+                    doc,
+                    allow_create=not context.config.dry_run,
+                )
+            except LegacyQuizStructureConflictError as exc:
+                conflict_details = exc.to_log_fields()
+                summary.add_conflict(record_id=record_id, reason=str(exc), **conflict_details)
+                log_migration_event(
+                    "v2_backfill_record_conflict",
+                    collection=summary.collection,
+                    record_id=record_id,
+                    run_id=context.config.run_id,
+                    **conflict_details,
+                )
+                continue
             except Exception as exc:
                 summary.add_malformed(record_id=record_id, reason=str(exc))
                 continue
@@ -326,6 +343,17 @@ async def backfill_quiz_history(context: MigrationContext) -> CollectionMigratio
                     doc,
                     allow_create=not context.config.dry_run,
                 )
+            except LegacyQuizStructureConflictError as exc:
+                conflict_details = exc.to_log_fields()
+                summary.add_conflict(record_id=record_id, reason=str(exc), **conflict_details)
+                log_migration_event(
+                    "v2_backfill_record_conflict",
+                    collection=summary.collection,
+                    record_id=record_id,
+                    run_id=context.config.run_id,
+                    **conflict_details,
+                )
+                continue
             except Exception as exc:
                 summary.add_malformed(record_id=record_id, reason=str(exc))
                 continue
@@ -434,7 +462,22 @@ async def backfill_folders(context: MigrationContext) -> CollectionMigrationSumm
                     summary.inserted += 1
             for item in folder.get("quizzes", []):
                 item_id = str(item.get("_id"))
-                canonical_quiz = await context.resolver.resolve_folder_item(item)
+                try:
+                    canonical_quiz = await context.resolver.resolve_folder_item(
+                        item,
+                        allow_create=not context.config.dry_run,
+                    )
+                except LegacyQuizStructureConflictError as exc:
+                    conflict_details = exc.to_log_fields()
+                    summary.add_conflict(record_id=item_id, reason=str(exc), **conflict_details)
+                    log_migration_event(
+                        "v2_backfill_record_conflict",
+                        collection=summary.collection,
+                        record_id=item_id,
+                        run_id=context.config.run_id,
+                        **conflict_details,
+                    )
+                    continue
                 if not canonical_quiz:
                     summary.add_unresolved(record_id=item_id, reason="No canonical quiz match for folder item")
                     continue

--- a/server/app/db/v2/migration/backfill_engine.py
+++ b/server/app/db/v2/migration/backfill_engine.py
@@ -276,7 +276,7 @@ async def backfill_saved_quizzes(context: MigrationContext) -> CollectionMigrati
                 saved_at=_stable_legacy_timestamp(doc, "saved_at", "created_at"),
             )
             existing = await context.database["saved_quizzes_v2"].find_one(
-                {"user_id": doc["user_id"], "quiz_id": str(canonical_quiz.id)}
+                {"legacy_saved_quiz_id": record_id}
             )
             if context.config.dry_run:
                 if existing:

--- a/server/app/db/v2/migration/config.py
+++ b/server/app/db/v2/migration/config.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import uuid4
+
+from server.app.db.core.config import settings
+
+
+@dataclass
+class BackfillConfig:
+    run_id: str
+    dry_run: bool
+    batch_size: int
+    limit: Optional[int]
+    start_after_id: Optional[str]
+    collections: list[str]
+    lock_lease_seconds: int
+
+    @classmethod
+    def from_settings(
+        cls,
+        *,
+        dry_run: Optional[bool] = None,
+        batch_size: Optional[int] = None,
+        limit: Optional[int] = None,
+        start_after_id: Optional[str] = None,
+        collections: Optional[list[str]] = None,
+        run_id: Optional[str] = None,
+    ) -> "BackfillConfig":
+        raw_collections = collections or [
+            item.strip()
+            for item in settings.V2_BACKFILL_COLLECTIONS.split(",")
+            if item.strip()
+        ]
+        generated_run_id = run_id or settings.V2_BACKFILL_RUN_ID
+        if not generated_run_id:
+            timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+            generated_run_id = f"stage3-{timestamp}-{uuid4().hex[:8]}"
+        return cls(
+            run_id=generated_run_id,
+            dry_run=settings.V2_BACKFILL_DRY_RUN if dry_run is None else dry_run,
+            batch_size=batch_size or settings.V2_BACKFILL_BATCH_SIZE,
+            limit=settings.V2_BACKFILL_LIMIT if limit is None else limit,
+            start_after_id=settings.V2_BACKFILL_START_AFTER_ID if start_after_id is None else start_after_id,
+            collections=raw_collections,
+            lock_lease_seconds=settings.V2_BACKFILL_LOCK_LEASE_SECONDS,
+        )

--- a/server/app/db/v2/migration/lock.py
+++ b/server/app/db/v2/migration/lock.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from pymongo.errors import DuplicateKeyError
+
+from .types import utcnow
+
+
+class MigrationLockError(RuntimeError):
+    pass
+
+
+class MigrationLockService:
+    def __init__(self, database):
+        self.database = database
+        self.locks = database["migration_locks"]
+        self.runs = database["migration_runs"]
+
+    async def ensure_indexes(self):
+        await self.locks.create_index("expires_at", expireAfterSeconds=0, name="expires_at_ttl")
+        await self.runs.create_index(
+            [("migration_name", 1), ("started_at", -1)],
+            name="migration_name_started_at_idx",
+        )
+
+    async def acquire_lock(
+        self,
+        *,
+        migration_name: str,
+        run_id: str,
+        dry_run: bool,
+        triggered_by: str,
+        lease_seconds: int,
+    ):
+        await self.ensure_indexes()
+        now = utcnow()
+        expires_at = now + timedelta(seconds=lease_seconds)
+        lock_doc = {
+            "_id": migration_name,
+            "run_id": run_id,
+            "dry_run": dry_run,
+            "triggered_by": triggered_by,
+            "started_at": now,
+            "expires_at": expires_at,
+        }
+        try:
+            await self.locks.insert_one(lock_doc)
+        except DuplicateKeyError as exc:
+            active = await self.locks.find_one({"_id": migration_name})
+            raise MigrationLockError(
+                f"Migration '{migration_name}' is already running with run_id={active.get('run_id')}"
+            ) from exc
+
+        await self.runs.insert_one(
+            {
+                "_id": run_id,
+                "migration_name": migration_name,
+                "status": "running",
+                "dry_run": dry_run,
+                "triggered_by": triggered_by,
+                "started_at": now,
+            }
+        )
+
+    async def renew_lock(self, *, migration_name: str, run_id: str, lease_seconds: int):
+        expires_at = utcnow() + timedelta(seconds=lease_seconds)
+        await self.locks.update_one(
+            {"_id": migration_name, "run_id": run_id},
+            {"$set": {"expires_at": expires_at}},
+        )
+
+    async def release_lock(
+        self,
+        *,
+        migration_name: str,
+        run_id: str,
+        status: str,
+        summary: dict | None = None,
+        error: str | None = None,
+    ):
+        now = utcnow()
+        await self.runs.update_one(
+            {"_id": run_id},
+            {
+                "$set": {
+                    "status": status,
+                    "completed_at": now,
+                    "summary": summary,
+                    "error": error,
+                }
+            },
+        )
+        await self.locks.delete_one({"_id": migration_name, "run_id": run_id})
+
+    async def get_last_run(self, migration_name: str):
+        return await self.runs.find_one(
+            {"migration_name": migration_name},
+            sort=[("started_at", -1)],
+        )

--- a/server/app/db/v2/migration/logging.py
+++ b/server/app/db/v2/migration/logging.py
@@ -1,0 +1,9 @@
+import json
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def log_migration_event(event: str, **fields):
+    logger.info("%s | %s", event, json.dumps(fields, default=str, sort_keys=True))

--- a/server/app/db/v2/migration/resolver.py
+++ b/server/app/db/v2/migration/resolver.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from server.app.db.crud.quiz_write_service import CanonicalQuizWriteService
+
+
+class LegacyQuizResolver:
+    def __init__(
+        self,
+        *,
+        canonical_service: CanonicalQuizWriteService,
+        ai_generated_quizzes_collection: AsyncIOMotorCollection,
+        quizzes_collection: AsyncIOMotorCollection,
+        saved_quizzes_collection: AsyncIOMotorCollection,
+    ):
+        self.canonical_service = canonical_service
+        self.ai_generated_quizzes_collection = ai_generated_quizzes_collection
+        self.quizzes_collection = quizzes_collection
+        self.saved_quizzes_collection = saved_quizzes_collection
+
+    def _build_structure_fingerprint(self, *, title: str, quiz_type: str, questions: list[Any]) -> str:
+        normalized_questions = self.canonical_service.normalize_questions(questions)
+        structure_payload = {
+            "title": title.strip(),
+            "quiz_type": quiz_type,
+            "questions": [
+                {
+                    "question": question.get("question"),
+                    "options": question.get("options"),
+                }
+                for question in normalized_questions
+            ],
+        }
+        return self.canonical_service.build_content_fingerprint(structure_payload)
+
+    async def resolve_from_canonical_backref(self, canonical_quiz_id: str | None):
+        if not canonical_quiz_id:
+            return None
+        return await self.canonical_service.get_quiz_v2_by_id(canonical_quiz_id)
+
+    async def resolve_from_source_quiz_id(self, source_quiz_id: str | None):
+        if not source_quiz_id:
+            return None
+
+        canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
+            "ai_generated_quizzes",
+            source_quiz_id,
+        )
+        if canonical_quiz:
+            return canonical_quiz
+
+        canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
+            "quizzes",
+            source_quiz_id,
+        )
+        if canonical_quiz:
+            return canonical_quiz
+
+        legacy_ai = await self.ai_generated_quizzes_collection.find_one({"_id": source_quiz_id})
+        if legacy_ai and legacy_ai.get("canonical_quiz_id"):
+            return await self.resolve_from_canonical_backref(legacy_ai["canonical_quiz_id"])
+
+        try:
+            from bson import ObjectId
+            object_id = ObjectId(source_quiz_id)
+        except Exception:
+            object_id = None
+
+        if object_id is not None:
+            legacy_manual = await self.quizzes_collection.find_one({"_id": object_id})
+            if legacy_manual and legacy_manual.get("canonical_quiz_id"):
+                return await self.resolve_from_canonical_backref(legacy_manual["canonical_quiz_id"])
+        return None
+
+    async def resolve_from_payload(
+        self,
+        *,
+        title: str,
+        quiz_type: str,
+        questions: list[Any],
+        description: str | None = None,
+        allow_create: bool = False,
+    ):
+        normalized_questions = self.canonical_service.normalize_questions(questions)
+        has_complete_answers = all(question.get("correct_answer") for question in normalized_questions)
+        if not has_complete_answers:
+            structure_fingerprint = self._build_structure_fingerprint(
+                title=title,
+                quiz_type=quiz_type,
+                questions=questions,
+            )
+            return await self.canonical_service.repository.find_by_structure_fingerprint(structure_fingerprint)
+
+        quiz_document = self.canonical_service.build_quiz_document(
+            title=title,
+            description=description,
+            quiz_type=quiz_type,
+            questions=questions,
+            source="legacy",
+        )
+        existing = await self.canonical_service.repository.find_by_content_fingerprint(
+            quiz_document.content_fingerprint
+        )
+        if existing:
+            return existing
+        existing = await self.canonical_service.repository.find_by_structure_fingerprint(
+            quiz_document.structure_fingerprint
+        )
+        if existing:
+            return existing
+        if allow_create:
+            return await self.canonical_service.find_or_create_quiz_v2_by_fingerprint(quiz_document)
+        return None
+
+    async def resolve_saved_quiz(self, legacy_saved_doc: dict):
+        canonical_quiz = await self.resolve_from_canonical_backref(
+            legacy_saved_doc.get("canonical_quiz_id")
+        )
+        if canonical_quiz:
+            return canonical_quiz
+        canonical_quiz = await self.resolve_from_source_quiz_id(legacy_saved_doc.get("quiz_id"))
+        if canonical_quiz:
+            return canonical_quiz
+        return await self.resolve_from_payload(
+            title=legacy_saved_doc["title"],
+            quiz_type=legacy_saved_doc["question_type"],
+            questions=legacy_saved_doc["questions"],
+            allow_create=False,
+        )
+
+    async def resolve_quiz_history(self, legacy_history_doc: dict, *, allow_create: bool = True):
+        canonical_quiz = await self.resolve_from_canonical_backref(
+            legacy_history_doc.get("canonical_quiz_id")
+        )
+        if canonical_quiz:
+            return canonical_quiz
+        canonical_quiz = await self.resolve_from_source_quiz_id(legacy_history_doc.get("quiz_id"))
+        if canonical_quiz:
+            return canonical_quiz
+        return await self.resolve_from_payload(
+            title=legacy_history_doc.get("quiz_name")
+            or legacy_history_doc.get("profession")
+            or "Quiz History",
+            description=legacy_history_doc.get("custom_instruction"),
+            quiz_type=legacy_history_doc["question_type"],
+            questions=legacy_history_doc["questions"],
+            allow_create=allow_create,
+        )
+
+    async def resolve_folder_item(self, legacy_folder_item: dict):
+        canonical_quiz = await self.resolve_from_canonical_backref(
+            legacy_folder_item.get("canonical_quiz_id")
+        )
+        if canonical_quiz:
+            return canonical_quiz
+
+        for source_id in (
+            legacy_folder_item.get("quiz_id"),
+            legacy_folder_item.get("quiz_data", {}).get("quiz_id"),
+        ):
+            canonical_quiz = await self.resolve_from_source_quiz_id(source_id)
+            if canonical_quiz:
+                return canonical_quiz
+
+        original_saved_quiz_id = legacy_folder_item.get("original_quiz_id")
+        if original_saved_quiz_id:
+            from bson import ObjectId
+            try:
+                saved_doc = await self.saved_quizzes_collection.find_one(
+                    {"_id": ObjectId(original_saved_quiz_id)}
+                )
+            except Exception:
+                saved_doc = None
+            if saved_doc:
+                canonical_quiz = await self.resolve_saved_quiz(saved_doc)
+                if canonical_quiz:
+                    return canonical_quiz
+
+        quiz_payload = legacy_folder_item.get("quiz_data", {})
+        return await self.resolve_from_payload(
+            title=legacy_folder_item.get("title") or quiz_payload.get("title") or "Untitled Quiz",
+            quiz_type=legacy_folder_item.get("question_type")
+            or quiz_payload.get("question_type")
+            or "multichoice",
+            questions=legacy_folder_item.get("questions")
+            or quiz_payload.get("questions", []),
+            allow_create=False,
+        )

--- a/server/app/db/v2/migration/resolver.py
+++ b/server/app/db/v2/migration/resolver.py
@@ -5,6 +5,9 @@ from typing import Any, Optional
 from motor.motor_asyncio import AsyncIOMotorCollection
 
 from server.app.db.crud.quiz_write_service import CanonicalQuizWriteService
+from server.app.db.services.legacy_quiz_resolution_service import (
+    LegacyQuizResolutionService,
+)
 
 
 class LegacyQuizResolver:
@@ -20,6 +23,11 @@ class LegacyQuizResolver:
         self.ai_generated_quizzes_collection = ai_generated_quizzes_collection
         self.quizzes_collection = quizzes_collection
         self.saved_quizzes_collection = saved_quizzes_collection
+        self.legacy_resolution_service = LegacyQuizResolutionService(
+            canonical_service=canonical_service,
+            ai_generated_quizzes_collection=ai_generated_quizzes_collection,
+            quizzes_collection=quizzes_collection,
+        )
 
     def _build_structure_fingerprint(self, *, title: str, quiz_type: str, questions: list[Any]) -> str:
         normalized_questions = self.canonical_service.normalize_questions(questions)
@@ -37,43 +45,10 @@ class LegacyQuizResolver:
         return self.canonical_service.build_content_fingerprint(structure_payload)
 
     async def resolve_from_canonical_backref(self, canonical_quiz_id: str | None):
-        if not canonical_quiz_id:
-            return None
-        return await self.canonical_service.get_quiz_v2_by_id(canonical_quiz_id)
+        return await self.legacy_resolution_service.resolve_from_canonical_backref(canonical_quiz_id)
 
     async def resolve_from_source_quiz_id(self, source_quiz_id: str | None):
-        if not source_quiz_id:
-            return None
-
-        canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
-            "ai_generated_quizzes",
-            source_quiz_id,
-        )
-        if canonical_quiz:
-            return canonical_quiz
-
-        canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
-            "quizzes",
-            source_quiz_id,
-        )
-        if canonical_quiz:
-            return canonical_quiz
-
-        legacy_ai = await self.ai_generated_quizzes_collection.find_one({"_id": source_quiz_id})
-        if legacy_ai and legacy_ai.get("canonical_quiz_id"):
-            return await self.resolve_from_canonical_backref(legacy_ai["canonical_quiz_id"])
-
-        try:
-            from bson import ObjectId
-            object_id = ObjectId(source_quiz_id)
-        except Exception:
-            object_id = None
-
-        if object_id is not None:
-            legacy_manual = await self.quizzes_collection.find_one({"_id": object_id})
-            if legacy_manual and legacy_manual.get("canonical_quiz_id"):
-                return await self.resolve_from_canonical_backref(legacy_manual["canonical_quiz_id"])
-        return None
+        return await self.legacy_resolution_service.resolve_from_source_quiz_id(source_quiz_id)
 
     async def resolve_from_payload(
         self,
@@ -87,6 +62,14 @@ class LegacyQuizResolver:
         normalized_questions = self.canonical_service.normalize_questions(questions)
         has_complete_answers = all(question.get("correct_answer") for question in normalized_questions)
         if not has_complete_answers:
+            canonical_quiz = await self.legacy_resolution_service.resolve_from_legacy_structure(
+                title=title,
+                quiz_type=quiz_type,
+                questions=questions,
+                allow_create=allow_create,
+            )
+            if canonical_quiz:
+                return canonical_quiz
             structure_fingerprint = self._build_structure_fingerprint(
                 title=title,
                 quiz_type=quiz_type,
@@ -115,13 +98,21 @@ class LegacyQuizResolver:
             return await self.canonical_service.find_or_create_quiz_v2_by_fingerprint(quiz_document)
         return None
 
-    async def resolve_saved_quiz(self, legacy_saved_doc: dict):
+    async def resolve_saved_quiz(self, legacy_saved_doc: dict, *, allow_create: bool = False):
         canonical_quiz = await self.resolve_from_canonical_backref(
             legacy_saved_doc.get("canonical_quiz_id")
         )
         if canonical_quiz:
             return canonical_quiz
         canonical_quiz = await self.resolve_from_source_quiz_id(legacy_saved_doc.get("quiz_id"))
+        if canonical_quiz:
+            return canonical_quiz
+        canonical_quiz = await self.legacy_resolution_service.resolve_from_legacy_structure(
+            title=legacy_saved_doc["title"],
+            quiz_type=legacy_saved_doc["question_type"],
+            questions=legacy_saved_doc["questions"],
+            allow_create=allow_create,
+        )
         if canonical_quiz:
             return canonical_quiz
         return await self.resolve_from_payload(
@@ -150,7 +141,7 @@ class LegacyQuizResolver:
             allow_create=allow_create,
         )
 
-    async def resolve_folder_item(self, legacy_folder_item: dict):
+    async def resolve_folder_item(self, legacy_folder_item: dict, *, allow_create: bool = False):
         canonical_quiz = await self.resolve_from_canonical_backref(
             legacy_folder_item.get("canonical_quiz_id")
         )
@@ -175,7 +166,7 @@ class LegacyQuizResolver:
             except Exception:
                 saved_doc = None
             if saved_doc:
-                canonical_quiz = await self.resolve_saved_quiz(saved_doc)
+                canonical_quiz = await self.resolve_saved_quiz(saved_doc, allow_create=allow_create)
                 if canonical_quiz:
                     return canonical_quiz
 
@@ -187,5 +178,5 @@ class LegacyQuizResolver:
             or "multichoice",
             questions=legacy_folder_item.get("questions")
             or quiz_payload.get("questions", []),
-            allow_create=False,
+            allow_create=allow_create,
         )

--- a/server/app/db/v2/migration/resolver.py
+++ b/server/app/db/v2/migration/resolver.py
@@ -70,6 +70,13 @@ class LegacyQuizResolver:
             )
             if canonical_quiz:
                 return canonical_quiz
+            canonical_quiz = await self.legacy_resolution_service.resolve_existing_v2_from_question_structure(
+                title=title,
+                quiz_type=quiz_type,
+                questions=questions,
+            )
+            if canonical_quiz:
+                return canonical_quiz
             structure_fingerprint = self._build_structure_fingerprint(
                 title=title,
                 quiz_type=quiz_type,
@@ -86,6 +93,13 @@ class LegacyQuizResolver:
         )
         existing = await self.canonical_service.repository.find_by_content_fingerprint(
             quiz_document.content_fingerprint
+        )
+        if existing:
+            return existing
+        existing = await self.legacy_resolution_service.resolve_existing_v2_from_question_structure(
+            title=title,
+            quiz_type=quiz_type,
+            questions=questions,
         )
         if existing:
             return existing
@@ -132,9 +146,12 @@ class LegacyQuizResolver:
         if canonical_quiz:
             return canonical_quiz
         return await self.resolve_from_payload(
-            title=legacy_history_doc.get("quiz_name")
-            or legacy_history_doc.get("profession")
-            or "Quiz History",
+            title=self.legacy_resolution_service.choose_preferred_title(
+                title=legacy_history_doc.get("quiz_name"),
+                fallback_title=legacy_history_doc.get("profession"),
+                quiz_type=legacy_history_doc.get("question_type"),
+                default="Quiz History",
+            ),
             description=legacy_history_doc.get("custom_instruction"),
             quiz_type=legacy_history_doc["question_type"],
             questions=legacy_history_doc["questions"],

--- a/server/app/db/v2/migration/summary.py
+++ b/server/app/db/v2/migration/summary.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def write_summary_json(path: Path, payload: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, default=str, indent=2), encoding="utf-8")

--- a/server/app/db/v2/migration/types.py
+++ b/server/app/db/v2/migration/types.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass
+class CollectionMigrationSummary:
+    collection: str
+    run_id: str
+    dry_run: bool
+    scanned: int = 0
+    inserted: int = 0
+    updated: int = 0
+    skipped: int = 0
+    unresolved: int = 0
+    malformed: int = 0
+    conflicts: int = 0
+    validation_failures: int = 0
+    batches: int = 0
+    start_after_id: Optional[str] = None
+    last_processed_id: Optional[str] = None
+    started_at: datetime = field(default_factory=utcnow)
+    ended_at: Optional[datetime] = None
+    unresolved_examples: list[dict[str, Any]] = field(default_factory=list)
+    malformed_examples: list[dict[str, Any]] = field(default_factory=list)
+    conflict_examples: list[dict[str, Any]] = field(default_factory=list)
+
+    def finish(self):
+        self.ended_at = utcnow()
+
+    def add_unresolved(self, *, record_id: str, reason: str):
+        self.unresolved += 1
+        if len(self.unresolved_examples) < 25:
+            self.unresolved_examples.append({"record_id": record_id, "reason": reason})
+
+    def add_malformed(self, *, record_id: str, reason: str):
+        self.malformed += 1
+        if len(self.malformed_examples) < 25:
+            self.malformed_examples.append({"record_id": record_id, "reason": reason})
+
+    def add_conflict(self, *, record_id: str, reason: str):
+        self.conflicts += 1
+        if len(self.conflict_examples) < 25:
+            self.conflict_examples.append({"record_id": record_id, "reason": reason})
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["started_at"] = self.started_at.isoformat()
+        data["ended_at"] = self.ended_at.isoformat() if self.ended_at else None
+        return data
+
+
+@dataclass
+class BackfillReport:
+    run_id: str
+    dry_run: bool
+    started_at: datetime = field(default_factory=utcnow)
+    ended_at: Optional[datetime] = None
+    collections: dict[str, CollectionMigrationSummary] = field(default_factory=dict)
+
+    def add_summary(self, summary: CollectionMigrationSummary):
+        self.collections[summary.collection] = summary
+
+    def finish(self):
+        self.ended_at = utcnow()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "dry_run": self.dry_run,
+            "started_at": self.started_at.isoformat(),
+            "ended_at": self.ended_at.isoformat() if self.ended_at else None,
+            "collections": {name: summary.to_dict() for name, summary in self.collections.items()},
+        }
+
+
+@dataclass
+class ParitySummary:
+    run_id: str
+    started_at: datetime = field(default_factory=utcnow)
+    ended_at: Optional[datetime] = None
+    sections: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def add_section(self, name: str, data: dict[str, Any]):
+        self.sections[name] = data
+
+    def finish(self):
+        self.ended_at = utcnow()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "started_at": self.started_at.isoformat(),
+            "ended_at": self.ended_at.isoformat() if self.ended_at else None,
+            "sections": self.sections,
+        }

--- a/server/app/db/v2/migration/types.py
+++ b/server/app/db/v2/migration/types.py
@@ -34,20 +34,20 @@ class CollectionMigrationSummary:
     def finish(self):
         self.ended_at = utcnow()
 
-    def add_unresolved(self, *, record_id: str, reason: str):
+    def add_unresolved(self, *, record_id: str, reason: str, **details: Any):
         self.unresolved += 1
         if len(self.unresolved_examples) < 25:
-            self.unresolved_examples.append({"record_id": record_id, "reason": reason})
+            self.unresolved_examples.append({"record_id": record_id, "reason": reason, **details})
 
-    def add_malformed(self, *, record_id: str, reason: str):
+    def add_malformed(self, *, record_id: str, reason: str, **details: Any):
         self.malformed += 1
         if len(self.malformed_examples) < 25:
-            self.malformed_examples.append({"record_id": record_id, "reason": reason})
+            self.malformed_examples.append({"record_id": record_id, "reason": reason, **details})
 
-    def add_conflict(self, *, record_id: str, reason: str):
+    def add_conflict(self, *, record_id: str, reason: str, **details: Any):
         self.conflicts += 1
         if len(self.conflict_examples) < 25:
-            self.conflict_examples.append({"record_id": record_id, "reason": reason})
+            self.conflict_examples.append({"record_id": record_id, "reason": reason, **details})
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)

--- a/server/app/db/v2/models/reference_models.py
+++ b/server/app/db/v2/models/reference_models.py
@@ -44,6 +44,7 @@ class FolderItemDocumentV2(BaseModel):
     quiz_id: str
     added_by: Optional[str] = None
     position: Optional[int] = None
+    display_title: Optional[str] = None
     legacy_folder_item_id: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
@@ -66,6 +67,7 @@ class SavedQuizDocumentV2(BaseModel):
     id: ObjectId = Field(default_factory=ObjectId, alias="_id")
     user_id: str
     quiz_id: str
+    display_title: Optional[str] = None
     legacy_saved_quiz_id: Optional[str] = None
     saved_at: datetime = Field(default_factory=datetime.utcnow)
 

--- a/server/app/db/v2/repositories/quiz_repository.py
+++ b/server/app/db/v2/repositories/quiz_repository.py
@@ -88,6 +88,22 @@ class QuizV2Repository:
             return None
         return QuizDocumentV2(**document) if document else None
 
+    async def find_many_by_ids(self, quiz_ids: list[str]) -> list[QuizDocumentV2]:
+        object_ids: list[ObjectId] = []
+        order: list[ObjectId] = []
+        for quiz_id in quiz_ids:
+            try:
+                object_id = ObjectId(quiz_id)
+            except InvalidId:
+                continue
+            object_ids.append(object_id)
+            order.append(object_id)
+        if not object_ids:
+            return []
+        documents = await self.collection.find({"_id": {"$in": object_ids}}).to_list(length=len(object_ids))
+        by_id = {document["_id"]: document for document in documents}
+        return [QuizDocumentV2(**by_id[object_id]) for object_id in order if object_id in by_id]
+
     async def update_metadata(
         self,
         quiz_id: str,

--- a/server/app/db/v2/repositories/reference_repository.py
+++ b/server/app/db/v2/repositories/reference_repository.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Optional
 
 from motor.motor_asyncio import AsyncIOMotorCollection
 from pymongo import ReturnDocument
@@ -29,6 +30,13 @@ class ReferenceV2Repository:
         if value.tzinfo is not None:
             return value.astimezone(timezone.utc).replace(tzinfo=None)
         return value
+
+    @staticmethod
+    def _merge_position(*values: Optional[int]) -> Optional[int]:
+        valid_values = [value for value in values if value is not None]
+        if not valid_values:
+            return None
+        return min(valid_values)
 
     async def insert_folder(self, folder: FolderDocumentV2) -> FolderDocumentV2:
         payload = folder.model_dump(by_alias=True)
@@ -69,6 +77,10 @@ class ReferenceV2Repository:
         document = await self.folders_collection.find_one({"legacy_folder_id": legacy_folder_id})
         return FolderDocumentV2(**document) if document else None
 
+    async def list_folders_for_user(self, user_id: str) -> list[FolderDocumentV2]:
+        documents = await self.folders_collection.find({"user_id": user_id}).to_list(length=500)
+        return [FolderDocumentV2(**document) for document in documents]
+
     async def delete_folder_by_legacy_id(self, legacy_folder_id: str):
         folder = await self.get_folder_by_legacy_id(legacy_folder_id)
         if folder:
@@ -94,13 +106,25 @@ class ReferenceV2Repository:
                 self._normalize_datetime(legacy_match.get("created_at", created_at)),
                 self._normalize_datetime(target_match.get("created_at", created_at)),
             )
+            merged_position = self._merge_position(
+                payload.get("position"),
+                legacy_match.get("position"),
+                target_match.get("position"),
+            )
             target_legacy_item_id = target_match.get("legacy_folder_item_id")
+            merged_display_title = (
+                payload.get("display_title")
+                or target_match.get("display_title")
+                or legacy_match.get("display_title")
+            )
             updated = await self.folder_items_collection.find_one_and_update(
                 {"_id": target_match["_id"]},
                 {
                     "$set": {
                         **payload,
                         "created_at": merged_created_at,
+                        "position": merged_position,
+                        "display_title": merged_display_title,
                         "legacy_folder_item_id": target_legacy_item_id or folder_item.legacy_folder_item_id,
                     }
                 },
@@ -115,6 +139,8 @@ class ReferenceV2Repository:
             filter_query = {"_id": target_match["_id"]}
             if target_match.get("legacy_folder_item_id"):
                 payload["legacy_folder_item_id"] = target_match["legacy_folder_item_id"]
+            payload["position"] = self._merge_position(payload.get("position"), target_match.get("position"))
+            payload["display_title"] = payload.get("display_title") or target_match.get("display_title")
         else:
             filter_query = (
                 {"legacy_folder_item_id": folder_item.legacy_folder_item_id}
@@ -134,6 +160,10 @@ class ReferenceV2Repository:
             {"legacy_folder_item_id": legacy_folder_item_id}
         )
         return FolderItemDocumentV2(**document) if document else None
+
+    async def list_folder_items_for_folder(self, folder_id: str) -> list[FolderItemDocumentV2]:
+        documents = await self.folder_items_collection.find({"folder_id": folder_id}).to_list(length=1000)
+        return [FolderItemDocumentV2(**document) for document in documents]
 
     async def delete_folder_item_by_legacy_id(self, legacy_folder_item_id: str):
         await self.folder_items_collection.delete_one({"legacy_folder_item_id": legacy_folder_item_id})
@@ -157,11 +187,17 @@ class ReferenceV2Repository:
                 self._normalize_datetime(legacy_match.get("saved_at", saved_at)),
                 self._normalize_datetime(target_match.get("saved_at", saved_at)),
             )
+            merged_display_title = (
+                payload.get("display_title")
+                or target_match.get("display_title")
+                or legacy_match.get("display_title")
+            )
             updated = await self.saved_quizzes_collection.find_one_and_update(
                 {"_id": target_match["_id"]},
                 {
                     "$set": {
                         **payload,
+                        "display_title": merged_display_title,
                         "saved_at": merged_saved_at,
                     }
                 },
@@ -174,6 +210,7 @@ class ReferenceV2Repository:
             filter_query = {"_id": legacy_match["_id"]}
         elif target_match is not None:
             filter_query = {"_id": target_match["_id"]}
+            payload["display_title"] = payload.get("display_title") or target_match.get("display_title")
         else:
             filter_query = (
                 {"legacy_saved_quiz_id": saved_quiz.legacy_saved_quiz_id}
@@ -188,6 +225,24 @@ class ReferenceV2Repository:
         )
         return SavedQuizDocumentV2(**updated)
 
+    async def list_saved_quizzes_for_user(self, user_id: str) -> list[SavedQuizDocumentV2]:
+        documents = await self.saved_quizzes_collection.find({"user_id": user_id}).to_list(length=500)
+        return [SavedQuizDocumentV2(**document) for document in documents]
+
+    async def get_saved_quiz_by_legacy_id(
+        self,
+        legacy_saved_quiz_id: str,
+        user_id: Optional[str] = None,
+    ) -> SavedQuizDocumentV2 | None:
+        query: dict[str, str] = {"legacy_saved_quiz_id": legacy_saved_quiz_id}
+        if user_id is not None:
+            query["user_id"] = user_id
+        document = await self.saved_quizzes_collection.find_one(query)
+        return SavedQuizDocumentV2(**document) if document else None
+
+    async def delete_saved_quiz(self, user_id: str, quiz_id: str):
+        await self.saved_quizzes_collection.delete_one({"user_id": user_id, "quiz_id": quiz_id})
+
     async def upsert_quiz_history(self, quiz_history: QuizHistoryDocumentV2) -> QuizHistoryDocumentV2:
         payload = quiz_history.model_dump(by_alias=True)
         payload.pop("_id", None)
@@ -199,3 +254,7 @@ class ReferenceV2Repository:
             return_document=ReturnDocument.AFTER,
         )
         return QuizHistoryDocumentV2(**updated)
+
+    async def list_quiz_history_for_user(self, user_id: str) -> list[QuizHistoryDocumentV2]:
+        documents = await self.quiz_history_collection.find({"user_id": user_id}).to_list(length=500)
+        return [QuizHistoryDocumentV2(**document) for document in documents]

--- a/server/app/db/v2/repositories/reference_repository.py
+++ b/server/app/db/v2/repositories/reference_repository.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from motor.motor_asyncio import AsyncIOMotorCollection
 from pymongo import ReturnDocument
 
@@ -21,6 +23,12 @@ class ReferenceV2Repository:
         self.folder_items_collection = folder_items_collection
         self.saved_quizzes_collection = saved_quizzes_collection
         self.quiz_history_collection = quiz_history_collection
+
+    @staticmethod
+    def _normalize_datetime(value: datetime) -> datetime:
+        if value.tzinfo is not None:
+            return value.astimezone(timezone.utc).replace(tzinfo=None)
+        return value
 
     async def insert_folder(self, folder: FolderDocumentV2) -> FolderDocumentV2:
         payload = folder.model_dump(by_alias=True)
@@ -91,8 +99,46 @@ class ReferenceV2Repository:
         payload = saved_quiz.model_dump(by_alias=True)
         payload.pop("_id", None)
         saved_at = payload.pop("saved_at")
+        legacy_match = None
+        if saved_quiz.legacy_saved_quiz_id:
+            legacy_match = await self.saved_quizzes_collection.find_one(
+                {"legacy_saved_quiz_id": saved_quiz.legacy_saved_quiz_id}
+            )
+        target_match = await self.saved_quizzes_collection.find_one(
+            {"user_id": saved_quiz.user_id, "quiz_id": saved_quiz.quiz_id}
+        )
+
+        if legacy_match and target_match and legacy_match["_id"] != target_match["_id"]:
+            merged_saved_at = min(
+                self._normalize_datetime(saved_at),
+                self._normalize_datetime(legacy_match.get("saved_at", saved_at)),
+                self._normalize_datetime(target_match.get("saved_at", saved_at)),
+            )
+            updated = await self.saved_quizzes_collection.find_one_and_update(
+                {"_id": target_match["_id"]},
+                {
+                    "$set": {
+                        **payload,
+                        "saved_at": merged_saved_at,
+                    }
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+            await self.saved_quizzes_collection.delete_one({"_id": legacy_match["_id"]})
+            return SavedQuizDocumentV2(**updated)
+
+        if legacy_match is not None:
+            filter_query = {"_id": legacy_match["_id"]}
+        elif target_match is not None:
+            filter_query = {"_id": target_match["_id"]}
+        else:
+            filter_query = (
+                {"legacy_saved_quiz_id": saved_quiz.legacy_saved_quiz_id}
+                if saved_quiz.legacy_saved_quiz_id
+                else {"user_id": saved_quiz.user_id, "quiz_id": saved_quiz.quiz_id}
+            )
         updated = await self.saved_quizzes_collection.find_one_and_update(
-            {"user_id": saved_quiz.user_id, "quiz_id": saved_quiz.quiz_id},
+            filter_query,
             {"$set": payload, "$setOnInsert": {"saved_at": saved_at}},
             upsert=True,
             return_document=ReturnDocument.AFTER,

--- a/server/app/db/v2/repositories/reference_repository.py
+++ b/server/app/db/v2/repositories/reference_repository.py
@@ -78,9 +78,52 @@ class ReferenceV2Repository:
     async def upsert_folder_item_by_legacy_id(self, folder_item: FolderItemDocumentV2) -> FolderItemDocumentV2:
         payload = folder_item.model_dump(by_alias=True)
         payload.pop("_id", None)
+        created_at = payload.pop("created_at")
+        legacy_match = None
+        if folder_item.legacy_folder_item_id:
+            legacy_match = await self.folder_items_collection.find_one(
+                {"legacy_folder_item_id": folder_item.legacy_folder_item_id}
+            )
+        target_match = await self.folder_items_collection.find_one(
+            {"folder_id": folder_item.folder_id, "quiz_id": folder_item.quiz_id}
+        )
+
+        if legacy_match and target_match and legacy_match["_id"] != target_match["_id"]:
+            merged_created_at = min(
+                self._normalize_datetime(created_at),
+                self._normalize_datetime(legacy_match.get("created_at", created_at)),
+                self._normalize_datetime(target_match.get("created_at", created_at)),
+            )
+            target_legacy_item_id = target_match.get("legacy_folder_item_id")
+            updated = await self.folder_items_collection.find_one_and_update(
+                {"_id": target_match["_id"]},
+                {
+                    "$set": {
+                        **payload,
+                        "created_at": merged_created_at,
+                        "legacy_folder_item_id": target_legacy_item_id or folder_item.legacy_folder_item_id,
+                    }
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+            await self.folder_items_collection.delete_one({"_id": legacy_match["_id"]})
+            return FolderItemDocumentV2(**updated)
+
+        if legacy_match is not None:
+            filter_query = {"_id": legacy_match["_id"]}
+        elif target_match is not None:
+            filter_query = {"_id": target_match["_id"]}
+            if target_match.get("legacy_folder_item_id"):
+                payload["legacy_folder_item_id"] = target_match["legacy_folder_item_id"]
+        else:
+            filter_query = (
+                {"legacy_folder_item_id": folder_item.legacy_folder_item_id}
+                if folder_item.legacy_folder_item_id
+                else {"folder_id": folder_item.folder_id, "quiz_id": folder_item.quiz_id}
+            )
         updated = await self.folder_items_collection.find_one_and_update(
-            {"legacy_folder_item_id": folder_item.legacy_folder_item_id},
-            {"$set": payload},
+            filter_query,
+            {"$set": payload, "$setOnInsert": {"created_at": created_at}},
             upsert=True,
             return_document=ReturnDocument.AFTER,
         )

--- a/server/app/db/v2/validators.py
+++ b/server/app/db/v2/validators.py
@@ -82,6 +82,7 @@ def get_v2_collection_validators() -> dict[str, dict]:
                     "quiz_id": {"bsonType": "string", "minLength": 1},
                     "added_by": {"bsonType": ["string", "null"]},
                     "position": {"bsonType": ["int", "null"]},
+                    "display_title": {"bsonType": ["string", "null"]},
                     "legacy_folder_item_id": {"bsonType": ["string", "null"]},
                     "created_at": {"bsonType": "date"},
                 },
@@ -94,6 +95,7 @@ def get_v2_collection_validators() -> dict[str, dict]:
                 "properties": {
                     "user_id": {"bsonType": "string", "minLength": 1},
                     "quiz_id": {"bsonType": "string", "minLength": 1},
+                    "display_title": {"bsonType": ["string", "null"]},
                     "legacy_saved_quiz_id": {"bsonType": ["string", "null"]},
                     "saved_at": {"bsonType": "date"},
                 },

--- a/server/app/share/routes/share_routes.py
+++ b/server/app/share/routes/share_routes.py
@@ -13,6 +13,7 @@ from ...db.core.connection import (
     get_saved_quizzes_collection,
 )
 from ...db.crud.quiz_crud import list_quizzes
+from ...db.services.shared_quiz_read_service import SharedQuizReadService
 from ...db.schemas.quiz_schemas import QuizSchema
 from .share_schemas import (
     ShareQuizResponse,
@@ -34,6 +35,7 @@ if not share_url:
 
 
 router = APIRouter()
+shared_quiz_read_service = SharedQuizReadService()
 
 def build_default_description(topic: str) -> str:
     return f"A quiz to test your knowledge on {topic}"
@@ -121,7 +123,7 @@ async def get_share_link(quiz_id: str):
 @router.get("/shared-quiz/{quiz_id}", response_model=SharedQuizDataResponse)
 async def get_shared_quiz_data(quiz_id: str):
     try:
-        shared_quiz = await resolve_shared_quiz(quiz_id)
+        shared_quiz = await shared_quiz_read_service.resolve_shared_quiz(quiz_id)
         if not shared_quiz:
             raise HTTPException(status_code=404, detail="Quiz not found")
         return shared_quiz
@@ -141,7 +143,7 @@ async def share_quiz_via_email(
     email_svc: EmailService = Depends(get_email_service),
 ):
     try:
-        shared_quiz = await resolve_shared_quiz(query.quiz_id)
+        shared_quiz = await shared_quiz_read_service.resolve_shared_quiz(query.quiz_id)
         if not shared_quiz:
             raise HTTPException(status_code=404, detail="Quiz not found")
         
@@ -167,4 +169,3 @@ async def share_quiz_via_email(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to send email. Please try again later."
         )
-

--- a/server/scripts/v2_backfill/__init__.py
+++ b/server/scripts/v2_backfill/__init__.py
@@ -1,0 +1,1 @@
+"""CLI entrypoints for Stage 3 V2 backfill and parity checks."""

--- a/server/scripts/v2_backfill/run_full_v2_backfill.py
+++ b/server/scripts/v2_backfill/run_full_v2_backfill.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+from server.app.db.core.connection import database
+from server.app.db.v2.migration.backfill_engine import (
+    build_migration_context,
+    run_backfill,
+    run_parity_checks,
+)
+from server.app.db.v2.migration.config import BackfillConfig
+from server.app.db.v2.migration.lock import MigrationLockError
+from server.app.db.v2.migration.logging import log_migration_event
+from server.app.db.v2.migration.summary import write_summary_json
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run Stage 3 full V2 backfill plus parity checks")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="Run backfill and parity without writing to V2")
+    mode.add_argument("--commit", action="store_true", help="Run backfill with writes enabled, then parity checks")
+    parser.add_argument("--batch-size", type=int, default=None)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--start-after-id", type=str, default=None)
+    parser.add_argument("--collections", type=str, default=None)
+    parser.add_argument("--run-id", type=str, default=None)
+    return parser.parse_args()
+
+
+def configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+
+
+async def main():
+    configure_logging()
+    args = parse_args()
+    config = BackfillConfig.from_settings(
+        dry_run=False if args.commit else True,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        start_after_id=args.start_after_id,
+        collections=args.collections.split(",") if args.collections else None,
+        run_id=args.run_id,
+    )
+    context = build_migration_context(
+        config=config,
+        database=database,
+        report_dir=Path(__file__).resolve().parents[2] / "tmp",
+    )
+    try:
+        await context.lock_service.acquire_lock(
+            migration_name="stage_3_backfill",
+            run_id=config.run_id,
+            dry_run=config.dry_run,
+            triggered_by="cli",
+            lease_seconds=config.lock_lease_seconds,
+        )
+    except MigrationLockError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    status = "completed"
+    try:
+        log_migration_event(
+            "v2_backfill_started",
+            run_id=config.run_id,
+            dry_run=config.dry_run,
+            batch_size=config.batch_size,
+            limit=config.limit,
+            start_after_id=config.start_after_id,
+            collections=context.config.collections,
+        )
+        backfill_report = await run_backfill(context)
+        parity_report = await run_parity_checks(context)
+        write_summary_json(
+            context.report_dir / f"v2_backfill_summary_{config.run_id}.json",
+            backfill_report.to_dict(),
+        )
+        write_summary_json(
+            context.report_dir / f"v2_parity_summary_{config.run_id}.json",
+            parity_report.to_dict(),
+        )
+        log_migration_event(
+            "v2_backfill_completed",
+            run_id=config.run_id,
+            backfill_summary_path=str(context.report_dir / f"v2_backfill_summary_{config.run_id}.json"),
+            parity_summary_path=str(context.report_dir / f"v2_parity_summary_{config.run_id}.json"),
+        )
+    except Exception as exc:
+        status = "failed"
+        await context.lock_service.release_lock(
+            migration_name="stage_3_backfill",
+            run_id=config.run_id,
+            status=status,
+            error=str(exc),
+        )
+        raise
+    else:
+        await context.lock_service.release_lock(
+            migration_name="stage_3_backfill",
+            run_id=config.run_id,
+            status=status,
+            summary={"backfill": backfill_report.to_dict(), "parity": parity_report.to_dict()},
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/scripts/v2_backfill/run_v2_backfill.py
+++ b/server/scripts/v2_backfill/run_v2_backfill.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+from server.app.db.core.connection import database
+from server.app.db.v2.migration.backfill_engine import build_migration_context, run_backfill
+from server.app.db.v2.migration.config import BackfillConfig
+from server.app.db.v2.migration.lock import MigrationLockError
+from server.app.db.v2.migration.logging import log_migration_event
+from server.app.db.v2.migration.summary import write_summary_json
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run Stage 3 V2 backfill")
+    parser.add_argument("--dry-run", action="store_true", help="Run without writing to V2 collections")
+    parser.add_argument("--batch-size", type=int, default=None)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--start-after-id", type=str, default=None)
+    parser.add_argument("--collections", type=str, default=None)
+    parser.add_argument("--run-id", type=str, default=None)
+    return parser.parse_args()
+
+
+def configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+
+
+async def main():
+    configure_logging()
+    args = parse_args()
+    config = BackfillConfig.from_settings(
+        dry_run=args.dry_run if args.dry_run else None,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        start_after_id=args.start_after_id,
+        collections=args.collections.split(",") if args.collections else None,
+        run_id=args.run_id,
+    )
+    context = build_migration_context(
+        config=config,
+        database=database,
+        report_dir=Path(__file__).resolve().parents[2] / "tmp",
+    )
+    try:
+        await context.lock_service.acquire_lock(
+            migration_name="stage_3_backfill",
+            run_id=config.run_id,
+            dry_run=config.dry_run,
+            triggered_by="cli",
+            lease_seconds=config.lock_lease_seconds,
+        )
+    except MigrationLockError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    status = "completed"
+    report = None
+    try:
+        log_migration_event(
+            "v2_backfill_started",
+            run_id=config.run_id,
+            dry_run=config.dry_run,
+            batch_size=config.batch_size,
+            limit=config.limit,
+            start_after_id=config.start_after_id,
+            collections=context.config.collections,
+        )
+        report = await run_backfill(context)
+        summary_path = context.report_dir / f"v2_backfill_summary_{config.run_id}.json"
+        write_summary_json(summary_path, report.to_dict())
+        log_migration_event(
+            "v2_backfill_completed",
+            run_id=config.run_id,
+            summary_path=str(summary_path),
+            collections=context.config.collections,
+        )
+    except Exception as exc:
+        status = "failed"
+        await context.lock_service.release_lock(
+            migration_name="stage_3_backfill",
+            run_id=config.run_id,
+            status=status,
+            error=str(exc),
+        )
+        raise
+    else:
+        await context.lock_service.release_lock(
+            migration_name="stage_3_backfill",
+            run_id=config.run_id,
+            status=status,
+            summary=report.to_dict() if report else None,
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/scripts/v2_backfill/run_v2_parity_checks.py
+++ b/server/scripts/v2_backfill/run_v2_parity_checks.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+from server.app.db.core.connection import database
+from server.app.db.v2.migration.backfill_engine import build_migration_context, run_parity_checks
+from server.app.db.v2.migration.config import BackfillConfig
+from server.app.db.v2.migration.logging import log_migration_event
+from server.app.db.v2.migration.summary import write_summary_json
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run Stage 3 V2 parity checks")
+    parser.add_argument("--run-id", type=str, default=None)
+    return parser.parse_args()
+
+
+def configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+
+
+async def main():
+    configure_logging()
+    args = parse_args()
+    config = BackfillConfig.from_settings(run_id=args.run_id)
+    context = build_migration_context(
+        config=config,
+        database=database,
+        report_dir=Path(__file__).resolve().parents[2] / "tmp",
+    )
+    log_migration_event("v2_parity_check_started", run_id=config.run_id)
+    report = await run_parity_checks(context)
+    summary_path = context.report_dir / f"v2_parity_summary_{config.run_id}.json"
+    write_summary_json(summary_path, report.to_dict())
+    log_migration_event(
+        "v2_parity_check_completed",
+        run_id=config.run_id,
+        summary_path=str(summary_path),
+    )
+    print(summary_path)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/tests/v2_database_tests/backfill_tests/__init__.py
+++ b/server/tests/v2_database_tests/backfill_tests/__init__.py
@@ -1,0 +1,1 @@
+"""Stage 3 backfill tests."""

--- a/server/tests/v2_database_tests/backfill_tests/conftest.py
+++ b/server/tests/v2_database_tests/backfill_tests/conftest.py
@@ -1,0 +1,49 @@
+import os
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+os.environ.setdefault("email_sender", "test@example.com")
+os.environ.setdefault("email_password", "password")
+os.environ.setdefault("email_host", "localhost")
+os.environ.setdefault("email_port", "1025")
+os.environ.setdefault("share_url", "http://localhost")
+os.environ.setdefault("db_name", "test_db")
+os.environ.setdefault("mongo_url", "mongodb://localhost:27017")
+
+from ....app.db.v2.migration.backfill_engine import build_migration_context
+from ....app.db.v2.migration.config import BackfillConfig
+from ....app.db.v2.setup import ensure_v2_collections_and_validators, ensure_v2_indexes
+
+
+@pytest_asyncio.fixture(scope="function")
+async def backfill_db(test_db):
+    await ensure_v2_collections_and_validators(test_db)
+    await ensure_v2_indexes(
+        test_db["quizzes_v2"],
+        test_db["folders_v2"],
+        test_db["folder_items_v2"],
+        test_db["saved_quizzes_v2"],
+        test_db["quiz_history_v2"],
+    )
+    return test_db
+
+
+@pytest.fixture(scope="function")
+def backfill_context_factory(backfill_db, tmp_path):
+    def factory(*, dry_run=False, collections=None, run_id="stage3-test"):
+        config = BackfillConfig.from_settings(
+            dry_run=dry_run,
+            collections=collections or ["quizzes", "saved", "history", "folders"],
+            run_id=run_id,
+            batch_size=50,
+        )
+        return build_migration_context(
+            config=config,
+            database=backfill_db,
+            report_dir=Path(tmp_path),
+        )
+
+    return factory

--- a/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
+++ b/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
@@ -1,0 +1,306 @@
+import pytest
+from bson import ObjectId
+
+from ....app.db.v2.migration.backfill_engine import (
+    backfill_folders,
+    backfill_quiz_history,
+    backfill_quizzes,
+    backfill_saved_quizzes,
+    run_backfill,
+    run_parity_checks,
+)
+
+
+@pytest.mark.asyncio
+async def test_stage3_backfill_reuses_ai_origin_for_saved_history_and_folder(
+    backfill_db,
+    backfill_context_factory,
+):
+    ai_id = ObjectId()
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Geography",
+            "question_type": "multichoice",
+            "difficulty_level": "easy",
+            "audience_type": "students",
+            "questions": [
+                {
+                    "question": "Capital of Kenya?",
+                    "options": ["Nairobi", "Mombasa"],
+                    "answer": "Nairobi",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    saved_id = ObjectId()
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-1",
+            "quiz_id": str(ai_id),
+            "title": "Geography",
+            "question_type": "multichoice",
+            "questions": [
+                {"question": "Capital of Kenya?", "options": ["Nairobi", "Mombasa"], "question_type": "multichoice"}
+            ],
+        }
+    )
+    history_id = ObjectId()
+    await backfill_db["quiz_history"].insert_one(
+        {
+            "_id": history_id,
+            "user_id": "user-1",
+            "quiz_id": str(ai_id),
+            "profession": "Geography",
+            "question_type": "multichoice",
+            "difficulty_level": "easy",
+            "audience_type": "students",
+            "questions": [
+                {
+                    "question": "Capital of Kenya?",
+                    "options": ["Nairobi", "Mombasa"],
+                    "answer": "Nairobi",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    folder_id = ObjectId()
+    await backfill_db["folders"].insert_one(
+        {
+            "_id": folder_id,
+            "user_id": "user-1",
+            "name": "Trips",
+            "quizzes": [
+                {
+                    "_id": "folder-item-1",
+                    "original_quiz_id": str(saved_id),
+                    "quiz_id": str(ai_id),
+                    "questions": [
+                        {"question": "Capital of Kenya?", "options": ["Nairobi", "Mombasa"], "question_type": "multichoice"}
+                    ],
+                    "question_type": "multichoice",
+                    "title": "Geography",
+                }
+            ],
+        }
+    )
+    context = backfill_context_factory()
+    await backfill_quizzes(context)
+    await backfill_saved_quizzes(context)
+    await backfill_quiz_history(context)
+    await backfill_folders(context)
+
+    canonical = await backfill_db["quizzes_v2"].find_one(
+        {"legacy_source_collection": "ai_generated_quizzes", "legacy_quiz_id": str(ai_id)}
+    )
+    saved_v2 = await backfill_db["saved_quizzes_v2"].find_one({"user_id": "user-1"})
+    history_v2 = await backfill_db["quiz_history_v2"].find_one({"legacy_history_id": str(history_id)})
+    folder_item_v2 = await backfill_db["folder_items_v2"].find_one({"legacy_folder_item_id": "folder-item-1"})
+
+    assert canonical is not None
+    assert saved_v2["quiz_id"] == str(canonical["_id"])
+    assert history_v2["quiz_id"] == str(canonical["_id"])
+    assert history_v2["metadata"]["source"] == "ai"
+    assert history_v2["metadata"]["topic"] == "Geography"
+    assert folder_item_v2["quiz_id"] == str(canonical["_id"])
+
+
+@pytest.mark.asyncio
+async def test_stage3_backfill_is_idempotent(backfill_db, backfill_context_factory):
+    ai_id = ObjectId()
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Networks",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is DNS?",
+                    "options": ["Name system", "Firewall"],
+                    "answer": "Name system",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    context = backfill_context_factory(collections=["quizzes"], run_id="idem-1")
+    await backfill_quizzes(context)
+    await backfill_quizzes(context)
+    assert await backfill_db["quizzes_v2"].count_documents({}) == 1
+
+
+@pytest.mark.asyncio
+async def test_stage3_history_rerun_counts_noop_records_as_skipped(backfill_db, backfill_context_factory):
+    ai_id = ObjectId()
+    history_id = ObjectId()
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Systems Design",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is caching?",
+                    "options": ["Storage", "Queue"],
+                    "answer": "Storage",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    await backfill_db["quiz_history"].insert_one(
+        {
+            "_id": history_id,
+            "user_id": "user-1",
+            "quiz_id": str(ai_id),
+            "profession": "Systems Design",
+            "question_type": "multichoice",
+            "difficulty_level": "easy",
+            "audience_type": "students",
+            "questions": [
+                {
+                    "question": "What is caching?",
+                    "options": ["Storage", "Queue"],
+                    "answer": "Storage",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["quizzes", "history"], run_id="history-rerun")
+    await backfill_quizzes(context)
+    first_summary = await backfill_quiz_history(context)
+    second_summary = await backfill_quiz_history(context)
+
+    assert first_summary.inserted == 1
+    assert second_summary.inserted == 0
+    assert second_summary.updated == 0
+    assert second_summary.skipped == 1
+
+
+@pytest.mark.asyncio
+async def test_stage3_backfill_dry_run_does_not_write(backfill_db, backfill_context_factory):
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ObjectId(),
+            "profession": "History",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "Who built the pyramids?",
+                    "options": ["Egyptians", "Romans"],
+                    "answer": "Egyptians",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    context = backfill_context_factory(dry_run=True, collections=["quizzes"], run_id="dry-run")
+    summary = await backfill_quizzes(context)
+    assert summary.inserted == 1
+    assert await backfill_db["quizzes_v2"].count_documents({}) == 0
+
+
+@pytest.mark.asyncio
+async def test_stage3_parity_reports_orphaned_references(backfill_db, backfill_context_factory):
+    await backfill_db["saved_quizzes_v2"].insert_one(
+        {"user_id": "user-1", "quiz_id": "missing-quiz", "saved_at": __import__("datetime").datetime.utcnow()}
+    )
+    context = backfill_context_factory(run_id="parity-1")
+    report = await run_parity_checks(context)
+    assert report.sections["saved"]["orphaned_quiz_refs"] == 1
+
+
+@pytest.mark.asyncio
+async def test_stage3_run_backfill_returns_collection_reports(backfill_db, backfill_context_factory):
+    ai_id = ObjectId()
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Biology",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is DNA?",
+                    "options": ["Acid", "Cell"],
+                    "answer": "Acid",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    context = backfill_context_factory(collections=["quizzes"], run_id="full-run")
+    report = await run_backfill(context)
+    assert "quizzes" in report.collections
+    assert report.collections["quizzes"].inserted == 1
+
+
+@pytest.mark.asyncio
+async def test_stage3_folder_backfill_with_structure_only_payload_does_not_crash(
+    backfill_db,
+    backfill_context_factory,
+):
+    ai_id = ObjectId()
+    saved_id = ObjectId()
+    folder_id = ObjectId()
+
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Geography",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "Capital of Kenya?",
+                    "options": ["Nairobi", "Mombasa"],
+                    "answer": "Nairobi",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-1",
+            "title": "Geography",
+            "question_type": "multichoice",
+            "questions": [
+                {"question": "Capital of Kenya?", "options": ["Nairobi", "Mombasa"], "question_type": "multichoice"}
+            ],
+        }
+    )
+    await backfill_db["folders"].insert_one(
+        {
+            "_id": folder_id,
+            "user_id": "user-1",
+            "name": "Trips",
+            "quizzes": [
+                {
+                    "_id": "folder-item-1",
+                    "original_quiz_id": str(saved_id),
+                    "questions": [
+                        {
+                            "question": "Capital of Kenya?",
+                            "options": ["Nairobi", "Mombasa"],
+                            "question_type": "multichoice",
+                        }
+                    ],
+                    "question_type": "multichoice",
+                    "title": "Geography",
+                }
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["quizzes", "folders"], run_id="folder-structure-only")
+    await backfill_quizzes(context)
+    summary = await backfill_folders(context)
+
+    assert summary.malformed == 0
+    assert summary.unresolved == 0
+    assert summary.inserted == 2

--- a/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
+++ b/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
@@ -304,3 +304,122 @@ async def test_stage3_folder_backfill_with_structure_only_payload_does_not_crash
     assert summary.malformed == 0
     assert summary.unresolved == 0
     assert summary.inserted == 2
+
+
+@pytest.mark.asyncio
+async def test_stage3_backfill_saved_quiz_without_answers_matches_legacy_ai_source(
+    backfill_db,
+    backfill_context_factory,
+):
+    ai_id = ObjectId()
+    saved_id = ObjectId()
+
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Entropy",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is entropy a measure of in a system?",
+                    "options": ["Energy", "Disorder", "Temperature", "Volume"],
+                    "answer": "Disorder",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-entropy",
+            "title": "Entropy Quiz",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is entropy a measure of in a system?",
+                    "options": ["Energy", "Disorder", "Temperature", "Volume"],
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["saved"], run_id="saved-legacy-structure")
+    summary = await backfill_saved_quizzes(context)
+
+    assert summary.unresolved == 0
+    assert summary.conflicts == 0
+    assert summary.inserted == 1
+
+    saved_v2 = await backfill_db["saved_quizzes_v2"].find_one({"legacy_saved_quiz_id": str(saved_id)})
+    canonical = await backfill_db["quizzes_v2"].find_one(
+        {"legacy_source_collection": "ai_generated_quizzes", "legacy_quiz_id": str(ai_id)}
+    )
+
+    assert saved_v2 is not None
+    assert canonical is not None
+    assert saved_v2["quiz_id"] == str(canonical["_id"])
+
+
+@pytest.mark.asyncio
+async def test_stage3_backfill_saved_quiz_reports_conflict_for_multiple_legacy_matches(
+    backfill_db,
+    backfill_context_factory,
+):
+    await backfill_db["ai_generated_quizzes"].insert_many(
+        [
+            {
+                "_id": ObjectId(),
+                "profession": "Entropy",
+                "question_type": "multichoice",
+                "questions": [
+                    {
+                        "question": "What is entropy?",
+                        "options": ["Order", "Disorder"],
+                        "answer": "Disorder",
+                        "question_type": "multichoice",
+                    }
+                ],
+            },
+            {
+                "_id": ObjectId(),
+                "profession": "Entropy",
+                "question_type": "multichoice",
+                "questions": [
+                    {
+                        "question": "What is entropy?",
+                        "options": ["Order", "Disorder"],
+                        "answer": "Disorder",
+                        "question_type": "multichoice",
+                    }
+                ],
+            },
+        ]
+    )
+    saved_id = ObjectId()
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-entropy",
+            "title": "Entropy Quiz",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is entropy?",
+                    "options": ["Order", "Disorder"],
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["saved"], run_id="saved-conflict")
+    summary = await backfill_saved_quizzes(context)
+
+    assert summary.inserted == 0
+    assert summary.conflicts == 1
+    assert summary.unresolved == 0
+    assert summary.conflict_examples[0]["record_id"] == str(saved_id)
+    assert len(summary.conflict_examples[0]["candidate_ids"]) == 2
+    assert await backfill_db["saved_quizzes_v2"].count_documents({}) == 0

--- a/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
+++ b/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
@@ -103,10 +103,13 @@ async def test_stage3_backfill_reuses_ai_origin_for_saved_history_and_folder(
 
     assert canonical is not None
     assert saved_v2["quiz_id"] == str(canonical["_id"])
+    assert saved_v2["display_title"] == "Geography"
     assert history_v2["quiz_id"] == str(canonical["_id"])
     assert history_v2["metadata"]["source"] == "ai"
     assert history_v2["metadata"]["topic"] == "Geography"
     assert folder_item_v2["quiz_id"] == str(canonical["_id"])
+    assert folder_item_v2["display_title"] == "Geography"
+    assert folder_item_v2["position"] == 0
 
 
 @pytest.mark.asyncio
@@ -377,6 +380,7 @@ async def test_stage3_folder_backfill_merges_duplicate_items_for_same_canonical_
     assert summary.conflicts == 0
     assert len(folder_items) == 1
     assert folder_items[0]["legacy_folder_item_id"] == "folder-item-1"
+    assert folder_items[0]["position"] == 0
 
 
 @pytest.mark.asyncio

--- a/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
+++ b/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
@@ -1,5 +1,6 @@
 import pytest
 from bson import ObjectId
+from datetime import datetime
 
 from ....app.db.v2.migration.backfill_engine import (
     backfill_folders,
@@ -423,3 +424,319 @@ async def test_stage3_backfill_saved_quiz_reports_conflict_for_multiple_legacy_m
     assert summary.conflict_examples[0]["record_id"] == str(saved_id)
     assert len(summary.conflict_examples[0]["candidate_ids"]) == 2
     assert await backfill_db["saved_quizzes_v2"].count_documents({}) == 0
+
+
+@pytest.mark.asyncio
+async def test_stage3_backfill_saved_quiz_reuses_existing_v2_question_only_match(
+    backfill_db,
+    backfill_context_factory,
+):
+    existing_quiz_id = ObjectId()
+    saved_id = ObjectId()
+    await backfill_db["quizzes_v2"].insert_one(
+        {
+            "_id": existing_quiz_id,
+            "title": "multichoice Quiz",
+            "quiz_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "correct_answer": "B) Moscow",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                },
+                {
+                    "question": "Russia is the largest country in the world by what measure?",
+                    "correct_answer": "B) Land area",
+                    "options": ["A) Population", "B) Land area", "C) Military size", "D) Number of cities"],
+                },
+            ],
+            "description": "Geopolitical power",
+            "owner_user_id": None,
+            "visibility": "private",
+            "status": "active",
+            "source": "legacy",
+            "tags": [],
+            "legacy_source_collection": None,
+            "legacy_quiz_id": None,
+            "content_fingerprint": "test-content",
+            "structure_fingerprint": "test-structure",
+            "schema_version": 1,
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow(),
+        }
+    )
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-russia",
+            "title": "Russia",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "question_type": "multichoice",
+                },
+                {
+                    "question": "Russia is the largest country in the world by what measure?",
+                    "options": ["A) Population", "B) Land area", "C) Military size", "D) Number of cities"],
+                    "question_type": "multichoice",
+                },
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["saved"], run_id="saved-v2-question-only")
+    summary = await backfill_saved_quizzes(context)
+    saved_v2 = await backfill_db["saved_quizzes_v2"].find_one({"legacy_saved_quiz_id": str(saved_id)})
+
+    assert summary.unresolved == 0
+    assert summary.conflicts == 0
+    assert summary.inserted == 1
+    assert saved_v2 is not None
+    assert saved_v2["quiz_id"] == str(existing_quiz_id)
+
+
+@pytest.mark.asyncio
+async def test_stage3_history_prefers_profession_over_generic_quiz_name_when_creating_canonical(
+    backfill_db,
+    backfill_context_factory,
+):
+    history_id = ObjectId()
+    await backfill_db["quiz_history"].insert_one(
+        {
+            "_id": history_id,
+            "user_id": "user-russia",
+            "quiz_name": "multichoice Quiz",
+            "profession": "Russia",
+            "question_type": "multichoice",
+            "difficulty_level": "easy",
+            "audience_type": "students",
+            "custom_instruction": "Geopolitical power",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "answer": "B) Moscow",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["history"], run_id="history-generic-title")
+    summary = await backfill_quiz_history(context)
+    history_v2 = await backfill_db["quiz_history_v2"].find_one({"legacy_history_id": str(history_id)})
+    canonical = await backfill_db["quizzes_v2"].find_one({"_id": ObjectId(history_v2["quiz_id"])})
+
+    assert summary.inserted == 1
+    assert history_v2 is not None
+    assert canonical["title"] == "Russia"
+
+
+@pytest.mark.asyncio
+async def test_stage3_saved_backfill_updates_existing_legacy_reference_in_place_when_canonical_changes(
+    backfill_db,
+    backfill_context_factory,
+):
+    old_quiz_id = ObjectId()
+    new_quiz_id = ObjectId()
+    saved_id = ObjectId()
+    now = datetime.utcnow()
+
+    await backfill_db["quizzes_v2"].insert_many(
+        [
+            {
+                "_id": old_quiz_id,
+                "title": "multichoice Quiz",
+                "quiz_type": "multichoice",
+                "questions": [
+                    {
+                        "question": "What is the capital of Russia?",
+                        "correct_answer": "B) Moscow",
+                        "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    }
+                ],
+                "description": "Geopolitical power",
+                "owner_user_id": None,
+                "visibility": "private",
+                "status": "active",
+                "source": "legacy",
+                "tags": [],
+                "legacy_source_collection": None,
+                "legacy_quiz_id": None,
+                "content_fingerprint": "old-content",
+                "structure_fingerprint": "old-structure",
+                "schema_version": 1,
+                "created_at": now,
+                "updated_at": now,
+            },
+            {
+                "_id": new_quiz_id,
+                "title": "Russia",
+                "quiz_type": "multichoice",
+                "questions": [
+                    {
+                        "question": "What is the capital of Russia?",
+                        "correct_answer": "B) Moscow",
+                        "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    }
+                ],
+                "description": "Geopolitical power",
+                "owner_user_id": None,
+                "visibility": "private",
+                "status": "active",
+                "source": "legacy",
+                "tags": [],
+                "legacy_source_collection": None,
+                "legacy_quiz_id": None,
+                "content_fingerprint": "new-content",
+                "structure_fingerprint": "new-structure",
+                "schema_version": 1,
+                "created_at": now,
+                "updated_at": now,
+            },
+        ]
+    )
+
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-russia",
+            "title": "Russia",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    await backfill_db["saved_quizzes_v2"].insert_one(
+        {
+            "_id": ObjectId(),
+            "user_id": "user-russia",
+            "quiz_id": str(old_quiz_id),
+            "legacy_saved_quiz_id": str(saved_id),
+            "saved_at": now,
+        }
+    )
+
+    context = backfill_context_factory(collections=["saved"], run_id="saved-legacy-id-upsert")
+    summary = await backfill_saved_quizzes(context)
+    rows = await backfill_db["saved_quizzes_v2"].find({"legacy_saved_quiz_id": str(saved_id)}).to_list(length=10)
+
+    assert summary.inserted == 0
+    assert summary.updated == 1
+    assert len(rows) == 1
+    assert rows[0]["quiz_id"] == str(new_quiz_id)
+
+
+@pytest.mark.asyncio
+async def test_stage3_saved_backfill_merges_existing_duplicate_saved_rows(
+    backfill_db,
+    backfill_context_factory,
+):
+    old_quiz_id = ObjectId()
+    new_quiz_id = ObjectId()
+    saved_id = ObjectId()
+    now = datetime.utcnow()
+
+    await backfill_db["quizzes_v2"].insert_many(
+        [
+            {
+                "_id": old_quiz_id,
+                "title": "multichoice Quiz",
+                "quiz_type": "multichoice",
+                "questions": [
+                    {
+                        "question": "What is the capital of Russia?",
+                        "correct_answer": "B) Moscow",
+                        "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    }
+                ],
+                "description": "Geopolitical power",
+                "owner_user_id": None,
+                "visibility": "private",
+                "status": "active",
+                "source": "legacy",
+                "tags": [],
+                "legacy_source_collection": None,
+                "legacy_quiz_id": None,
+                "content_fingerprint": "merge-old-content",
+                "structure_fingerprint": "merge-old-structure",
+                "schema_version": 1,
+                "created_at": now,
+                "updated_at": now,
+            },
+            {
+                "_id": new_quiz_id,
+                "title": "Russia",
+                "quiz_type": "multichoice",
+                "questions": [
+                    {
+                        "question": "What is the capital of Russia?",
+                        "correct_answer": "B) Moscow",
+                        "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    }
+                ],
+                "description": "Geopolitical power",
+                "owner_user_id": None,
+                "visibility": "private",
+                "status": "active",
+                "source": "legacy",
+                "tags": [],
+                "legacy_source_collection": None,
+                "legacy_quiz_id": None,
+                "content_fingerprint": "merge-new-content",
+                "structure_fingerprint": "merge-new-structure",
+                "schema_version": 1,
+                "created_at": now,
+                "updated_at": now,
+            },
+        ]
+    )
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-russia",
+            "title": "Russia",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    await backfill_db["saved_quizzes_v2"].insert_many(
+        [
+            {
+                "_id": ObjectId(),
+                "user_id": "user-russia",
+                "quiz_id": str(old_quiz_id),
+                "legacy_saved_quiz_id": str(saved_id),
+                "saved_at": now,
+            },
+            {
+                "_id": ObjectId(),
+                "user_id": "user-russia",
+                "quiz_id": str(new_quiz_id),
+                "legacy_saved_quiz_id": str(saved_id),
+                "saved_at": now,
+            },
+        ]
+    )
+
+    context = backfill_context_factory(collections=["saved"], run_id="saved-merge-duplicates")
+    summary = await backfill_saved_quizzes(context)
+    rows = await backfill_db["saved_quizzes_v2"].find({"legacy_saved_quiz_id": str(saved_id)}).to_list(length=10)
+
+    assert summary.inserted == 0
+    assert summary.updated == 1
+    assert len(rows) == 1
+    assert rows[0]["quiz_id"] == str(new_quiz_id)

--- a/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
+++ b/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
@@ -308,6 +308,78 @@ async def test_stage3_folder_backfill_with_structure_only_payload_does_not_crash
 
 
 @pytest.mark.asyncio
+async def test_stage3_folder_backfill_merges_duplicate_items_for_same_canonical_quiz(
+    backfill_db,
+    backfill_context_factory,
+):
+    ai_id = ObjectId()
+    folder_id = ObjectId()
+
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Geography",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "answer": "B) Moscow",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    await backfill_db["folders"].insert_one(
+        {
+            "_id": folder_id,
+            "user_id": "user-russia",
+            "name": "Geopolitics",
+            "quizzes": [
+                {
+                    "_id": "folder-item-1",
+                    "quiz_id": str(ai_id),
+                    "title": "Russia",
+                    "question_type": "multichoice",
+                    "questions": [
+                        {
+                            "question": "What is the capital of Russia?",
+                            "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                            "question_type": "multichoice",
+                        }
+                    ],
+                },
+                {
+                    "_id": "folder-item-2",
+                    "quiz_id": str(ai_id),
+                    "title": "Russia duplicate",
+                    "question_type": "multichoice",
+                    "questions": [
+                        {
+                            "question": "What is the capital of Russia?",
+                            "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                            "question_type": "multichoice",
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["quizzes", "folders"], run_id="folder-duplicate-items")
+    await backfill_quizzes(context)
+    summary = await backfill_folders(context)
+    folder_v2 = await backfill_db["folders_v2"].find_one({"legacy_folder_id": str(folder_id)})
+    folder_items = await backfill_db["folder_items_v2"].find({"folder_id": str(folder_v2["_id"])}).to_list(length=10)
+
+    assert summary.malformed == 0
+    assert summary.unresolved == 0
+    assert summary.conflicts == 0
+    assert len(folder_items) == 1
+    assert folder_items[0]["legacy_folder_item_id"] == "folder-item-1"
+
+
+@pytest.mark.asyncio
 async def test_stage3_backfill_saved_quiz_without_answers_matches_legacy_ai_source(
     backfill_db,
     backfill_context_factory,

--- a/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
+++ b/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
@@ -314,6 +314,76 @@ async def test_dual_writes_migration_folder_create_and_add_dual_write(
 
 
 @pytest.mark.asyncio
+async def test_dual_writes_migration_folder_add_merges_duplicate_items_for_same_quiz(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(saved_quiz_crud, "collection", dual_write_db["saved_quizzes"])
+    monkeypatch.setattr(saved_quiz_crud, "dual_write_service", service)
+    monkeypatch.setattr(folder_crud, "folders_collection", dual_write_db["folders"])
+    monkeypatch.setattr(folder_crud, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "dual_write")
+
+    await service.mirror_ai_generated_quiz(
+        "legacy-ai-quiz-dup-folder",
+        {
+            "_id": "legacy-ai-quiz-dup-folder",
+            "user_id": "user-folder",
+            "profession": "Russia",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "answer": "B) Moscow",
+                    "question_type": "multichoice",
+                }
+            ],
+        },
+    )
+
+    legacy_saved_id = await saved_quiz_crud.save_quiz(
+        user_id="user-folder",
+        title="Russia",
+        question_type="multichoice",
+        quiz_id="legacy-ai-quiz-dup-folder",
+        questions=[
+            {
+                "question": "What is the capital of Russia?",
+                "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                "question_type": "multichoice",
+            }
+        ],
+    )
+    saved_doc = await dual_write_db["saved_quizzes"].find_one({"_id": ObjectId(legacy_saved_id)})
+    folder = await folder_crud.create_folder({"user_id": "user-folder", "name": "Geopolitics"})
+
+    item_payload = {
+        "original_quiz_id": legacy_saved_id,
+        "quiz_id": saved_doc["quiz_id"],
+        "canonical_quiz_id": saved_doc["canonical_quiz_id"],
+        "title": saved_doc["title"],
+        "question_type": saved_doc["question_type"],
+        "questions": saved_doc["questions"],
+        "created_at": saved_doc["created_at"],
+        "quiz_data": saved_doc,
+    }
+
+    await folder_crud.add_quiz_to_folder(folder["_id"], {"_id": "legacy-folder-item-1", **item_payload})
+    await folder_crud.add_quiz_to_folder(folder["_id"], {"_id": "legacy-folder-item-2", **item_payload})
+
+    folder_v2 = await dual_write_db["folders_v2"].find_one({"legacy_folder_id": folder["_id"]})
+    folder_items = await dual_write_db["folder_items_v2"].find({"folder_id": str(folder_v2["_id"])}).to_list(length=10)
+
+    assert folder_v2 is not None
+    assert len(folder_items) == 1
+    assert folder_items[0]["legacy_folder_item_id"] == "legacy-folder-item-1"
+    assert folder_items[0]["quiz_id"] == saved_doc["canonical_quiz_id"]
+
+
+@pytest.mark.asyncio
 async def test_dual_writes_migration_saved_quiz_without_quiz_id_reuses_legacy_ai_source(
     dual_write_db,
     dual_write_service_factory,

--- a/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
+++ b/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
@@ -1,5 +1,6 @@
 import pytest
 from bson import ObjectId
+from datetime import datetime
 
 from ....app.db.core.config import settings
 from ....app.db.crud import folder_crud, quiz_crud, saved_quiz_crud, update_quiz_history
@@ -365,3 +366,113 @@ async def test_dual_writes_migration_saved_quiz_without_quiz_id_reuses_legacy_ai
     assert canonical is not None
     assert legacy_doc["canonical_quiz_id"] == str(canonical["_id"])
     assert saved_reference["quiz_id"] == str(canonical["_id"])
+
+
+@pytest.mark.asyncio
+async def test_dual_writes_migration_saved_quiz_without_quiz_id_reuses_existing_v2_question_match(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(saved_quiz_crud, "collection", dual_write_db["saved_quizzes"])
+    monkeypatch.setattr(saved_quiz_crud, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "dual_write")
+
+    existing_quiz_id = ObjectId()
+    await dual_write_db["quizzes_v2"].insert_one(
+        {
+            "_id": existing_quiz_id,
+            "title": "multichoice Quiz",
+            "quiz_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "correct_answer": "B) Moscow",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                },
+                {
+                    "question": "Russia is the largest country in the world by what measure?",
+                    "correct_answer": "B) Land area",
+                    "options": ["A) Population", "B) Land area", "C) Military size", "D) Number of cities"],
+                },
+            ],
+            "description": "Geopolitical power",
+            "owner_user_id": None,
+            "visibility": "private",
+            "status": "active",
+            "source": "legacy",
+            "tags": [],
+            "legacy_source_collection": None,
+            "legacy_quiz_id": None,
+            "content_fingerprint": "dual-write-content",
+            "structure_fingerprint": "dual-write-structure",
+            "schema_version": 1,
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow(),
+        }
+    )
+
+    legacy_id = await saved_quiz_crud.save_quiz(
+        user_id="user-russia",
+        title="Russia",
+        question_type="multichoice",
+        questions=[
+            {
+                "question": "What is the capital of Russia?",
+                "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                "question_type": "multichoice",
+            },
+            {
+                "question": "Russia is the largest country in the world by what measure?",
+                "options": ["A) Population", "B) Land area", "C) Military size", "D) Number of cities"],
+                "question_type": "multichoice",
+            },
+        ],
+    )
+
+    legacy_doc = await dual_write_db["saved_quizzes"].find_one({"_id": ObjectId(legacy_id)})
+    saved_reference = await dual_write_db["saved_quizzes_v2"].find_one({"legacy_saved_quiz_id": legacy_id})
+
+    assert legacy_doc is not None
+    assert saved_reference is not None
+    assert legacy_doc["canonical_quiz_id"] == str(existing_quiz_id)
+    assert saved_reference["quiz_id"] == str(existing_quiz_id)
+
+
+@pytest.mark.asyncio
+async def test_dual_writes_migration_history_prefers_profession_over_generic_quiz_name(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(update_quiz_history, "quiz_history_collection", dual_write_db["quiz_history"])
+    monkeypatch.setattr(update_quiz_history, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "dual_write")
+
+    legacy_id = await update_quiz_history.update_quiz_history(
+        {
+            "user_id": "user-russia",
+            "quiz_name": "multichoice Quiz",
+            "question_type": "multichoice",
+            "profession": "Russia",
+            "audience_type": "students",
+            "difficulty_level": "easy",
+            "custom_instruction": "Geopolitical power",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "answer": "B) Moscow",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    history_reference = await dual_write_db["quiz_history_v2"].find_one({"legacy_history_id": legacy_id})
+    canonical = await dual_write_db["quizzes_v2"].find_one({"_id": ObjectId(history_reference["quiz_id"])})
+
+    assert history_reference is not None
+    assert canonical["title"] == "Russia"

--- a/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
+++ b/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
@@ -310,3 +310,58 @@ async def test_dual_writes_migration_folder_create_and_add_dual_write(
     assert folder_item_v2 is not None
     assert folder_item_v2["quiz_id"] == str(canonical_quiz["_id"])
     assert folder_item_v2["quiz_id"] == saved_doc["canonical_quiz_id"]
+
+
+@pytest.mark.asyncio
+async def test_dual_writes_migration_saved_quiz_without_quiz_id_reuses_legacy_ai_source(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(saved_quiz_crud, "collection", dual_write_db["saved_quizzes"])
+    monkeypatch.setattr(saved_quiz_crud, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "dual_write")
+
+    ai_id = ObjectId()
+    await dual_write_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "user_id": "user-entropy",
+            "profession": "Entropy",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is entropy?",
+                    "options": ["Order", "Disorder"],
+                    "answer": "Disorder",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    legacy_id = await saved_quiz_crud.save_quiz(
+        user_id="user-entropy",
+        title="Entropy Quiz",
+        question_type="multichoice",
+        questions=[
+            {
+                "question": "What is entropy?",
+                "options": ["Order", "Disorder"],
+                "question_type": "multichoice",
+            }
+        ],
+    )
+
+    legacy_doc = await dual_write_db["saved_quizzes"].find_one({"_id": ObjectId(legacy_id)})
+    saved_reference = await dual_write_db["saved_quizzes_v2"].find_one({"legacy_saved_quiz_id": legacy_id})
+    canonical = await dual_write_db["quizzes_v2"].find_one(
+        {"legacy_source_collection": "ai_generated_quizzes", "legacy_quiz_id": str(ai_id)}
+    )
+
+    assert legacy_doc is not None
+    assert saved_reference is not None
+    assert canonical is not None
+    assert legacy_doc["canonical_quiz_id"] == str(canonical["_id"])
+    assert saved_reference["quiz_id"] == str(canonical["_id"])

--- a/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
+++ b/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
@@ -125,6 +125,7 @@ async def test_dual_writes_migration_saved_quiz_dual_write(
     assert legacy_doc["quiz_id"] == "legacy-ai-quiz-1"
     assert legacy_doc["is_deleted"] is False
     assert legacy_doc["canonical_quiz_id"] == saved_reference["quiz_id"]
+    assert saved_reference["display_title"] == "Saved quiz"
 
 
 @pytest.mark.asyncio
@@ -311,6 +312,8 @@ async def test_dual_writes_migration_folder_create_and_add_dual_write(
     assert folder_item_v2 is not None
     assert folder_item_v2["quiz_id"] == str(canonical_quiz["_id"])
     assert folder_item_v2["quiz_id"] == saved_doc["canonical_quiz_id"]
+    assert folder_item_v2["display_title"] == saved_doc["title"]
+    assert folder_item_v2["position"] == 0
 
 
 @pytest.mark.asyncio
@@ -381,6 +384,7 @@ async def test_dual_writes_migration_folder_add_merges_duplicate_items_for_same_
     assert len(folder_items) == 1
     assert folder_items[0]["legacy_folder_item_id"] == "legacy-folder-item-1"
     assert folder_items[0]["quiz_id"] == saved_doc["canonical_quiz_id"]
+    assert folder_items[0]["position"] == 0
 
 
 @pytest.mark.asyncio

--- a/server/tests/v2_database_tests/read_cutover_tests/conftest.py
+++ b/server/tests/v2_database_tests/read_cutover_tests/conftest.py
@@ -1,0 +1,79 @@
+import os
+
+import pytest
+import pytest_asyncio
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+os.environ.setdefault("email_sender", "test@example.com")
+os.environ.setdefault("email_password", "password")
+os.environ.setdefault("email_host", "localhost")
+os.environ.setdefault("email_port", "1025")
+os.environ.setdefault("share_url", "http://localhost")
+os.environ.setdefault("db_name", "test_db")
+os.environ.setdefault("mongo_url", "mongodb://localhost:27017")
+
+from server.app.db.core.config import settings
+from server.app.db.services.quiz_user_library_read_service import QuizUserLibraryReadService
+from server.app.db.services.shared_quiz_read_service import SharedQuizReadService
+from server.app.db.v2.repositories.quiz_repository import QuizV2Repository
+from server.app.db.v2.repositories.reference_repository import ReferenceV2Repository
+from server.app.db.v2.setup import ensure_v2_collections_and_validators, ensure_v2_indexes
+
+
+@pytest_asyncio.fixture(scope="function")
+async def read_cutover_db(test_db):
+    await ensure_v2_collections_and_validators(test_db)
+    await ensure_v2_indexes(
+        test_db["quizzes_v2"],
+        test_db["folders_v2"],
+        test_db["folder_items_v2"],
+        test_db["saved_quizzes_v2"],
+        test_db["quiz_history_v2"],
+    )
+    return test_db
+
+
+@pytest.fixture(scope="function")
+def read_service_factory(read_cutover_db):
+    def factory():
+        return QuizUserLibraryReadService(
+            saved_quizzes_collection=read_cutover_db["saved_quizzes"],
+            quiz_history_collection=read_cutover_db["quiz_history"],
+            folders_collection=read_cutover_db["folders"],
+            quiz_repository=QuizV2Repository(read_cutover_db["quizzes_v2"]),
+            reference_repository=ReferenceV2Repository(
+                read_cutover_db["folders_v2"],
+                read_cutover_db["folder_items_v2"],
+                read_cutover_db["saved_quizzes_v2"],
+                read_cutover_db["quiz_history_v2"],
+            ),
+        )
+
+    return factory
+
+
+@pytest.fixture(scope="function")
+def shared_read_service_factory(read_cutover_db):
+    def factory():
+        return SharedQuizReadService(
+            quizzes_collection=read_cutover_db["quizzes"],
+            ai_generated_quizzes_collection=read_cutover_db["ai_generated_quizzes"],
+            saved_quizzes_collection=read_cutover_db["saved_quizzes"],
+            quiz_repository=QuizV2Repository(read_cutover_db["quizzes_v2"]),
+            reference_repository=ReferenceV2Repository(
+                read_cutover_db["folders_v2"],
+                read_cutover_db["folder_items_v2"],
+                read_cutover_db["saved_quizzes_v2"],
+                read_cutover_db["quiz_history_v2"],
+            ),
+        )
+
+    return factory
+
+
+@pytest.fixture(scope="function", autouse=True)
+def reset_read_modes(monkeypatch):
+    monkeypatch.setattr(settings, "QUIZ_V2_SAVED_READ_MODE", "legacy_only")
+    monkeypatch.setattr(settings, "QUIZ_V2_HISTORY_READ_MODE", "legacy_only")
+    monkeypatch.setattr(settings, "QUIZ_V2_FOLDER_READ_MODE", "legacy_only")
+    monkeypatch.setattr(settings, "QUIZ_V2_SHARE_READ_MODE", "legacy_only")

--- a/server/tests/v2_database_tests/read_cutover_tests/test_stage4_read_cutover.py
+++ b/server/tests/v2_database_tests/read_cutover_tests/test_stage4_read_cutover.py
@@ -1,0 +1,343 @@
+from datetime import datetime
+
+import pytest
+from bson import ObjectId
+
+from server.app.db.core.config import settings
+
+
+@pytest.mark.asyncio
+async def test_stage4_history_v2_only_reads_legacy_compatible_payload(
+    read_cutover_db,
+    read_service_factory,
+    monkeypatch,
+):
+    service = read_service_factory()
+    monkeypatch.setattr(settings, "QUIZ_V2_HISTORY_READ_MODE", "v2_only")
+
+    quiz_id = ObjectId()
+    history_id = ObjectId()
+    await read_cutover_db["quizzes_v2"].insert_one(
+        {
+            "_id": quiz_id,
+            "title": "Caching",
+            "quiz_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What does Redis store?",
+                    "options": ["Rows", "Keys"],
+                    "correct_answer": "Keys",
+                }
+            ],
+            "description": "Infra topic",
+            "owner_user_id": None,
+            "visibility": "private",
+            "status": "active",
+            "source": "legacy",
+            "tags": [],
+            "legacy_source_collection": "ai_generated_quizzes",
+            "legacy_quiz_id": "legacy-ai-1",
+            "content_fingerprint": "history-content",
+            "structure_fingerprint": "history-structure",
+            "schema_version": 1,
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow(),
+            "deleted_at": None,
+        }
+    )
+    await read_cutover_db["quiz_history_v2"].insert_one(
+        {
+            "user_id": "user-1",
+            "quiz_id": str(quiz_id),
+            "action": "generated",
+            "metadata": {"topic": "Caching", "difficulty_level": "easy"},
+            "legacy_history_id": str(history_id),
+            "created_at": datetime.utcnow(),
+        }
+    )
+
+    payload = await service.get_quiz_history_for_user("user-1")
+
+    assert len(payload) == 1
+    assert payload[0]["_id"] == str(history_id)
+    assert payload[0]["question_type"] == "multichoice"
+    assert payload[0]["questions"][0]["answer"] == "Keys"
+    assert payload[0]["questions"][0]["question_type"] == "multichoice"
+
+
+@pytest.mark.asyncio
+async def test_stage4_saved_compare_mode_returns_legacy_contract(
+    read_cutover_db,
+    read_service_factory,
+    monkeypatch,
+):
+    service = read_service_factory()
+    monkeypatch.setattr(settings, "QUIZ_V2_SAVED_READ_MODE", "compare")
+
+    saved_id = ObjectId()
+    quiz_id = ObjectId()
+    created_at = datetime.utcnow()
+    await read_cutover_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-1",
+            "quiz_id": "legacy-ai-1",
+            "title": "Legacy Saved Quiz",
+            "question_type": "multichoice",
+            "questions": [{"question": "Legacy question", "options": ["A", "B"], "question_type": "multichoice"}],
+            "created_at": created_at,
+        }
+    )
+    await read_cutover_db["quizzes_v2"].insert_one(
+        {
+            "_id": quiz_id,
+            "title": "Legacy Saved Quiz",
+            "quiz_type": "multichoice",
+            "questions": [
+                {
+                    "question": "Legacy question",
+                    "options": ["A", "B"],
+                    "correct_answer": "A",
+                }
+            ],
+            "description": None,
+            "owner_user_id": None,
+            "visibility": "private",
+            "status": "active",
+            "source": "legacy",
+            "tags": [],
+            "legacy_source_collection": "ai_generated_quizzes",
+            "legacy_quiz_id": "legacy-ai-1",
+            "content_fingerprint": "saved-content",
+            "structure_fingerprint": "saved-structure",
+            "schema_version": 1,
+            "created_at": created_at,
+            "updated_at": created_at,
+            "deleted_at": None,
+        }
+    )
+    await read_cutover_db["saved_quizzes_v2"].insert_one(
+        {
+            "user_id": "user-1",
+            "quiz_id": str(quiz_id),
+            "legacy_saved_quiz_id": str(saved_id),
+            "saved_at": created_at,
+        }
+    )
+
+    payload = await service.get_saved_quizzes_for_user("user-1")
+
+    assert len(payload) == 1
+    assert payload[0]["_id"] == str(saved_id)
+    assert payload[0]["title"] == "Legacy Saved Quiz"
+    assert payload[0]["questions"][0]["question"] == "Legacy question"
+    assert "correct_answer" not in payload[0]["questions"][0]
+
+
+@pytest.mark.asyncio
+async def test_stage4_saved_v2_only_preserves_legacy_saved_id_and_restores_answers(
+    read_cutover_db,
+    read_service_factory,
+    monkeypatch,
+):
+    service = read_service_factory()
+    monkeypatch.setattr(settings, "QUIZ_V2_SAVED_READ_MODE", "v2_only")
+
+    saved_id = ObjectId()
+    quiz_id = ObjectId()
+    created_at = datetime.utcnow()
+    await read_cutover_db["quizzes_v2"].insert_one(
+        {
+            "_id": quiz_id,
+            "title": "Russian Federation",
+            "quiz_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow"],
+                    "correct_answer": "B) Moscow",
+                }
+            ],
+            "description": "Geopolitics",
+            "owner_user_id": None,
+            "visibility": "private",
+            "status": "active",
+            "source": "legacy",
+            "tags": [],
+            "legacy_source_collection": "ai_generated_quizzes",
+            "legacy_quiz_id": "legacy-russia",
+            "content_fingerprint": "saved-content-v2",
+            "structure_fingerprint": "saved-structure-v2",
+            "schema_version": 1,
+            "created_at": created_at,
+            "updated_at": created_at,
+            "deleted_at": None,
+        }
+    )
+    await read_cutover_db["saved_quizzes_v2"].insert_one(
+        {
+            "user_id": "user-2",
+            "quiz_id": str(quiz_id),
+            "display_title": "Russia",
+            "legacy_saved_quiz_id": str(saved_id),
+            "saved_at": created_at,
+        }
+    )
+
+    payload = await service.get_saved_quiz_by_id(str(saved_id), "user-2")
+
+    assert payload is not None
+    assert payload["_id"] == str(saved_id)
+    assert payload["title"] == "Russia"
+    assert payload["canonical_quiz_id"] == str(quiz_id)
+    assert payload["questions"][0]["correct_answer"] == "B) Moscow"
+
+
+@pytest.mark.asyncio
+async def test_stage4_folder_v2_only_preserves_folder_and_item_legacy_ids_and_position(
+    read_cutover_db,
+    read_service_factory,
+    monkeypatch,
+):
+    service = read_service_factory()
+    monkeypatch.setattr(settings, "QUIZ_V2_FOLDER_READ_MODE", "v2_only")
+
+    folder_v2_id = ObjectId()
+    quiz_one_id = ObjectId()
+    quiz_two_id = ObjectId()
+    created_at = datetime.utcnow()
+    await read_cutover_db["folders_v2"].insert_one(
+        {
+            "_id": folder_v2_id,
+            "user_id": "user-folder",
+            "name": "Research",
+            "legacy_folder_id": "legacy-folder-1",
+            "created_at": created_at,
+            "updated_at": created_at,
+        }
+    )
+    await read_cutover_db["quizzes_v2"].insert_many(
+        [
+            {
+                "_id": quiz_one_id,
+                "title": "United States Military",
+                "quiz_type": "multichoice",
+                "questions": [{"question": "Q2", "options": ["A", "B"], "correct_answer": "A"}],
+                "description": None,
+                "owner_user_id": None,
+                "visibility": "private",
+                "status": "active",
+                "source": "legacy",
+                "tags": [],
+                "legacy_source_collection": "ai_generated_quizzes",
+                "legacy_quiz_id": "legacy-quiz-2",
+                "content_fingerprint": "folder-content-2",
+                "structure_fingerprint": "folder-structure-2",
+                "schema_version": 1,
+                "created_at": created_at,
+                "updated_at": created_at,
+                "deleted_at": None,
+            },
+            {
+                "_id": quiz_two_id,
+                "title": "Russian Federation",
+                "quiz_type": "multichoice",
+                "questions": [{"question": "Q1", "options": ["A", "B"], "correct_answer": "B"}],
+                "description": None,
+                "owner_user_id": None,
+                "visibility": "private",
+                "status": "active",
+                "source": "legacy",
+                "tags": [],
+                "legacy_source_collection": "ai_generated_quizzes",
+                "legacy_quiz_id": "legacy-quiz-1",
+                "content_fingerprint": "folder-content-1",
+                "structure_fingerprint": "folder-structure-1",
+                "schema_version": 1,
+                "created_at": created_at,
+                "updated_at": created_at,
+                "deleted_at": None,
+            },
+        ]
+    )
+    await read_cutover_db["folder_items_v2"].insert_many(
+        [
+            {
+                "folder_id": str(folder_v2_id),
+                "quiz_id": str(quiz_one_id),
+                "added_by": "user-folder",
+                "position": 1,
+                "display_title": "USA Military",
+                "legacy_folder_item_id": "item-2",
+                "created_at": created_at,
+            },
+            {
+                "folder_id": str(folder_v2_id),
+                "quiz_id": str(quiz_two_id),
+                "added_by": "user-folder",
+                "position": 0,
+                "display_title": "Russia",
+                "legacy_folder_item_id": "item-1",
+                "created_at": created_at,
+            },
+        ]
+    )
+
+    payload = await service.get_folder_by_id("legacy-folder-1", "user-folder")
+
+    assert payload is not None
+    assert payload["_id"] == "legacy-folder-1"
+    assert [item["_id"] for item in payload["quizzes"]] == ["item-1", "item-2"]
+    assert payload["quizzes"][0]["title"] == "Russia"
+    assert payload["quizzes"][1]["title"] == "USA Military"
+
+
+@pytest.mark.asyncio
+async def test_stage4_shared_v2_only_resolves_saved_quiz_legacy_id(
+    read_cutover_db,
+    shared_read_service_factory,
+    monkeypatch,
+):
+    service = shared_read_service_factory()
+    monkeypatch.setattr(settings, "QUIZ_V2_SHARE_READ_MODE", "v2_only")
+
+    saved_id = ObjectId()
+    quiz_id = ObjectId()
+    created_at = datetime.utcnow()
+    await read_cutover_db["quizzes_v2"].insert_one(
+        {
+            "_id": quiz_id,
+            "title": "Shared Quiz",
+            "quiz_type": "multichoice",
+            "questions": [{"question": "Q1", "options": ["A", "B"], "correct_answer": "B"}],
+            "description": "Shared description",
+            "owner_user_id": None,
+            "visibility": "private",
+            "status": "active",
+            "source": "legacy",
+            "tags": [],
+            "legacy_source_collection": "ai_generated_quizzes",
+            "legacy_quiz_id": "legacy-shared-ai",
+            "content_fingerprint": "shared-content",
+            "structure_fingerprint": "shared-structure",
+            "schema_version": 1,
+            "created_at": created_at,
+            "updated_at": created_at,
+            "deleted_at": None,
+        }
+    )
+    await read_cutover_db["saved_quizzes_v2"].insert_one(
+        {
+            "user_id": "user-1",
+            "quiz_id": str(quiz_id),
+            "legacy_saved_quiz_id": str(saved_id),
+            "saved_at": created_at,
+        }
+    )
+
+    payload = await service.resolve_shared_quiz(str(saved_id))
+
+    assert payload is not None
+    assert payload["id"] == str(saved_id)
+    assert payload["title"] == "Shared Quiz"
+    assert payload["questions"][0]["correct_answer"] == "B"


### PR DESCRIPTION
## Summary

This PR completes Stage 4 of the V2 migration by introducing a controlled read cutover from legacy collections to V2-backed read services while preserving the current frontend/API contract.

Stage 4 is a read-migration stage only:
- Stage 2 dual writes remain active
- Stage 3 backfill remains the source of historical V2 population
- legacy collections are not deprecated in this PR

## What changed

### Read cutover services
Added centralized V2-aware read services for user-library and shared-quiz reads:
- `QuizUserLibraryReadService`
- `SharedQuizReadService`

These services:
- support `legacy_only`, `compare`, and `v2_only` read modes
- adapt V2 data back into the current legacy-shaped response contract
- preserve legacy ids at the API boundary for compatibility during the cutover

### Config-gated read routing
Added per-surface read mode flags:
- `QUIZ_V2_SAVED_READ_MODE`
- `QUIZ_V2_HISTORY_READ_MODE`
- `QUIZ_V2_FOLDER_READ_MODE`
- `QUIZ_V2_SHARE_READ_MODE`

### Route cutover coverage
Read paths now support V2-backed reads for:
- saved quizzes
- quiz history
- folders
- shared quiz reads

### Data parity improvements
Added/preserved V2 reference metadata required for parity-safe reads:
- `display_title` for saved quizzes and folder items
- `position` for folder items

This keeps user-facing saved/folder titles aligned with legacy behavior and preserves folder item ordering in V2 reads.

### Migration/backfill alignment
Updated dual-write and backfill paths so existing and future V2 data stay aligned with Stage 4 read expectations:
- folder item `position` is populated
- saved/folder `display_title` is populated
- reruns remain idempotent and duplicate-safe

## Why devs need to rerun the migration

If you already ran the Stage 3 backfill before this branch, rerun it once after pulling this PR.

Reason:
- existing `saved_quizzes_v2` rows need `display_title`
- existing `folder_items_v2` rows need `display_title`
- existing `folder_items_v2` rows need `position`

Without that rerun, V2 compare/read behavior may show avoidable parity drift in saved/folder views.

## How to test

### 1. Run backend tests

```bash
cd quiz-generator/server
pipenv run pytest tests/v2_database_tests/read_cutover_tests -q
pipenv run pytest tests/v2_database_tests/backfill_tests -q
pipenv run pytest tests/v2_database_tests/dual_writes_migration_tests -q
```

### 2. Rerun migration for a local non-Docker environment

Dry-run:
```bash
cd /quiz-generator
python -m server.scripts.v2_backfill.run_full_v2_backfill --dry-run
```

Commit:
```bash
cd /quiz-generator
python -m server.scripts.v2_backfill.run_full_v2_backfill --commit
```

### 3. Rerun migration for a Docker dev environment

Make sure the app is running in Docker:
- From another terminal, run the following:

Dry-run:
```bash
docker compose exec server python -m server.scripts.v2_backfill.run_full_v2_backfill --dry-run
```

Commit:
```bash
docker compose exec server python -m server.scripts.v2_backfill.run_full_v2_backfill --commit
```

### 4. Optional compare-mode verification

If you want to verify parity before switching fully to V2 reads, set the relevant read mode(s) to `compare` and inspect compare logs while checking out the following in the frontend:
- saved quizzes
- quiz history
- folders
- shared quiz views

### 5. Manual app verification

Verify these flows after the migration rerun:
- saved quiz list/detail
- quiz history list/detail
- folder list/detail
- shared quiz access
- folder ordering remains unchanged
- user-facing titles remain unchanged

## Rollout notes

Recommended rollout:
1. rerun backfill on the target environment
2. use `compare` mode if you want to inspect parity
3. switch read modes to `v2_only`
4. keep Stage 2 dual writes active.