### PR TITLE
Feature/add soft delete structure to saved history and folders quizdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,4 @@ cython_debug/
 node_modules/
 
 client/.pnpm-store/*
+server/tmp/

--- a/client/components/home/DownloadQuizButton.tsx
+++ b/client/components/home/DownloadQuizButton.tsx
@@ -10,7 +10,6 @@ type FileFormat = "txt" | "csv" | "pdf" | "docx";
 
 export default function DownloadQuizButton({
   quizId,
-  userId,
   question_type,
   numQuestion,
 }: DownloadQuizProps) {
@@ -34,11 +33,9 @@ export default function DownloadQuizButton({
           ? {
               quiz_id: quizId,
               format: selectedFormat,
-              user_id: userId,
             }
           : {
               pattern: QueryPattern.DownloadQuiz,
-              user_id: userId,
               format: selectedFormat,
               question_type: question_type,
               num_question: numQuestion,

--- a/client/components/home/folders/FolderCard.tsx
+++ b/client/components/home/folders/FolderCard.tsx
@@ -3,9 +3,11 @@
 import React from "react";
 
 export interface Folder {
-  _id: string;
+  id?: string;
+  _id?: string;
   name: string;
   quizzes?: any[];
+  quiz_count?: number;
 }
 
 interface FolderCardProps {
@@ -34,7 +36,7 @@ const FolderCard: React.FC<FolderCardProps> = ({
         <div>
           <h3 className="font-semibold text-navy-800">{folder.name}</h3>
           <p className="text-sm text-gray-500">
-            {folder.quizzes?.length || 0} quizzes
+            {folder.quizzes?.length ?? folder.quiz_count ?? 0} quizzes
           </p>
         </div>
         <label className="flex items-center gap-2 text-xs text-gray-600">

--- a/client/components/home/folders/FolderView.tsx
+++ b/client/components/home/folders/FolderView.tsx
@@ -7,21 +7,17 @@ import OrganizeModal from "./OrganizeModal";
 interface FolderViewProps {
   folder: {
     id?: string;
-    _id?: string;
     name: string;
     quizzes: {
       id?: string;
-      _id?: string;
       title: string;
       category: string;
     }[];
   };
 }
 
-const getFolderId = (folder: { id?: string; _id?: string }) =>
-  folder.id || folder._id || "";
-const getFolderItemId = (quiz: { id?: string; _id?: string }) =>
-  quiz.id || quiz._id || "";
+const getFolderId = (folder: { id?: string }) => folder.id || "";
+const getFolderItemId = (quiz: { id?: string }) => quiz.id || "";
 
 const FolderView: React.FC<FolderViewProps> = ({ folder }) => {
   const [selectedQuiz, setSelectedQuiz] = useState<any | null>(null);

--- a/client/components/home/folders/FolderView.tsx
+++ b/client/components/home/folders/FolderView.tsx
@@ -6,15 +6,22 @@ import OrganizeModal from "./OrganizeModal";
 
 interface FolderViewProps {
   folder: {
-    _id: string;
+    id?: string;
+    _id?: string;
     name: string;
     quizzes: {
-      _id: string;
+      id?: string;
+      _id?: string;
       title: string;
       category: string;
     }[];
   };
 }
+
+const getFolderId = (folder: { id?: string; _id?: string }) =>
+  folder.id || folder._id || "";
+const getFolderItemId = (quiz: { id?: string; _id?: string }) =>
+  quiz.id || quiz._id || "";
 
 const FolderView: React.FC<FolderViewProps> = ({ folder }) => {
   const [selectedQuiz, setSelectedQuiz] = useState<any | null>(null);
@@ -40,7 +47,7 @@ const FolderView: React.FC<FolderViewProps> = ({ folder }) => {
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {quizzes.map((quiz) => (
             <div
-              key={quiz._id}
+              key={getFolderItemId(quiz)}
               className="p-4 border border-gray-200 rounded-xl hover:shadow-md transition"
             >
               <h3 className="text-lg font-medium text-navy-700 mb-1">
@@ -70,7 +77,7 @@ const FolderView: React.FC<FolderViewProps> = ({ folder }) => {
           isOpen={showMoveModal}
           onClose={() => setShowMoveModal(false)}
           quiz={selectedQuiz}
-          sourceFolderId={folder._id}
+          sourceFolderId={getFolderId(folder)}
         />
       )}
 

--- a/client/components/home/folders/MoveQuizModal.tsx
+++ b/client/components/home/folders/MoveQuizModal.tsx
@@ -9,6 +9,9 @@ import {
 } from "../../../lib/functions/folders";
 import { useAuth } from "../../../contexts/authContext";
 
+const getFolderId = (folder: any) => folder?.id || folder?._id || "";
+const getFolderItemId = (quiz: any) => quiz?.id || quiz?._id || "";
+
 interface MoveQuizModalProps {
   isOpen: boolean;
   onClose: () => void;
@@ -68,10 +71,10 @@ const MoveQuizModal: React.FC<MoveQuizModalProps> = ({
 
       if (isCreatingNew && newFolderName.trim()) {
         const newFolder = await createFolder({ name: newFolderName });
-        targetFolderId = newFolder._id;
+        targetFolderId = getFolderId(newFolder);
       }
 
-      await moveQuiz(quiz._id, sourceFolderId, targetFolderId);
+      await moveQuiz(getFolderItemId(quiz), sourceFolderId, targetFolderId);
 
       toast.success("Quiz moved successfully");
       onQuizMoved?.();
@@ -110,10 +113,10 @@ const MoveQuizModal: React.FC<MoveQuizModalProps> = ({
               <div className="space-y-2 overflow-y-auto max-h-[50vh] pr-1">
                 {folders.map((folder) => (
                   <div
-                    key={folder._id}
-                    onClick={() => setSelectedFolderId(folder._id)}
+                    key={getFolderId(folder)}
+                    onClick={() => setSelectedFolderId(getFolderId(folder))}
                     className={`p-3 border rounded-xl cursor-pointer ${
-                      selectedFolderId === folder._id
+                      selectedFolderId === getFolderId(folder)
                         ? "border-navy-600 bg-blue-50"
                         : "border-gray-200 hover:bg-gray-50"
                     }`}

--- a/client/components/home/folders/MoveQuizModal.tsx
+++ b/client/components/home/folders/MoveQuizModal.tsx
@@ -9,8 +9,8 @@ import {
 } from "../../../lib/functions/folders";
 import { useAuth } from "../../../contexts/authContext";
 
-const getFolderId = (folder: any) => folder?.id || folder?._id || "";
-const getFolderItemId = (quiz: any) => quiz?.id || quiz?._id || "";
+const getFolderId = (folder: any) => folder?.id || "";
+const getFolderItemId = (quiz: any) => quiz?.id || "";
 
 interface MoveQuizModalProps {
   isOpen: boolean;

--- a/client/interfaces/props/download-quiz-props.ts
+++ b/client/interfaces/props/download-quiz-props.ts
@@ -1,5 +1,4 @@
 export interface DownloadQuizProps {
-  userId: string;
   question_type: string;
   numQuestion: number;
   quizId: string;

--- a/client/lib/functions/folders.ts
+++ b/client/lib/functions/folders.ts
@@ -1,8 +1,7 @@
 import { api } from "./auth";
 
 const API_BASE = `/api/folders`;
-const getResourceId = (resource: any) =>
-  resource?.id || resource?._id || resource?.quiz_id;
+const getResourceId = (resource: any) => resource?.id || resource?.quiz_id;
 
 export const getUserFolders = async () => {
   const res = await api.get(`${API_BASE}/`);

--- a/client/lib/functions/folders.ts
+++ b/client/lib/functions/folders.ts
@@ -1,6 +1,8 @@
 import { api } from "./auth";
 
 const API_BASE = `/api/folders`;
+const getResourceId = (resource: any) =>
+  resource?.id || resource?._id || resource?.quiz_id;
 
 export const getUserFolders = async () => {
   const res = await api.get(`${API_BASE}/`);
@@ -25,7 +27,7 @@ export const deleteFolder = async (folderId: string) => {
 };
 
 export const addQuizToFolder = async (folderId: string, quiz: any) => {
-  const quizId = quiz._id || quiz.id || quiz.quiz_id;
+  const quizId = getResourceId(quiz);
   const res = await api.post(`${API_BASE}/${folderId}/add_quiz`, {
     quiz_id: quizId,
   });
@@ -34,9 +36,12 @@ export const addQuizToFolder = async (folderId: string, quiz: any) => {
 
 export const removeQuizFromFolder = async (
   folderId: string,
-  quizId: string,
+  folderItemId: string,
 ) => {
-  const res = await api.post(`${API_BASE}/${folderId}/remove/${quizId}`, {});
+  const res = await api.post(
+    `${API_BASE}/${folderId}/remove/${folderItemId}`,
+    {},
+  );
   return res.data;
 };
 
@@ -46,12 +51,12 @@ export const getFolderById = async (folderId: string) => {
 };
 
 export const moveQuiz = async (
-  quizId: string,
+  folderItemId: string,
   sourceFolderId: string,
   targetFolderId: string,
 ) => {
   const res = await api.patch(`${API_BASE}/move_quiz`, {
-    quiz_id: quizId,
+    quiz_id: folderItemId,
     from_folder_id: sourceFolderId,
     to_folder_id: targetFolderId,
   });

--- a/client/lib/functions/saveQuizToHistory.ts
+++ b/client/lib/functions/saveQuizToHistory.ts
@@ -24,7 +24,7 @@ export async function saveQuizToHistory(
 
   const payload = {
     quiz_id: meta.quiz_id,
-    quiz_name: `${meta.question_type} Quiz`,
+    quiz_name: meta.profession || `${meta.question_type} Quiz`,
     question_type: meta.question_type,
     num_questions: meta.num_questions,
     difficulty_level: meta.difficulty_level,

--- a/client/pages/folders/[folderId].tsx
+++ b/client/pages/folders/[folderId].tsx
@@ -15,6 +15,8 @@ import Footer from "../../components/home/Footer";
 import { useAuth } from "../../contexts/authContext";
 import RequireAuth from "../../components/auth/RequireAuth";
 
+const getFolderItemId = (quiz: any) => quiz?.id || quiz?._id || "";
+
 const FolderView = () => {
   const router = useRouter();
   const { folderId } = router.query;
@@ -64,7 +66,9 @@ const FolderView = () => {
         prev
           ? {
               ...prev,
-              quizzes: prev.quizzes.filter((q: any) => q._id !== quizId),
+              quizzes: prev.quizzes.filter(
+                (q: any) => getFolderItemId(q) !== quizId,
+              ),
             }
           : prev,
       );
@@ -86,7 +90,9 @@ const FolderView = () => {
 
   const handleViewQuiz = (quiz: any) => {
     localStorage.setItem("saved_quiz_view", JSON.stringify(quiz));
-    router.push("/quiz_display");
+    router.push(
+      `/quiz_display?quizId=${quiz.quiz_id || ""}&questionType=${quiz.question_type || quiz.quiz_data?.question_type || "multichoice"}`,
+    );
   };
 
   const formatDate = (date: string) => {
@@ -146,7 +152,7 @@ const FolderView = () => {
               ) : (
                 folder.quizzes.map((quiz: any) => (
                   <div
-                    key={quiz._id}
+                    key={getFolderItemId(quiz)}
                     className="quiz-card relative border rounded-2xl p-4 shadow-sm bg-white hover:shadow-md transition-all flex flex-col justify-between w-full max-w-3xl group"
                   >
                     <div>
@@ -200,7 +206,9 @@ const FolderView = () => {
                       <button
                         onClick={() =>
                           setOpenMenuId(
-                            openMenuId === quiz._id ? null : quiz._id,
+                            openMenuId === getFolderItemId(quiz)
+                              ? null
+                              : getFolderItemId(quiz),
                           )
                         }
                         className="p-2 hover:bg-gray-100 rounded-full"
@@ -208,7 +216,7 @@ const FolderView = () => {
                         <FaEllipsisV className="text-gray-600" />
                       </button>
 
-                      {openMenuId === quiz._id && (
+                      {openMenuId === getFolderItemId(quiz) && (
                         <div className="absolute right-0 mt-2 w-36 bg-white border border-gray-200 rounded-lg shadow-lg z-10 flex flex-col">
                           <button
                             onClick={() => handleViewQuiz(quiz)}
@@ -223,7 +231,9 @@ const FolderView = () => {
                             Move
                           </button>
                           <button
-                            onClick={() => handleDeleteQuizClick(quiz._id)}
+                            onClick={() =>
+                              handleDeleteQuizClick(getFolderItemId(quiz))
+                            }
                             className="px-3 py-2 text-sm text-red-600 bg-red-100 hover:bg-red-200 rounded-b-lg"
                           >
                             Delete

--- a/client/pages/folders/[folderId].tsx
+++ b/client/pages/folders/[folderId].tsx
@@ -15,7 +15,7 @@ import Footer from "../../components/home/Footer";
 import { useAuth } from "../../contexts/authContext";
 import RequireAuth from "../../components/auth/RequireAuth";
 
-const getFolderItemId = (quiz: any) => quiz?.id || quiz?._id || "";
+const getFolderItemId = (quiz: any) => quiz?.id || "";
 
 const FolderView = () => {
   const router = useRouter();

--- a/client/pages/folders/index.tsx
+++ b/client/pages/folders/index.tsx
@@ -19,11 +19,16 @@ import {
 } from "../../lib/functions/folders";
 
 interface Folder {
-  _id: string;
+  id: string;
+  _id?: string;
+  legacy_id?: string;
   name: string;
   created_at: string;
   quizzes: any[];
+  quiz_count?: number;
 }
+
+const getFolderId = (folder: Partial<Folder>) => folder.id || folder._id || "";
 
 const FoldersPage = () => {
   const router = useRouter();
@@ -53,7 +58,7 @@ const FoldersPage = () => {
   const handleDeleteFolder = async (folderId: string) => {
     try {
       await deleteFolder(folderId);
-      setFolders((prev) => prev.filter((f) => f._id !== folderId));
+      setFolders((prev) => prev.filter((f) => getFolderId(f) !== folderId));
       toast.success("Folder deleted successfully");
     } catch (err) {
       console.error(err);
@@ -65,7 +70,9 @@ const FoldersPage = () => {
     if (!folderIds.length) return;
     try {
       await bulkDeleteFolders(folderIds);
-      setFolders((prev) => prev.filter((f) => !folderIds.includes(f._id)));
+      setFolders((prev) =>
+        prev.filter((f) => !folderIds.includes(getFolderId(f))),
+      );
       toast.success("Selected folders deleted successfully");
     } catch (err) {
       console.error(err);
@@ -104,15 +111,15 @@ const FoldersPage = () => {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
               {folders.map((folder) => (
                 <FolderCard
-                  key={folder._id}
+                  key={getFolderId(folder)}
                   folder={folder}
-                  isSelected={selectedFolders.includes(folder._id)}
-                  onOpen={() => router.push(`/folders/${folder._id}`)}
+                  isSelected={selectedFolders.includes(getFolderId(folder))}
+                  onOpen={() => router.push(`/folders/${getFolderId(folder)}`)}
                   onToggleSelect={() =>
                     setSelectedFolders((prev) =>
-                      prev.includes(folder._id)
-                        ? prev.filter((id) => id !== folder._id)
-                        : [...prev, folder._id],
+                      prev.includes(getFolderId(folder))
+                        ? prev.filter((id) => id !== getFolderId(folder))
+                        : [...prev, getFolderId(folder)],
                     )
                   }
                 />

--- a/client/pages/folders/index.tsx
+++ b/client/pages/folders/index.tsx
@@ -20,15 +20,13 @@ import {
 
 interface Folder {
   id: string;
-  _id?: string;
-  legacy_id?: string;
   name: string;
   created_at: string;
   quizzes: any[];
   quiz_count?: number;
 }
 
-const getFolderId = (folder: Partial<Folder>) => folder.id || folder._id || "";
+const getFolderId = (folder: Partial<Folder>) => folder.id || "";
 
 const FoldersPage = () => {
   const router = useRouter();

--- a/client/pages/quiz_display/index.tsx
+++ b/client/pages/quiz_display/index.tsx
@@ -28,7 +28,6 @@ const QuizDisplayPage: React.FC = () => {
   const difficultyLevel = searchParams.get("difficultyLevel") || "easy";
   const audienceType = searchParams.get("audienceType") || "students";
   const customInstruction = searchParams.get("customInstruction") || "";
-  const userId = searchParams.get("userId") || "defaultUserId"; // ✅ dummy user until auth works
   const token = searchParams.get("token") || "";
 
   const [quizQuestions, setQuizQuestions] = useState<any[]>([]);
@@ -44,16 +43,6 @@ const QuizDisplayPage: React.FC = () => {
     hasFetchedRef.current = true;
 
     const fetchQuizQuestions = async () => {
-      const basePayload = {
-        question_type: questionType,
-        num_questions: numQuestions,
-        profession: profession,
-        difficulty_level: difficultyLevel,
-        audience_type: audienceType,
-        custom_instruction: customInstruction,
-        token: token,
-      };
-
       try {
         setIsLoading(true);
         let questions: any[] = [];
@@ -305,7 +294,6 @@ const QuizDisplayPage: React.FC = () => {
               <SaveQuizButton quizData={quizQuestions} quizId={quizId} />
               <DownloadQuizButton
                 quizId={quizId}
-                userId={userId}
                 question_type={questionType}
                 numQuestion={numQuestions}
               />

--- a/client/pages/quiz_display/index.tsx
+++ b/client/pages/quiz_display/index.tsx
@@ -20,7 +20,8 @@ import { TokenService } from "../../lib/functions/tokenService";
 
 const QuizDisplayPage: React.FC = () => {
   const searchParams = useSearchParams();
-  const savedQuizId = searchParams.get("id");
+  const savedQuizId = searchParams.get("savedId") || searchParams.get("id");
+  const canonicalQuizId = searchParams.get("quizId") || "";
   const questionType = searchParams.get("questionType") || "multichoice";
   const numQuestions = Number(searchParams.get("numQuestions")) || 1;
   const profession = searchParams.get("profession") || "general knowledge";
@@ -34,7 +35,7 @@ const QuizDisplayPage: React.FC = () => {
   const [userAnswers, setUserAnswers] = useState<(string | number)[]>([]);
   const [isQuizChecked, setIsQuizChecked] = useState<boolean>(false);
   const [quizReport, setQuizReport] = useState<any[]>([]);
-  const [quizId, setQuizId] = useState("");
+  const [quizId, setQuizId] = useState(canonicalQuizId);
   const [isLoading, setIsLoading] = useState(true);
   const hasFetchedRef = useRef(false); // ✅ Prevent double fetch
 
@@ -70,6 +71,8 @@ const QuizDisplayPage: React.FC = () => {
               : [];
 
           if (storedQuestions.length > 0) {
+            const resolvedStoredQuizId =
+              parsedQuiz?.quiz_id || canonicalQuizId || "";
             const normalizedQuestions = storedQuestions.map((q: any) => ({
               ...q,
               answer: q.answer || q.correct_answer,
@@ -77,6 +80,9 @@ const QuizDisplayPage: React.FC = () => {
             }));
             setQuizQuestions(normalizedQuestions);
             setUserAnswers(Array(normalizedQuestions.length).fill(""));
+            if (resolvedStoredQuizId) {
+              setQuizId(resolvedStoredQuizId);
+            }
             toast.success(`Loaded saved quiz: ${parsedQuiz.title}`);
             localStorage.removeItem("saved_quiz_view");
             setIsLoading(false);
@@ -97,8 +103,9 @@ const QuizDisplayPage: React.FC = () => {
             answer: q.answer || q.correct_answer,
             question_type: q.question_type || questionType,
           }));
-          setQuizId(savedQuizId);
-          resolvedQuizId = savedQuizId;
+          const resolvedSavedQuizId = data.quiz_id || canonicalQuizId || "";
+          setQuizId(resolvedSavedQuizId);
+          resolvedQuizId = resolvedSavedQuizId;
           toast.success("Loaded saved quiz successfully!");
         } else {
           // ✅ Step 3: Fallback — generate a new quiz
@@ -175,12 +182,14 @@ const QuizDisplayPage: React.FC = () => {
     fetchQuizQuestions();
   }, [
     savedQuizId,
+    canonicalQuizId,
     questionType,
     numQuestions,
     profession,
     difficultyLevel,
     audienceType,
     customInstruction,
+    token,
   ]);
 
   const handleAnswerChange = (index: number, answer: string | number) => {

--- a/client/pages/quiz_history/index.tsx
+++ b/client/pages/quiz_history/index.tsx
@@ -11,7 +11,7 @@ const transformQuizHistory = (quizHistory: any[]) => {
   if (!quizHistory || quizHistory.length === 0) return [];
 
   return quizHistory.map((quizItem: any, quizIndex: number) => {
-    const quizHistoryId = quizItem.id || quizItem._id || `${quizIndex}`;
+    const quizHistoryId = quizItem.id || `${quizIndex}`;
     const createdAt = quizItem.created_at
       ? new Date(quizItem.created_at).toLocaleString()
       : "Unknown date";

--- a/client/pages/quiz_history/index.tsx
+++ b/client/pages/quiz_history/index.tsx
@@ -11,6 +11,7 @@ const transformQuizHistory = (quizHistory: any[]) => {
   if (!quizHistory || quizHistory.length === 0) return [];
 
   return quizHistory.map((quizItem: any, quizIndex: number) => {
+    const quizHistoryId = quizItem.id || quizItem._id || `${quizIndex}`;
     const createdAt = quizItem.created_at
       ? new Date(quizItem.created_at).toLocaleString()
       : "Unknown date";
@@ -48,7 +49,7 @@ const transformQuizHistory = (quizHistory: any[]) => {
     );
 
     return (
-      <div key={quizIndex}>
+      <div key={quizHistoryId}>
         <hr className="border-gray-300 my-4" />
         <p className="text-sm text-gray-500 mb-3">Generated on: {createdAt}</p>
         <div>{listedQuizQuestions}</div>

--- a/client/pages/saved_quiz/index.tsx
+++ b/client/pages/saved_quiz/index.tsx
@@ -25,10 +25,7 @@ interface QuizQuestion {
 
 interface SavedQuiz {
   id: string;
-  _id?: string;
-  legacy_id?: string;
   quiz_id: string;
-  legacy_quiz_id?: string | null;
   title: string;
   created_at: string;
   questions?: QuizQuestion[];
@@ -37,13 +34,12 @@ interface SavedQuiz {
 
 interface Folder {
   id: string;
-  _id?: string;
   name: string;
   created_at: string;
 }
 
-const getSavedQuizId = (quiz: Partial<SavedQuiz>) => quiz.id || quiz._id || "";
-const getFolderId = (folder: Partial<Folder>) => folder.id || folder._id || "";
+const getSavedQuizId = (quiz: Partial<SavedQuiz>) => quiz.id || "";
+const getFolderId = (folder: Partial<Folder>) => folder.id || "";
 
 const AddToFolderModal = ({
   isOpen,

--- a/client/pages/saved_quiz/index.tsx
+++ b/client/pages/saved_quiz/index.tsx
@@ -24,7 +24,11 @@ interface QuizQuestion {
 }
 
 interface SavedQuiz {
-  _id: string;
+  id: string;
+  _id?: string;
+  legacy_id?: string;
+  quiz_id: string;
+  legacy_quiz_id?: string | null;
   title: string;
   created_at: string;
   questions?: QuizQuestion[];
@@ -32,10 +36,14 @@ interface SavedQuiz {
 }
 
 interface Folder {
-  _id: string;
+  id: string;
+  _id?: string;
   name: string;
   created_at: string;
 }
+
+const getSavedQuizId = (quiz: Partial<SavedQuiz>) => quiz.id || quiz._id || "";
+const getFolderId = (folder: Partial<Folder>) => folder.id || folder._id || "";
 
 const AddToFolderModal = ({
   isOpen,
@@ -94,11 +102,11 @@ const AddToFolderModal = ({
 
       if (!targetFolderId && newFolderName) {
         const newFolder = await createFolder({ name: newFolderName });
-        targetFolderId = newFolder._id;
+        targetFolderId = getFolderId(newFolder);
       }
 
       for (const quizId of selectedQuizIds) {
-        await addQuizToFolder(targetFolderId!, { _id: quizId });
+        await addQuizToFolder(targetFolderId!, { id: quizId });
       }
 
       toast.success("Quiz(es) added to folder successfully!");
@@ -142,7 +150,8 @@ const AddToFolderModal = ({
                     <span>
                       {selectedFolderId
                         ? folders.find(
-                            (folder) => folder._id === selectedFolderId,
+                            (folder) =>
+                              getFolderId(folder) === selectedFolderId,
                           )?.name
                         : "Select a folder"}
                     </span>
@@ -168,16 +177,18 @@ const AddToFolderModal = ({
                     >
                       {folders.map((folder) => (
                         <button
-                          key={folder._id}
+                          key={getFolderId(folder)}
                           type="button"
                           role="option"
-                          aria-selected={folder._id === selectedFolderId}
+                          aria-selected={
+                            getFolderId(folder) === selectedFolderId
+                          }
                           onClick={() => {
-                            setSelectedFolderId(folder._id);
+                            setSelectedFolderId(getFolderId(folder));
                             setFolderMenuOpen(false);
                           }}
                           className={`w-full px-4 py-2 text-left text-sm ${
-                            folder._id === selectedFolderId
+                            getFolderId(folder) === selectedFolderId
                               ? "bg-[#0F2654] text-white"
                               : "text-[#2C3E50] hover:bg-[#0F2654]/10"
                           }`}
@@ -263,7 +274,9 @@ const DisplaySavedQuizzesPage: React.FC<{
     }
 
     localStorage.setItem("saved_quiz_view", JSON.stringify(quiz));
-    router.push(`/quiz_display?id=${quiz._id}`);
+    router.push(
+      `/quiz_display?savedId=${getSavedQuizId(quiz)}&quizId=${quiz.quiz_id}&questionType=${quiz.question_type || "multichoice"}`,
+    );
   };
 
   return (
@@ -293,14 +306,14 @@ const DisplaySavedQuizzesPage: React.FC<{
           ) : (
             savedQuizzes.map((quiz) => (
               <div
-                key={quiz._id}
+                key={getSavedQuizId(quiz)}
                 className="bg-white p-6 rounded-xl shadow-md border border-gray-200 relative"
               >
                 <input
                   type="checkbox"
                   className="absolute top-4 left-4 w-4 h-4"
-                  checked={selectedQuizIds.includes(quiz._id)}
-                  onChange={() => toggleSelectQuiz(quiz._id)}
+                  checked={selectedQuizIds.includes(getSavedQuizId(quiz))}
+                  onChange={() => toggleSelectQuiz(getSavedQuizId(quiz))}
                 />
 
                 <div className="ml-6">
@@ -341,7 +354,7 @@ const DisplaySavedQuizzesPage: React.FC<{
 
                     <div className="flex gap-2">
                       <button
-                        onClick={() => setConfirmDeleteId(quiz._id)}
+                        onClick={() => setConfirmDeleteId(getSavedQuizId(quiz))}
                         className="text-sm text-red-600 hover:text-red-800 font-semibold"
                       >
                         Delete
@@ -441,7 +454,9 @@ export default function SavedQuizzes() {
           <DisplaySavedQuizzesPage
             savedQuizzes={savedQuizzes}
             onDeleteClick={(id) =>
-              setSavedQuizzes((prev) => prev.filter((q) => q._id !== id))
+              setSavedQuizzes((prev) =>
+                prev.filter((q) => getSavedQuizId(q) !== id),
+              )
             }
             token={token!}
           />

--- a/server/api/v1/crud/download/download_quiz.py
+++ b/server/api/v1/crud/download/download_quiz.py
@@ -3,6 +3,8 @@ from fastapi.responses import StreamingResponse
 from bson import ObjectId
 from bson.errors import InvalidId
 from .....app.db.core.connection import get_ai_generated_quizzes_collection
+from .....app.db.core.connection import get_quizzes_collection
+from .....app.db.core.connection import get_quizzes_v2_collection
 from ..generate_csv import generate_csv
 from ..generate_docx import generate_docx
 from ..generate_pdf import generate_pdf
@@ -15,6 +17,19 @@ from ...db import (
 import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_questions_for_download(questions: list[dict]) -> list[dict]:
+    normalized_questions = []
+    for question in questions:
+        normalized_questions.append(
+            {
+                "question": question.get("question"),
+                "options": question.get("options"),
+                "answer": question.get("answer") or question.get("correct_answer"),
+            }
+        )
+    return normalized_questions
 
 
 def download_mock_quiz(format: str, question_type: str, num_question: int) -> StreamingResponse:
@@ -61,8 +76,9 @@ async def download_quiz_by_id(
     Download an existing quiz by its MongoDB ObjectId.
     Extracts only the 'questions' list to match existing generators.
     """
-
-    collection = get_ai_generated_quizzes_collection()
+    v2_collection = get_quizzes_v2_collection()
+    legacy_ai_collection = get_ai_generated_quizzes_collection()
+    legacy_manual_collection = get_quizzes_collection()
     logger.info(f"pulling quiz {quiz_id} from database")
 
     try:
@@ -71,13 +87,25 @@ async def download_quiz_by_id(
         logger.warning(f"Invalid quiz_id format: {quiz_id}")
         raise HTTPException(status_code=400, detail="Invalid quiz_id (must be a valid ObjectId)")
 
-    quiz_doc = await collection.find_one({"_id": object_id})
+    quiz_doc = await v2_collection.find_one({"_id": object_id})
+    if quiz_doc:
+        quiz_data = _normalize_questions_for_download(quiz_doc.get("questions", []))
+    else:
+        quiz_doc = await legacy_ai_collection.find_one({"_id": object_id})
+        if quiz_doc:
+            quiz_data = _normalize_questions_for_download(quiz_doc.get("questions", []))
+        else:
+            quiz_doc = await legacy_manual_collection.find_one({"_id": object_id})
+            if quiz_doc:
+                quiz_data = _normalize_questions_for_download(quiz_doc.get("questions", []))
+            else:
+                quiz_data = []
+
     if not quiz_doc:
         logger.warning(f"unable to pull quiz {quiz_id} from db")
         raise HTTPException(status_code=404, detail=f"Quiz not found for id {quiz_id}")
 
     # STEP 3 — Extract compatible quiz structure
-    quiz_data = quiz_doc.get("questions", [])
     if not quiz_data:
         logger.warning(f"Quiz with id {quiz_id} contains no questions")
         raise HTTPException(
@@ -114,4 +142,3 @@ async def download_quiz_by_id(
             "Content-Disposition": f"attachment; filename=quiz_{quiz_id}.{file_format}"
         }
     )
-

--- a/server/api/v1/crud/download/download_quiz.py
+++ b/server/api/v1/crud/download/download_quiz.py
@@ -70,7 +70,6 @@ def download_mock_quiz(format: str, question_type: str, num_question: int) -> St
 async def download_quiz_by_id(
     quiz_id: str,
     file_format: str,
-    user_id: str
 ) -> StreamingResponse:
     """
     Download an existing quiz by its MongoDB ObjectId.

--- a/server/app/db/core/config.py
+++ b/server/app/db/core/config.py
@@ -20,10 +20,6 @@ class Settings(BaseSettings):
     db_name: str
     mongo_url: str
     QUIZ_V2_WRITE_MODE: Literal["legacy_only", "dual_write", "v2_only"] = "v2_only"
-    QUIZ_V2_SAVED_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
-    QUIZ_V2_HISTORY_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
-    QUIZ_V2_FOLDER_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
-    QUIZ_V2_SHARE_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
     QUIZ_V2_FAIL_OPEN: bool = True
     QUIZ_V2_STRUCTURED_LOGGING: bool = True
     V2_BACKFILL_BATCH_SIZE: int = 200

--- a/server/app/db/core/config.py
+++ b/server/app/db/core/config.py
@@ -19,7 +19,7 @@ class Settings(BaseSettings):
     share_url: str
     db_name: str
     mongo_url: str
-    QUIZ_V2_WRITE_MODE: Literal["legacy_only", "dual_write"] = "dual_write"
+    QUIZ_V2_WRITE_MODE: Literal["legacy_only", "dual_write", "v2_only"] = "v2_only"
     QUIZ_V2_SAVED_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
     QUIZ_V2_HISTORY_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
     QUIZ_V2_FOLDER_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"

--- a/server/app/db/core/config.py
+++ b/server/app/db/core/config.py
@@ -20,6 +20,10 @@ class Settings(BaseSettings):
     db_name: str
     mongo_url: str
     QUIZ_V2_WRITE_MODE: Literal["legacy_only", "dual_write"] = "dual_write"
+    QUIZ_V2_SAVED_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
+    QUIZ_V2_HISTORY_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
+    QUIZ_V2_FOLDER_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
+    QUIZ_V2_SHARE_READ_MODE: Literal["legacy_only", "compare", "v2_only"] = "v2_only"
     QUIZ_V2_FAIL_OPEN: bool = True
     QUIZ_V2_STRUCTURED_LOGGING: bool = True
     V2_BACKFILL_BATCH_SIZE: int = 200

--- a/server/app/db/core/config.py
+++ b/server/app/db/core/config.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -22,6 +22,13 @@ class Settings(BaseSettings):
     QUIZ_V2_WRITE_MODE: Literal["legacy_only", "dual_write"] = "dual_write"
     QUIZ_V2_FAIL_OPEN: bool = True
     QUIZ_V2_STRUCTURED_LOGGING: bool = True
+    V2_BACKFILL_BATCH_SIZE: int = 200
+    V2_BACKFILL_DRY_RUN: bool = True
+    V2_BACKFILL_START_AFTER_ID: Optional[str] = None
+    V2_BACKFILL_LIMIT: Optional[int] = None
+    V2_BACKFILL_COLLECTIONS: str = "quizzes,saved,history,folders"
+    V2_BACKFILL_RUN_ID: Optional[str] = None
+    V2_BACKFILL_LOCK_LEASE_SECONDS: int = 600
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/server/app/db/core/connection.py
+++ b/server/app/db/core/connection.py
@@ -107,6 +107,11 @@ def get_saved_quizzes_collection() -> AsyncIOMotorCollection:
         raise RuntimeError("[DB Error] saved_quizzes_collection has not been initialized properly.")
     return saved_quizzes_collection
 
+def get_quiz_history_collection() -> AsyncIOMotorCollection:
+    if quiz_history_collection is None:
+        raise RuntimeError("[DB Error] quiz_history_collection has not been initialized properly.")
+    return quiz_history_collection
+
 def get_user_tokens_collection() -> AsyncIOMotorCollection:
     if user_tokens_collection is None:
         raise RuntimeError("[DB Error] user_tokens_collection has not been initialized properly.")

--- a/server/app/db/crud/ai_generated_quiz_crud.py
+++ b/server/app/db/crud/ai_generated_quiz_crud.py
@@ -1,11 +1,5 @@
 import logging
 
-from fastapi.encoders import jsonable_encoder
-from pymongo.errors import DuplicateKeyError
-
-from server.app.db.core.config import settings
-from server.app.db.core.connection import get_ai_generated_quizzes_collection
-from server.app.db.models.ai_generated_quiz_model import AIGeneratedQuiz
 from server.app.db.services.quiz_dual_write_service import QuizDualWriteService
 
 
@@ -14,73 +8,19 @@ dual_write_service = QuizDualWriteService()
 
 
 async def save_ai_generated_quiz(quiz_data: dict):
-    """
-    Save an AI-generated quiz to the legacy collection, then mirror it into V2
-    when dual-write is enabled.
-    """
-
-    collection = get_ai_generated_quizzes_collection()
-
     try:
-        new_quiz = AIGeneratedQuiz(**quiz_data)
-        questions_serialized = jsonable_encoder(new_quiz.questions)
-
-        if settings.QUIZ_V2_WRITE_MODE == "v2_only":
-            canonical_quiz = await dual_write_service._mirror_quiz_document(
-                title=quiz_data.get("profession") or "General Knowledge",
-                description=quiz_data.get("custom_instruction"),
-                quiz_type=quiz_data.get("question_type", "multichoice"),
-                owner_user_id=quiz_data.get("user_id"),
-                source="ai",
-                questions=quiz_data["questions"],
-            )
-            return {
-                "message": "Quiz saved successfully",
-                "quiz_id": str(canonical_quiz.id),
-                "duplicate": False,
-            }
-
-        existing_quiz = await collection.find_one({"questions": questions_serialized})
-        if existing_quiz:
-            await dual_write_service.mirror_ai_generated_quiz(str(existing_quiz["_id"]), existing_quiz)
-            logger.info("Duplicate quiz detected based on identical questions. Skipping save.")
-            return {
-                "message": "Quiz with these exact questions already exists",
-                "quiz_id": str(existing_quiz["_id"]),
-                "duplicate": True,
-            }
-
-        quiz_to_save = jsonable_encoder(new_quiz.dict())
-        insert_result = await collection.insert_one(quiz_to_save)
-
-        try:
-            mirrored = await dual_write_service.mirror_ai_generated_quiz(
-                str(insert_result.inserted_id),
-                {**quiz_to_save, "_id": insert_result.inserted_id},
-            )
-            if mirrored:
-                await collection.update_one(
-                    {"_id": insert_result.inserted_id},
-                    {"$set": {"canonical_quiz_id": str(mirrored.id)}},
-                )
-        except Exception as exc:
-            logger.exception(
-                "AI quiz dual-write failed after legacy insert for ai_quiz_id=%s: %s",
-                insert_result.inserted_id,
-                exc,
-            )
-
-        logger.info("Quiz saved successfully with MongoDB _id: %s", insert_result.inserted_id)
+        canonical_quiz = await dual_write_service._mirror_quiz_document(
+            title=quiz_data.get("profession") or "General Knowledge",
+            description=quiz_data.get("custom_instruction"),
+            quiz_type=quiz_data.get("question_type", "multichoice"),
+            owner_user_id=quiz_data.get("user_id"),
+            source="ai",
+            questions=quiz_data["questions"],
+        )
         return {
             "message": "Quiz saved successfully",
-            "quiz_id": str(insert_result.inserted_id),
+            "quiz_id": str(canonical_quiz.id),
             "duplicate": False,
-        }
-    except DuplicateKeyError:
-        logger.warning("Duplicate quiz detected by MongoDB index. Skipping save.")
-        return {
-            "message": "Duplicate quiz detected",
-            "duplicate": True,
         }
     except Exception as exc:
         logger.error("Error saving quiz: %s", exc)

--- a/server/app/db/crud/ai_generated_quiz_crud.py
+++ b/server/app/db/crud/ai_generated_quiz_crud.py
@@ -3,6 +3,7 @@ import logging
 from fastapi.encoders import jsonable_encoder
 from pymongo.errors import DuplicateKeyError
 
+from server.app.db.core.config import settings
 from server.app.db.core.connection import get_ai_generated_quizzes_collection
 from server.app.db.models.ai_generated_quiz_model import AIGeneratedQuiz
 from server.app.db.services.quiz_dual_write_service import QuizDualWriteService
@@ -23,6 +24,21 @@ async def save_ai_generated_quiz(quiz_data: dict):
     try:
         new_quiz = AIGeneratedQuiz(**quiz_data)
         questions_serialized = jsonable_encoder(new_quiz.questions)
+
+        if settings.QUIZ_V2_WRITE_MODE == "v2_only":
+            canonical_quiz = await dual_write_service._mirror_quiz_document(
+                title=quiz_data.get("profession") or "General Knowledge",
+                description=quiz_data.get("custom_instruction"),
+                quiz_type=quiz_data.get("question_type", "multichoice"),
+                owner_user_id=quiz_data.get("user_id"),
+                source="ai",
+                questions=quiz_data["questions"],
+            )
+            return {
+                "message": "Quiz saved successfully",
+                "quiz_id": str(canonical_quiz.id),
+                "duplicate": False,
+            }
 
         existing_quiz = await collection.find_one({"questions": questions_serialized})
         if existing_quiz:

--- a/server/app/db/crud/saved_quiz_crud.py
+++ b/server/app/db/crud/saved_quiz_crud.py
@@ -41,6 +41,16 @@ async def save_quiz(
                 if not getattr(question, "question_type", None):
                     question.question_type = question_type
                 parsed_questions.append(question)
+        if dual_write_service.v2_only_enabled:
+            saved_reference = await dual_write_service.create_saved_quiz_v2(
+                user_id=user_id,
+                title=title,
+                question_type=question_type,
+                questions=parsed_questions,
+                quiz_id=quiz_id,
+            )
+            return str(saved_reference.id)
+
         quiz = SavedQuizModel(
             user_id=user_id,
             quiz_id=quiz_id or str(ObjectId()),
@@ -84,6 +94,12 @@ async def get_saved_quizzes(user_id: str):
 
 
 async def delete_saved_quiz(quiz_id: str, user_id: str):
+    if dual_write_service.v2_only_enabled:
+        return await dual_write_service.delete_saved_quiz_v2(
+            saved_quiz_id=quiz_id,
+            user_id=user_id,
+        )
+
     legacy_quiz = await collection.find_one({"_id": ObjectId(quiz_id), "user_id": user_id})
     result = await collection.delete_one({"_id": ObjectId(quiz_id), "user_id": user_id})
     if result.deleted_count and legacy_quiz and legacy_quiz.get("canonical_quiz_id"):

--- a/server/app/db/crud/saved_quiz_crud.py
+++ b/server/app/db/crud/saved_quiz_crud.py
@@ -1,24 +1,11 @@
-from datetime import datetime
-import logging
-
-from bson import ObjectId
 from pydantic import ValidationError
 
-from ....app.db.core.connection import get_saved_quizzes_collection
-from ....app.db.models.saved_quiz_model import QuizQuestionModel, SavedQuizModel
+from ....app.db.models.saved_quiz_model import QuizQuestionModel
 from ....app.db.services.quiz_dual_write_service import QuizDualWriteService
 
 
-collection = get_saved_quizzes_collection()
 dual_write_service = QuizDualWriteService()
-logger = logging.getLogger(__name__)
-
-
-def model_to_dict(model):
-    dump_fn = getattr(model, "model_dump", None)
-    if callable(dump_fn):
-        return model.model_dump(by_alias=True, exclude_none=True)
-    return model.dict(by_alias=True, exclude_none=True)
+collection = None
 
 
 async def save_quiz(
@@ -41,77 +28,20 @@ async def save_quiz(
                 if not getattr(question, "question_type", None):
                     question.question_type = question_type
                 parsed_questions.append(question)
-        if dual_write_service.v2_only_enabled:
-            saved_reference = await dual_write_service.create_saved_quiz_v2(
-                user_id=user_id,
-                title=title,
-                question_type=question_type,
-                questions=parsed_questions,
-                quiz_id=quiz_id,
-            )
-            return str(saved_reference.id)
 
-        quiz = SavedQuizModel(
+        return await dual_write_service.create_saved_quiz_v2(
             user_id=user_id,
-            quiz_id=quiz_id or str(ObjectId()),
             title=title,
             question_type=question_type,
-            is_deleted=False,
             questions=parsed_questions,
-            created_at=datetime.utcnow(),
+            quiz_id=quiz_id,
         )
-
-        doc = model_to_dict(quiz)
-        if "_id" in doc and doc["_id"] is None:
-            doc.pop("_id")
-
-        result = await collection.insert_one(doc)
-        try:
-            legacy_saved_quiz = await collection.find_one({"_id": result.inserted_id})
-            mirrored = await dual_write_service.mirror_saved_quiz(legacy_saved_quiz)
-            if mirrored:
-                await collection.update_one(
-                    {"_id": result.inserted_id},
-                    {"$set": {"canonical_quiz_id": str(mirrored.id)}},
-                )
-        except Exception as exc:
-            logger.exception(
-                "Saved quiz dual-write failed after legacy insert for saved_quiz_id=%s: %s",
-                result.inserted_id,
-                exc,
-            )
-
-        return str(result.inserted_id)
     except ValidationError as exc:
         raise Exception(f"Validation error: {exc}") from exc
 
 
-async def get_saved_quizzes(user_id: str):
-    quizzes = await collection.find({"user_id": user_id}).sort("created_at", -1).to_list(100)
-    for quiz in quizzes:
-        quiz["_id"] = str(quiz["_id"])
-    return quizzes
-
-
 async def delete_saved_quiz(quiz_id: str, user_id: str):
-    if dual_write_service.v2_only_enabled:
-        return await dual_write_service.delete_saved_quiz_v2(
-            saved_quiz_id=quiz_id,
-            user_id=user_id,
-        )
-
-    legacy_quiz = await collection.find_one({"_id": ObjectId(quiz_id), "user_id": user_id})
-    result = await collection.delete_one({"_id": ObjectId(quiz_id), "user_id": user_id})
-    if result.deleted_count and legacy_quiz and legacy_quiz.get("canonical_quiz_id"):
-        await dual_write_service.reference_repository.delete_saved_quiz(
-            user_id,
-            legacy_quiz["canonical_quiz_id"],
-        )
-    return result.deleted_count > 0
-
-
-async def get_saved_quiz_by_id(quiz_id: str, user_id: str):
-    quiz = await collection.find_one({"_id": ObjectId(quiz_id), "user_id": user_id})
-    if quiz:
-        quiz["_id"] = str(quiz["_id"])
-    return quiz
+    return await dual_write_service.delete_saved_quiz_v2(
+        saved_quiz_id=quiz_id,
+        user_id=user_id,
+    )

--- a/server/app/db/crud/update_quiz_history.py
+++ b/server/app/db/crud/update_quiz_history.py
@@ -2,48 +2,16 @@ import logging
 from datetime import datetime
 from typing import Any, Dict
 
-from ....app.db.core.connection import quiz_history_collection
 from ....app.db.services.quiz_dual_write_service import QuizDualWriteService
 
 
 logger = logging.getLogger(__name__)
 dual_write_service = QuizDualWriteService()
+quiz_history_collection = None
 
 
 async def update_quiz_history(quiz_data: Dict[str, Any]):
     quiz_data["created_at"] = datetime.utcnow()
-    if dual_write_service.v2_only_enabled:
-        history_reference = await dual_write_service.create_quiz_history_v2(quiz_data)
-        logger.info("Quiz history saved for user %s: %s", quiz_data.get("user_id"), str(history_reference.id))
-        return str(history_reference.id)
-
-    result = await quiz_history_collection.insert_one(quiz_data)
-
-    try:
-        legacy_history = await quiz_history_collection.find_one({"_id": result.inserted_id})
-        mirrored = await dual_write_service.mirror_quiz_history(legacy_history)
-        if mirrored:
-            await quiz_history_collection.update_one(
-                {"_id": result.inserted_id},
-                {"$set": {"canonical_quiz_id": str(mirrored.id)}},
-            )
-    except Exception as exc:
-        logger.exception(
-            "Quiz history dual-write failed after legacy insert for history_id=%s: %s",
-            result.inserted_id,
-            exc,
-        )
-
-    logger.info("Quiz saved for user %s: %s", quiz_data.get("user_id"), str(result.inserted_id))
-    return str(result.inserted_id)
-
-
-async def get_quiz_history(user_id: str, limit: int = 100):
-    cursor = quiz_history_collection.find({"user_id": user_id}).sort("created_at", -1)
-    quizzes = await cursor.to_list(length=limit)
-
-    for quiz in quizzes:
-        quiz["_id"] = str(quiz["_id"])
-        if isinstance(quiz.get("created_at"), datetime):
-            quiz["created_at"] = quiz["created_at"].isoformat()
-    return quizzes
+    history_reference = await dual_write_service.create_quiz_history_v2(quiz_data)
+    logger.info("Quiz history saved for user %s: %s", quiz_data.get("user_id"), str(history_reference.id))
+    return history_reference

--- a/server/app/db/crud/update_quiz_history.py
+++ b/server/app/db/crud/update_quiz_history.py
@@ -12,6 +12,11 @@ dual_write_service = QuizDualWriteService()
 
 async def update_quiz_history(quiz_data: Dict[str, Any]):
     quiz_data["created_at"] = datetime.utcnow()
+    if dual_write_service.v2_only_enabled:
+        history_reference = await dual_write_service.create_quiz_history_v2(quiz_data)
+        logger.info("Quiz history saved for user %s: %s", quiz_data.get("user_id"), str(history_reference.id))
+        return str(history_reference.id)
+
     result = await quiz_history_collection.insert_one(quiz_data)
 
     try:

--- a/server/app/db/routes/folder_routes.py
+++ b/server/app/db/routes/folder_routes.py
@@ -36,9 +36,11 @@ from ....app.db.crud.folder_crud import (
 from ....app.db.core.connection import get_saved_quizzes_collection
 
 from ....app.db.models.folder_model import FolderCreate, BulkDeleteFoldersRequest, BulkRemoveRequest
+from ....app.db.services.quiz_dual_write_service import QuizDualWriteService
 from ....app.db.services.quiz_user_library_read_service import QuizUserLibraryReadService
 
 from ....app.dependancies import get_current_user
+from ....app.db.core.config import settings
 
 
 router = APIRouter(tags=["Folders"])
@@ -46,6 +48,7 @@ router = APIRouter(tags=["Folders"])
 
 saved_quizzes_collection = get_saved_quizzes_collection()
 read_service = QuizUserLibraryReadService()
+write_service = QuizDualWriteService()
 
 
 
@@ -78,6 +81,23 @@ class RenameFolderRequest(BaseModel):
 async def create_new_folder(folder: FolderCreate, user = Depends(get_current_user)):
 
     folder.user_id = user.id
+    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
+        new_folder = await write_service.create_folder_v2(
+            user_id=user.id,
+            name=folder.name,
+        )
+        return {
+            "message": "Folder created successfully",
+            "folder": {
+                "id": str(new_folder.id),
+                "_id": str(new_folder.id),
+                "user_id": new_folder.user_id,
+                "name": new_folder.name,
+                "quizzes": [],
+                "created_at": new_folder.created_at.isoformat(),
+                "updated_at": new_folder.updated_at.isoformat(),
+            },
+        }
 
     new_folder = await create_folder(folder.dict())
 
@@ -121,12 +141,23 @@ async def rename_existing_folder(
     user = Depends(get_current_user),
 
 ):
-
-    folder = await get_folder_by_id(folder_id)
-
-    if not folder or folder["user_id"] != user.id:
-
+    try:
+        folder = await read_service.get_folder_by_id(folder_id, user.id)
+    except PermissionError:
         raise HTTPException(status_code=403, detail="Unauthorized access to folder")
+
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+
+    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
+        updated = await write_service.rename_folder_v2(
+            folder_id=folder_id,
+            user_id=user.id,
+            new_name=payload.new_name,
+        )
+        if not updated:
+            raise HTTPException(status_code=404, detail="Folder not found")
+        return {"message": "Folder renamed successfully"}
 
     await rename_folder(folder_id, payload.new_name)
 
@@ -137,12 +168,19 @@ async def rename_existing_folder(
 @router.delete("/{folder_id}")
 
 async def delete_existing_folder(folder_id: str, user = Depends(get_current_user)):
-
-    folder = await get_folder_by_id(folder_id)
-
-    if not folder or folder["user_id"] != user.id:
-
+    try:
+        folder = await read_service.get_folder_by_id(folder_id, user.id)
+    except PermissionError:
         raise HTTPException(status_code=403, detail="Unauthorized access to folder")
+
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+
+    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
+        deleted = await write_service.delete_folder_v2(folder_id=folder_id, user_id=user.id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Folder not found")
+        return {"message": "Folder deleted successfully"}
 
     await delete_folder(folder_id)
 
@@ -158,13 +196,19 @@ async def bulk_delete_folders_route(req: BulkDeleteFoldersRequest = Body(...), u
 
     for fid in req.folder_ids:
 
-        folder = await get_folder_by_id(fid)
+        try:
+            folder = await read_service.get_folder_by_id(fid, user.id)
+        except PermissionError:
+            folder = None
 
-        if folder and folder["user_id"] == user.id:
-
-            await bulk_delete_folders([fid])
-
-            deleted_count += 1
+        if folder:
+            if settings.QUIZ_V2_WRITE_MODE == "v2_only":
+                deleted = await write_service.delete_folder_v2(folder_id=fid, user_id=user.id)
+                if deleted:
+                    deleted_count += 1
+            else:
+                await bulk_delete_folders([fid])
+                deleted_count += 1
 
     return {"deleted": deleted_count}
 
@@ -175,12 +219,35 @@ async def bulk_delete_folders_route(req: BulkDeleteFoldersRequest = Body(...), u
 @router.post("/{folder_id}/add_quiz")
 
 async def add_quiz_to_folder_route(folder_id: str, quiz_data: QuizData, user = Depends(get_current_user)):
-
-    folder = await get_folder_by_id(folder_id)
-
-    if not folder or folder["user_id"] != user.id:
-
+    try:
+        folder = await read_service.get_folder_by_id(folder_id, user.id)
+    except PermissionError:
         raise HTTPException(status_code=403, detail="Unauthorized access to folder")
+
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+
+    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
+        try:
+            _folder_v2, folder_item = await write_service.add_saved_quiz_to_folder_v2(
+                folder_id=folder_id,
+                saved_quiz_id=quiz_data.quiz_id,
+                user_id=user.id,
+            )
+        except PermissionError:
+            raise HTTPException(status_code=403, detail="Unauthorized access to folder")
+        except ValueError as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+
+        return {
+            "message": "Quiz added to folder successfully",
+            "quiz": {
+                "id": str(folder_item.id),
+                "_id": str(folder_item.id),
+                "title": folder_item.display_title,
+                "canonical_quiz_id": folder_item.quiz_id,
+            },
+        }
 
 
     quiz_id = quiz_data.quiz_id
@@ -241,13 +308,23 @@ async def add_quiz_to_folder_route(folder_id: str, quiz_data: QuizData, user = D
 @router.post("/{folder_id}/remove/{quiz_id}")
 
 async def remove_quiz(folder_id: str, quiz_id: str, user = Depends(get_current_user)):
-
-    folder = await get_folder_by_id(folder_id)
-
-    if not folder or folder["user_id"] != user.id:
-
+    try:
+        folder = await read_service.get_folder_by_id(folder_id, user.id)
+    except PermissionError:
         raise HTTPException(status_code=403, detail="Unauthorized access to folder")
 
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+
+    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
+        removed = await write_service.remove_folder_item_v2(
+            folder_id=folder_id,
+            folder_item_id=quiz_id,
+            user_id=user.id,
+        )
+        if not removed:
+            raise HTTPException(status_code=404, detail="Quiz not found in folder")
+        return {"message": "Quiz removed from folder"}
 
     await remove_quiz_from_folder(folder_id, quiz_id)
 
@@ -258,24 +335,28 @@ async def remove_quiz(folder_id: str, quiz_id: str, user = Depends(get_current_u
 @router.patch("/move_quiz")
 
 async def move_quiz_between_folders_route(request: MoveQuizRequest, user = Depends(get_current_user)):
-
-    source = await get_folder_by_id(request.from_folder_id)
-
-    target = await get_folder_by_id(request.to_folder_id)
-
-    if not source or not target:
-
-        raise HTTPException(status_code=404, detail="Folder not found")
-
-    if source["user_id"] != user.id or target["user_id"] != user.id:
-
+    try:
+        source = await read_service.get_folder_by_id(request.from_folder_id, user.id)
+        target = await read_service.get_folder_by_id(request.to_folder_id, user.id)
+    except PermissionError:
         raise HTTPException(status_code=403, detail="Unauthorized access")
 
+    if not source or not target:
+        raise HTTPException(status_code=404, detail="Folder not found")
+
+    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
+        moved = await write_service.move_folder_item_v2(
+            folder_item_id=request.quiz_id,
+            source_folder_id=request.from_folder_id,
+            target_folder_id=request.to_folder_id,
+            user_id=user.id,
+        )
+        if not moved:
+            raise HTTPException(status_code=404, detail="Quiz not found in source folder")
+        return {"message": "Quiz moved successfully", "result": None}
 
     result = await move_quiz_between_folders(
-
         request.from_folder_id, request.to_folder_id, request.quiz_id
-
     )
 
     return {"message": "Quiz moved successfully", "result": result}
@@ -285,13 +366,24 @@ async def move_quiz_between_folders_route(request: MoveQuizRequest, user = Depen
 @router.post("/{folder_id}/bulk_remove")
 
 async def bulk_remove_quizzes(folder_id: str, request: BulkRemoveRequest, user = Depends(get_current_user)):
-
-    folder = await get_folder_by_id(folder_id)
-
-    if not folder or folder["user_id"] != user.id:
-
+    try:
+        folder = await read_service.get_folder_by_id(folder_id, user.id)
+    except PermissionError:
         raise HTTPException(status_code=403, detail="Unauthorized access")
 
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+
+    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
+        removed = 0
+        for quiz_id in request.quiz_ids:
+            if await write_service.remove_folder_item_v2(
+                folder_id=folder_id,
+                folder_item_id=quiz_id,
+                user_id=user.id,
+            ):
+                removed += 1
+        return {"message": "Quizzes removed successfully", "removed": removed}
 
     await bulk_remove_quizzes_from_folder(folder_id, request.quiz_ids)
 

--- a/server/app/db/routes/folder_routes.py
+++ b/server/app/db/routes/folder_routes.py
@@ -1,123 +1,58 @@
-from fastapi import APIRouter, HTTPException, Body, Depends
-
+from fastapi import APIRouter, Body, Depends, HTTPException
 from pydantic import BaseModel
 
-from typing import List
-
-from datetime import datetime
-
-from bson import ObjectId
-
-
-from ....app.db.crud.folder_crud import (
-
-    create_folder,
-
-    get_user_folders,
-
-    add_quiz_to_folder,
-
-    remove_quiz_from_folder,
-
-    rename_folder,
-
-    delete_folder,
-
-    get_folder_by_id,
-
-    move_quiz_between_folders,
-
-    bulk_delete_folders,
-
-    bulk_remove_quizzes_from_folder,
-
-)
-
-from ....app.db.core.connection import get_saved_quizzes_collection
-
-from ....app.db.models.folder_model import FolderCreate, BulkDeleteFoldersRequest, BulkRemoveRequest
+from ....app.db.models.folder_model import BulkDeleteFoldersRequest, BulkRemoveRequest, FolderCreate
 from ....app.db.services.quiz_dual_write_service import QuizDualWriteService
 from ....app.db.services.quiz_user_library_read_service import QuizUserLibraryReadService
-
 from ....app.dependancies import get_current_user
-from ....app.db.core.config import settings
 
 
 router = APIRouter(tags=["Folders"])
-
-
-saved_quizzes_collection = get_saved_quizzes_collection()
 read_service = QuizUserLibraryReadService()
 write_service = QuizDualWriteService()
 
 
-
 class QuizData(BaseModel):
-
     quiz_id: str
-
 
 
 class MoveQuizRequest(BaseModel):
-
     quiz_id: str
-
     from_folder_id: str
-
     to_folder_id: str
 
 
-
 class RenameFolderRequest(BaseModel):
-
     new_name: str
 
 
-
-
-
 @router.post("/create")
-
-async def create_new_folder(folder: FolderCreate, user = Depends(get_current_user)):
-
-    folder.user_id = user.id
-    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
-        new_folder = await write_service.create_folder_v2(
-            user_id=user.id,
-            name=folder.name,
-        )
-        return {
-            "message": "Folder created successfully",
-            "folder": {
-                "id": str(new_folder.id),
-                "_id": str(new_folder.id),
-                "user_id": new_folder.user_id,
-                "name": new_folder.name,
-                "quizzes": [],
-                "created_at": new_folder.created_at.isoformat(),
-                "updated_at": new_folder.updated_at.isoformat(),
-            },
-        }
-
-    new_folder = await create_folder(folder.dict())
-
-    return {"message": "Folder created successfully", "folder": new_folder}
-
+async def create_new_folder(folder: FolderCreate, user=Depends(get_current_user)):
+    new_folder = await write_service.create_folder_v2(
+        user_id=user.id,
+        name=folder.name,
+    )
+    return {
+        "message": "Folder created successfully",
+        "folder": {
+            "id": str(new_folder.id),
+            "user_id": new_folder.user_id,
+            "name": new_folder.name,
+            "quizzes": [],
+            "quiz_count": 0,
+            "created_at": new_folder.created_at.isoformat(),
+            "updated_at": new_folder.updated_at.isoformat(),
+        },
+    }
 
 
 @router.get("/")
-
-async def get_folders_for_user(user = Depends(get_current_user)):
-
-    folders = await read_service.get_user_folders(user.id)
-
-    return folders
-
+async def get_folders_for_user(user=Depends(get_current_user)):
+    return await read_service.get_user_folders(user.id)
 
 
 @router.get("/view/{folder_id}")
-
-async def get_folder_by_id_route(folder_id: str, user = Depends(get_current_user)):
+async def get_folder_by_id_route(folder_id: str, user=Depends(get_current_user)):
     try:
         folder = await read_service.get_folder_by_id(folder_id, user.id)
     except PermissionError:
@@ -129,262 +64,95 @@ async def get_folder_by_id_route(folder_id: str, user = Depends(get_current_user
     return folder
 
 
-
 @router.put("/{folder_id}/rename")
-
 async def rename_existing_folder(
-
     folder_id: str,
-
     payload: RenameFolderRequest,
-
-    user = Depends(get_current_user),
-
+    user=Depends(get_current_user),
 ):
-    try:
-        folder = await read_service.get_folder_by_id(folder_id, user.id)
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="Unauthorized access to folder")
-
-    if not folder:
+    updated = await write_service.rename_folder_v2(
+        folder_id=folder_id,
+        user_id=user.id,
+        new_name=payload.new_name,
+    )
+    if not updated:
         raise HTTPException(status_code=404, detail="Folder not found")
-
-    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
-        updated = await write_service.rename_folder_v2(
-            folder_id=folder_id,
-            user_id=user.id,
-            new_name=payload.new_name,
-        )
-        if not updated:
-            raise HTTPException(status_code=404, detail="Folder not found")
-        return {"message": "Folder renamed successfully"}
-
-    await rename_folder(folder_id, payload.new_name)
-
     return {"message": "Folder renamed successfully"}
 
 
-
 @router.delete("/{folder_id}")
-
-async def delete_existing_folder(folder_id: str, user = Depends(get_current_user)):
-    try:
-        folder = await read_service.get_folder_by_id(folder_id, user.id)
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="Unauthorized access to folder")
-
-    if not folder:
+async def delete_existing_folder(folder_id: str, user=Depends(get_current_user)):
+    deleted = await write_service.delete_folder_v2(folder_id=folder_id, user_id=user.id)
+    if not deleted:
         raise HTTPException(status_code=404, detail="Folder not found")
-
-    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
-        deleted = await write_service.delete_folder_v2(folder_id=folder_id, user_id=user.id)
-        if not deleted:
-            raise HTTPException(status_code=404, detail="Folder not found")
-        return {"message": "Folder deleted successfully"}
-
-    await delete_folder(folder_id)
-
     return {"message": "Folder deleted successfully"}
 
 
-
 @router.delete("/bulk_delete")
-
-async def bulk_delete_folders_route(req: BulkDeleteFoldersRequest = Body(...), user = Depends(get_current_user)):
-
+async def bulk_delete_folders_route(req: BulkDeleteFoldersRequest = Body(...), user=Depends(get_current_user)):
     deleted_count = 0
-
-    for fid in req.folder_ids:
-
-        try:
-            folder = await read_service.get_folder_by_id(fid, user.id)
-        except PermissionError:
-            folder = None
-
-        if folder:
-            if settings.QUIZ_V2_WRITE_MODE == "v2_only":
-                deleted = await write_service.delete_folder_v2(folder_id=fid, user_id=user.id)
-                if deleted:
-                    deleted_count += 1
-            else:
-                await bulk_delete_folders([fid])
-                deleted_count += 1
-
+    for folder_id in req.folder_ids:
+        if await write_service.delete_folder_v2(folder_id=folder_id, user_id=user.id):
+            deleted_count += 1
     return {"deleted": deleted_count}
 
 
-
-
-
 @router.post("/{folder_id}/add_quiz")
-
-async def add_quiz_to_folder_route(folder_id: str, quiz_data: QuizData, user = Depends(get_current_user)):
+async def add_quiz_to_folder_route(folder_id: str, quiz_data: QuizData, user=Depends(get_current_user)):
     try:
-        folder = await read_service.get_folder_by_id(folder_id, user.id)
+        _folder_v2, folder_item = await write_service.add_saved_quiz_to_folder_v2(
+            folder_id=folder_id,
+            saved_quiz_id=quiz_data.quiz_id,
+            user_id=user.id,
+        )
     except PermissionError:
         raise HTTPException(status_code=403, detail="Unauthorized access to folder")
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
 
-    if not folder:
-        raise HTTPException(status_code=404, detail="Folder not found")
-
-    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
-        try:
-            _folder_v2, folder_item = await write_service.add_saved_quiz_to_folder_v2(
-                folder_id=folder_id,
-                saved_quiz_id=quiz_data.quiz_id,
-                user_id=user.id,
-            )
-        except PermissionError:
-            raise HTTPException(status_code=403, detail="Unauthorized access to folder")
-        except ValueError as exc:
-            raise HTTPException(status_code=404, detail=str(exc))
-
-        return {
-            "message": "Quiz added to folder successfully",
-            "quiz": {
-                "id": str(folder_item.id),
-                "_id": str(folder_item.id),
-                "title": folder_item.display_title,
-                "canonical_quiz_id": folder_item.quiz_id,
-            },
-        }
-
-
-    quiz_id = quiz_data.quiz_id
-
-    quiz = await saved_quizzes_collection.find_one({"_id": ObjectId(quiz_id)})
-
-    if not quiz:
-
-        raise HTTPException(status_code=404, detail="Quiz not found in saved quizzes")
-
-
-    def convert_object_ids(doc):
-
-        if isinstance(doc, dict):
-
-            return {k: convert_object_ids(v) for k, v in doc.items()}
-
-        elif isinstance(doc, list):
-
-            return [convert_object_ids(i) for i in doc]
-
-        elif isinstance(doc, ObjectId):
-
-            return str(doc)
-
-        return doc
-
-
-    quiz_entry = {
-
-        "_id": str(ObjectId()),
-
-        "original_quiz_id": str(quiz["_id"]),
-        "quiz_id": quiz.get("quiz_id"),
-        "canonical_quiz_id": quiz.get("canonical_quiz_id"),
-
-        "title": quiz.get("title", "Untitled Quiz"),
-
-        "question_type": quiz.get("question_type", "N/A"),
-
-        "questions": quiz.get("questions", []),
-
-        "created_at": quiz.get("created_at"),
-
-        "added_on": datetime.utcnow(),
-
-        "quiz_data": convert_object_ids(quiz),
-
+    return {
+        "message": "Quiz added to folder successfully",
+        "quiz": {
+            "id": str(folder_item.id),
+            "title": folder_item.display_title,
+            "quiz_id": folder_item.quiz_id,
+        },
     }
 
 
-    await add_quiz_to_folder(folder_id, quiz_entry)
-
-    return {"message": "Quiz added to folder successfully", "quiz": quiz_entry}
-
-
-
 @router.post("/{folder_id}/remove/{quiz_id}")
-
-async def remove_quiz(folder_id: str, quiz_id: str, user = Depends(get_current_user)):
-    try:
-        folder = await read_service.get_folder_by_id(folder_id, user.id)
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="Unauthorized access to folder")
-
-    if not folder:
-        raise HTTPException(status_code=404, detail="Folder not found")
-
-    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
-        removed = await write_service.remove_folder_item_v2(
-            folder_id=folder_id,
-            folder_item_id=quiz_id,
-            user_id=user.id,
-        )
-        if not removed:
-            raise HTTPException(status_code=404, detail="Quiz not found in folder")
-        return {"message": "Quiz removed from folder"}
-
-    await remove_quiz_from_folder(folder_id, quiz_id)
-
+async def remove_quiz(folder_id: str, quiz_id: str, user=Depends(get_current_user)):
+    removed = await write_service.remove_folder_item_v2(
+        folder_id=folder_id,
+        folder_item_id=quiz_id,
+        user_id=user.id,
+    )
+    if not removed:
+        raise HTTPException(status_code=404, detail="Quiz not found in folder")
     return {"message": "Quiz removed from folder"}
 
 
-
 @router.patch("/move_quiz")
-
-async def move_quiz_between_folders_route(request: MoveQuizRequest, user = Depends(get_current_user)):
-    try:
-        source = await read_service.get_folder_by_id(request.from_folder_id, user.id)
-        target = await read_service.get_folder_by_id(request.to_folder_id, user.id)
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="Unauthorized access")
-
-    if not source or not target:
-        raise HTTPException(status_code=404, detail="Folder not found")
-
-    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
-        moved = await write_service.move_folder_item_v2(
-            folder_item_id=request.quiz_id,
-            source_folder_id=request.from_folder_id,
-            target_folder_id=request.to_folder_id,
-            user_id=user.id,
-        )
-        if not moved:
-            raise HTTPException(status_code=404, detail="Quiz not found in source folder")
-        return {"message": "Quiz moved successfully", "result": None}
-
-    result = await move_quiz_between_folders(
-        request.from_folder_id, request.to_folder_id, request.quiz_id
+async def move_quiz_between_folders_route(request: MoveQuizRequest, user=Depends(get_current_user)):
+    moved = await write_service.move_folder_item_v2(
+        folder_item_id=request.quiz_id,
+        source_folder_id=request.from_folder_id,
+        target_folder_id=request.to_folder_id,
+        user_id=user.id,
     )
-
-    return {"message": "Quiz moved successfully", "result": result}
-
+    if not moved:
+        raise HTTPException(status_code=404, detail="Quiz not found in source folder")
+    return {"message": "Quiz moved successfully"}
 
 
 @router.post("/{folder_id}/bulk_remove")
-
-async def bulk_remove_quizzes(folder_id: str, request: BulkRemoveRequest, user = Depends(get_current_user)):
-    try:
-        folder = await read_service.get_folder_by_id(folder_id, user.id)
-    except PermissionError:
-        raise HTTPException(status_code=403, detail="Unauthorized access")
-
-    if not folder:
-        raise HTTPException(status_code=404, detail="Folder not found")
-
-    if settings.QUIZ_V2_WRITE_MODE == "v2_only":
-        removed = 0
-        for quiz_id in request.quiz_ids:
-            if await write_service.remove_folder_item_v2(
-                folder_id=folder_id,
-                folder_item_id=quiz_id,
-                user_id=user.id,
-            ):
-                removed += 1
-        return {"message": "Quizzes removed successfully", "removed": removed}
-
-    await bulk_remove_quizzes_from_folder(folder_id, request.quiz_ids)
-
-    return {"message": "Quizzes removed successfully"}
+async def bulk_remove_quizzes(folder_id: str, request: BulkRemoveRequest, user=Depends(get_current_user)):
+    removed = 0
+    for quiz_id in request.quiz_ids:
+        if await write_service.remove_folder_item_v2(
+            folder_id=folder_id,
+            folder_item_id=quiz_id,
+            user_id=user.id,
+        ):
+            removed += 1
+    return {"message": "Quizzes removed successfully", "removed": removed}

--- a/server/app/db/routes/folder_routes.py
+++ b/server/app/db/routes/folder_routes.py
@@ -36,6 +36,7 @@ from ....app.db.crud.folder_crud import (
 from ....app.db.core.connection import get_saved_quizzes_collection
 
 from ....app.db.models.folder_model import FolderCreate, BulkDeleteFoldersRequest, BulkRemoveRequest
+from ....app.db.services.quiz_user_library_read_service import QuizUserLibraryReadService
 
 from ....app.dependancies import get_current_user
 
@@ -44,6 +45,7 @@ router = APIRouter(tags=["Folders"])
 
 
 saved_quizzes_collection = get_saved_quizzes_collection()
+read_service = QuizUserLibraryReadService()
 
 
 
@@ -87,7 +89,7 @@ async def create_new_folder(folder: FolderCreate, user = Depends(get_current_use
 
 async def get_folders_for_user(user = Depends(get_current_user)):
 
-    folders = await get_user_folders(user.id)
+    folders = await read_service.get_user_folders(user.id)
 
     return folders
 
@@ -96,16 +98,13 @@ async def get_folders_for_user(user = Depends(get_current_user)):
 @router.get("/view/{folder_id}")
 
 async def get_folder_by_id_route(folder_id: str, user = Depends(get_current_user)):
-
-    folder = await get_folder_by_id(folder_id)
+    try:
+        folder = await read_service.get_folder_by_id(folder_id, user.id)
+    except PermissionError:
+        raise HTTPException(status_code=403, detail="Unauthorized access to folder")
 
     if not folder:
-
         raise HTTPException(status_code=404, detail="Folder not found")
-
-    if folder["user_id"] != user.id:
-
-        raise HTTPException(status_code=403, detail="Unauthorized access to folder")
 
     return folder
 

--- a/server/app/db/routes/get_quiz_history.py
+++ b/server/app/db/routes/get_quiz_history.py
@@ -1,11 +1,11 @@
 from fastapi import APIRouter, Depends
 
 from ....app.dependancies import get_current_user
-
-from ....app.db.crud.update_quiz_history import get_quiz_history
+from ....app.db.services.quiz_user_library_read_service import QuizUserLibraryReadService
 
 
 router = APIRouter()
+read_service = QuizUserLibraryReadService()
 
 
 @router.get("/quiz-history")
@@ -19,7 +19,6 @@ async def get_user_quiz_history(current_user=Depends(get_current_user)):
 
     user_id = current_user.id
 
-    quizzes = await get_quiz_history(user_id)
+    quizzes = await read_service.get_quiz_history_for_user(user_id)
 
     return quizzes
-

--- a/server/app/db/routes/get_quiz_history.py
+++ b/server/app/db/routes/get_quiz_history.py
@@ -17,7 +17,7 @@ async def get_user_quiz_history(current_user=Depends(get_current_user)):
     JWT token required in Authorization header.
     """
 
-    user_id = current_user.id
+    user_id = str(current_user.id)
 
     quizzes = await read_service.get_quiz_history_for_user(user_id)
 

--- a/server/app/db/routes/save_quiz_history.py
+++ b/server/app/db/routes/save_quiz_history.py
@@ -20,6 +20,10 @@ async def save_quiz(quiz: QuizHistoryModel, current_user=Depends(get_current_use
 
     inserted_id = await update_quiz_history(quiz_dict)
 
-    return {"message": "Quiz saved", "quiz_id": inserted_id}
-
+    return {
+        "message": "Quiz saved",
+        "id": inserted_id,
+        "history_id": inserted_id,
+        "quiz_id": inserted_id,
+    }
 

--- a/server/app/db/routes/save_quiz_history.py
+++ b/server/app/db/routes/save_quiz_history.py
@@ -14,16 +14,14 @@ router = APIRouter()
 
 async def save_quiz(quiz: QuizHistoryModel, current_user=Depends(get_current_user)):
 
-    quiz.user_id = current_user.id
+    quiz.user_id = str(current_user.id)
 
     quiz_dict = quiz.model_dump(by_alias=True, exclude_none=True)
 
-    inserted_id = await update_quiz_history(quiz_dict)
+    history_reference = await update_quiz_history(quiz_dict)
 
     return {
         "message": "Quiz saved",
-        "id": inserted_id,
-        "history_id": inserted_id,
-        "quiz_id": inserted_id,
+        "id": str(history_reference.id),
+        "quiz_id": history_reference.quiz_id,
     }
-

--- a/server/app/db/routes/saved_quizzes.py
+++ b/server/app/db/routes/saved_quizzes.py
@@ -1,18 +1,6 @@
 from fastapi import APIRouter, HTTPException, Depends, status
 
-from bson import ObjectId
-
-from ....app.db.crud.saved_quiz_crud import (
-
-    save_quiz,
-
-    get_saved_quizzes,
-
-    delete_saved_quiz,
-
-    get_saved_quiz_by_id,
-
-)
+from ....app.db.crud.saved_quiz_crud import delete_saved_quiz, save_quiz
 
 from ....app.db.models.saved_quiz_model import SavedQuizModel
 from ....app.db.services.quiz_user_library_read_service import QuizUserLibraryReadService
@@ -39,11 +27,7 @@ async def create_saved_quiz(
     try:
 
         quiz.user_id = str(current_user.id)
-
-        print("Received quiz payload:", quiz.dict())
-
-
-        saved_quiz_id = await save_quiz(
+        saved_quiz = await save_quiz(
 
             user_id=quiz.user_id,
 
@@ -58,14 +42,14 @@ async def create_saved_quiz(
 
         return {
             "message": "Quiz saved successfully",
-            "id": saved_quiz_id,
-            "saved_quiz_id": saved_quiz_id,
-            "quiz_id": saved_quiz_id,
+            "id": str(saved_quiz.id),
+            "quiz_id": saved_quiz.quiz_id,
         }
 
 
+    except HTTPException:
+        raise
     except Exception as e:
-
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -83,8 +67,9 @@ async def list_saved_quizzes(
 
         return quizzes
 
+    except HTTPException:
+        raise
     except Exception as e:
-
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -108,8 +93,9 @@ async def remove_saved_quiz(
 
         return {"message": "Quiz deleted successfully"}
 
+    except HTTPException:
+        raise
     except Exception as e:
-
         raise HTTPException(status_code=500, detail=str(e))
 
 
@@ -124,12 +110,6 @@ async def get_saved_quiz(
 ):
 
     try:
-
-        if not ObjectId.is_valid(quiz_id):
-
-            raise HTTPException(status_code=400, detail="Invalid quiz ID")
-
-
         quiz = await read_service.get_saved_quiz_by_id(quiz_id, user_id=str(current_user.id))
 
         if not quiz or quiz.get("user_id") != str(current_user.id):
@@ -139,6 +119,7 @@ async def get_saved_quiz(
 
         return quiz
 
+    except HTTPException:
+        raise
     except Exception as e:
-
         raise HTTPException(status_code=500, detail=str(e))

--- a/server/app/db/routes/saved_quizzes.py
+++ b/server/app/db/routes/saved_quizzes.py
@@ -43,7 +43,7 @@ async def create_saved_quiz(
         print("Received quiz payload:", quiz.dict())
 
 
-        quiz_id = await save_quiz(
+        saved_quiz_id = await save_quiz(
 
             user_id=quiz.user_id,
 
@@ -56,7 +56,12 @@ async def create_saved_quiz(
 
         )
 
-        return {"message": "Quiz saved successfully", "quiz_id": quiz_id}
+        return {
+            "message": "Quiz saved successfully",
+            "id": saved_quiz_id,
+            "saved_quiz_id": saved_quiz_id,
+            "quiz_id": saved_quiz_id,
+        }
 
 
     except Exception as e:

--- a/server/app/db/routes/saved_quizzes.py
+++ b/server/app/db/routes/saved_quizzes.py
@@ -15,6 +15,7 @@ from ....app.db.crud.saved_quiz_crud import (
 )
 
 from ....app.db.models.saved_quiz_model import SavedQuizModel
+from ....app.db.services.quiz_user_library_read_service import QuizUserLibraryReadService
 
 from ....app.dependancies import get_current_user
 
@@ -22,6 +23,7 @@ from ....app.db.schemas.user_schemas import UserResponseSchema
 
 
 router = APIRouter(prefix="/saved-quizzes", tags=["Saved Quizzes"])
+read_service = QuizUserLibraryReadService()
 
 
 @router.post("/", status_code=status.HTTP_201_CREATED)
@@ -72,7 +74,7 @@ async def list_saved_quizzes(
 
     try:
 
-        quizzes = await get_saved_quizzes(user_id=str(current_user.id))
+        quizzes = await read_service.get_saved_quizzes_for_user(user_id=str(current_user.id))
 
         return quizzes
 
@@ -123,7 +125,7 @@ async def get_saved_quiz(
             raise HTTPException(status_code=400, detail="Invalid quiz ID")
 
 
-        quiz = await get_saved_quiz_by_id(quiz_id, user_id=str(current_user.id))
+        quiz = await read_service.get_saved_quiz_by_id(quiz_id, user_id=str(current_user.id))
 
         if not quiz or quiz.get("user_id") != str(current_user.id):
 

--- a/server/app/db/services/legacy_quiz_resolution_service.py
+++ b/server/app/db/services/legacy_quiz_resolution_service.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from bson import ObjectId
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from server.app.db.crud.quiz_write_service import CanonicalQuizWriteService
+
+
+@dataclass
+class LegacySourceQuizMatch:
+    source_collection: str
+    legacy_quiz_id: str
+    document: dict[str, Any]
+
+
+class LegacyQuizStructureConflictError(ValueError):
+    def __init__(
+        self,
+        *,
+        title: str,
+        quiz_type: str,
+        candidates: list[dict[str, Any]],
+    ):
+        self.title = title
+        self.quiz_type = quiz_type
+        self.candidates = candidates
+        candidate_ids = ", ".join(candidate["legacy_quiz_id"] for candidate in candidates)
+        super().__init__(
+            f"Multiple legacy source matches for '{title}' ({quiz_type}): {candidate_ids}"
+        )
+
+    def to_log_fields(self) -> dict[str, Any]:
+        return {
+            "title": self.title,
+            "quiz_type": self.quiz_type,
+            "candidate_ids": [candidate["legacy_quiz_id"] for candidate in self.candidates],
+            "candidates": self.candidates,
+        }
+
+
+class LegacyQuizResolutionService:
+    def __init__(
+        self,
+        *,
+        canonical_service: CanonicalQuizWriteService,
+        ai_generated_quizzes_collection: AsyncIOMotorCollection,
+        quizzes_collection: AsyncIOMotorCollection,
+    ):
+        self.canonical_service = canonical_service
+        self.ai_generated_quizzes_collection = ai_generated_quizzes_collection
+        self.quizzes_collection = quizzes_collection
+
+    @staticmethod
+    def _coerce_object_id(value: str | None):
+        if not value:
+            return None
+        try:
+            return ObjectId(value)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _normalize_title(value: str | None) -> str:
+        if not value:
+            return ""
+        normalized = re.sub(r"\s+", " ", value.strip().casefold())
+        if normalized.endswith(" quiz"):
+            normalized = normalized[:-5].strip()
+        return normalized
+
+    @staticmethod
+    def _candidate_display_title(document: dict[str, Any]) -> str:
+        return document.get("profession") or document.get("title") or "Untitled Quiz"
+
+    def _build_question_structure_fingerprint(self, *, quiz_type: str, questions: list[Any]) -> str:
+        normalized_questions = self.canonical_service.normalize_questions(questions)
+        structure_payload = {
+            "quiz_type": quiz_type,
+            "questions": [
+                {
+                    "question": question.get("question"),
+                    "options": question.get("options"),
+                }
+                for question in normalized_questions
+            ],
+        }
+        return self.canonical_service.build_content_fingerprint(structure_payload)
+
+    async def resolve_from_canonical_backref(self, canonical_quiz_id: str | None):
+        if not canonical_quiz_id:
+            return None
+        return await self.canonical_service.get_quiz_v2_by_id(canonical_quiz_id)
+
+    async def resolve_from_source_quiz_id(self, source_quiz_id: str | None):
+        if not source_quiz_id:
+            return None
+
+        for collection_name in ("ai_generated_quizzes", "quizzes"):
+            canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
+                collection_name,
+                source_quiz_id,
+            )
+            if canonical_quiz:
+                return canonical_quiz
+
+        object_id = self._coerce_object_id(source_quiz_id)
+
+        legacy_ai = await self.ai_generated_quizzes_collection.find_one(
+            {"_id": object_id if object_id is not None else source_quiz_id}
+        )
+        if legacy_ai and legacy_ai.get("canonical_quiz_id"):
+            canonical_quiz = await self.resolve_from_canonical_backref(legacy_ai["canonical_quiz_id"])
+            if canonical_quiz:
+                return canonical_quiz
+
+        legacy_manual = await self.quizzes_collection.find_one(
+            {"_id": object_id if object_id is not None else source_quiz_id}
+        )
+        if legacy_manual and legacy_manual.get("canonical_quiz_id"):
+            return await self.resolve_from_canonical_backref(legacy_manual["canonical_quiz_id"])
+
+        return None
+
+    async def _find_structure_candidates(
+        self,
+        *,
+        collection_name: str,
+        collection: AsyncIOMotorCollection,
+        target_fingerprint: str,
+        quiz_type: str,
+    ) -> list[LegacySourceQuizMatch]:
+        candidates: list[LegacySourceQuizMatch] = []
+        async for document in collection.find(
+            {"question_type": quiz_type},
+            {
+                "_id": 1,
+                "profession": 1,
+                "title": 1,
+                "question_type": 1,
+                "quiz_type": 1,
+                "questions": 1,
+                "custom_instruction": 1,
+                "description": 1,
+                "user_id": 1,
+                "owner_id": 1,
+                "canonical_quiz_id": 1,
+            },
+        ):
+            candidate_type = document.get("question_type") or document.get("quiz_type") or "multichoice"
+            candidate_fingerprint = self._build_question_structure_fingerprint(
+                quiz_type=candidate_type,
+                questions=document.get("questions", []),
+            )
+            if candidate_fingerprint != target_fingerprint:
+                continue
+            candidates.append(
+                LegacySourceQuizMatch(
+                    source_collection=collection_name,
+                    legacy_quiz_id=str(document["_id"]),
+                    document=document,
+                )
+            )
+        return candidates
+
+    def _candidate_log_payload(self, match: LegacySourceQuizMatch) -> dict[str, Any]:
+        return {
+            "legacy_source_collection": match.source_collection,
+            "legacy_quiz_id": match.legacy_quiz_id,
+            "title": self._candidate_display_title(match.document),
+        }
+
+    def _select_preferred_candidate(
+        self,
+        *,
+        title: str,
+        candidates: list[LegacySourceQuizMatch],
+    ) -> LegacySourceQuizMatch | None:
+        if not candidates:
+            return None
+        if len(candidates) == 1:
+            return candidates[0]
+
+        normalized_title = self._normalize_title(title)
+        if normalized_title:
+            title_matches = [
+                candidate
+                for candidate in candidates
+                if self._normalize_title(self._candidate_display_title(candidate.document)) == normalized_title
+            ]
+            if len(title_matches) == 1:
+                return title_matches[0]
+            if len(title_matches) > 1:
+                raise LegacyQuizStructureConflictError(
+                    title=title,
+                    quiz_type=candidates[0].document.get("question_type")
+                    or candidates[0].document.get("quiz_type")
+                    or "multichoice",
+                    candidates=[self._candidate_log_payload(candidate) for candidate in title_matches],
+                )
+
+        raise LegacyQuizStructureConflictError(
+            title=title,
+            quiz_type=candidates[0].document.get("question_type")
+            or candidates[0].document.get("quiz_type")
+            or "multichoice",
+            candidates=[self._candidate_log_payload(candidate) for candidate in candidates],
+        )
+
+    async def find_legacy_source_match_by_structure(
+        self,
+        *,
+        title: str,
+        quiz_type: str,
+        questions: list[Any],
+    ) -> LegacySourceQuizMatch | None:
+        target_fingerprint = self._build_question_structure_fingerprint(
+            quiz_type=quiz_type,
+            questions=questions,
+        )
+        ai_candidates = await self._find_structure_candidates(
+            collection_name="ai_generated_quizzes",
+            collection=self.ai_generated_quizzes_collection,
+            target_fingerprint=target_fingerprint,
+            quiz_type=quiz_type,
+        )
+        selected = self._select_preferred_candidate(title=title, candidates=ai_candidates)
+        if selected:
+            return selected
+
+        manual_candidates = await self._find_structure_candidates(
+            collection_name="quizzes",
+            collection=self.quizzes_collection,
+            target_fingerprint=target_fingerprint,
+            quiz_type=quiz_type,
+        )
+        return self._select_preferred_candidate(title=title, candidates=manual_candidates)
+
+    async def resolve_or_build_from_legacy_source_match(
+        self,
+        match: LegacySourceQuizMatch,
+        *,
+        allow_create: bool,
+    ):
+        existing = await self.canonical_service.repository.find_by_legacy_mapping(
+            match.source_collection,
+            match.legacy_quiz_id,
+        )
+        if existing:
+            return existing
+
+        if match.document.get("canonical_quiz_id"):
+            canonical_quiz = await self.resolve_from_canonical_backref(match.document["canonical_quiz_id"])
+            if canonical_quiz:
+                return canonical_quiz
+
+        quiz_document = self.canonical_service.build_quiz_document(
+            title=self._candidate_display_title(match.document),
+            description=match.document.get("custom_instruction") or match.document.get("description"),
+            quiz_type=match.document.get("question_type") or match.document.get("quiz_type") or "multichoice",
+            owner_user_id=match.document.get("user_id") or match.document.get("owner_id"),
+            source="ai" if match.source_collection == "ai_generated_quizzes" else "legacy",
+            questions=match.document.get("questions", []),
+            legacy_source_collection=match.source_collection,
+            legacy_quiz_id=match.legacy_quiz_id,
+        )
+        if allow_create:
+            return await self.canonical_service.upsert_quiz_v2_by_legacy_mapping(quiz_document)
+        return quiz_document
+
+    async def resolve_from_legacy_structure(
+        self,
+        *,
+        title: str,
+        quiz_type: str,
+        questions: list[Any],
+        allow_create: bool,
+    ):
+        match = await self.find_legacy_source_match_by_structure(
+            title=title,
+            quiz_type=quiz_type,
+            questions=questions,
+        )
+        if not match:
+            return None
+        return await self.resolve_or_build_from_legacy_source_match(
+            match,
+            allow_create=allow_create,
+        )

--- a/server/app/db/services/legacy_quiz_resolution_service.py
+++ b/server/app/db/services/legacy_quiz_resolution_service.py
@@ -28,7 +28,10 @@ class LegacyQuizStructureConflictError(ValueError):
         self.title = title
         self.quiz_type = quiz_type
         self.candidates = candidates
-        candidate_ids = ", ".join(candidate["legacy_quiz_id"] for candidate in candidates)
+        candidate_ids = ", ".join(
+            candidate.get("legacy_quiz_id") or candidate.get("canonical_quiz_id") or "unknown"
+            for candidate in candidates
+        )
         super().__init__(
             f"Multiple legacy source matches for '{title}' ({quiz_type}): {candidate_ids}"
         )
@@ -37,7 +40,10 @@ class LegacyQuizStructureConflictError(ValueError):
         return {
             "title": self.title,
             "quiz_type": self.quiz_type,
-            "candidate_ids": [candidate["legacy_quiz_id"] for candidate in self.candidates],
+            "candidate_ids": [
+                candidate.get("legacy_quiz_id") or candidate.get("canonical_quiz_id")
+                for candidate in self.candidates
+            ],
             "candidates": self.candidates,
         }
 
@@ -75,6 +81,33 @@ class LegacyQuizResolutionService:
     @staticmethod
     def _candidate_display_title(document: dict[str, Any]) -> str:
         return document.get("profession") or document.get("title") or "Untitled Quiz"
+
+    @classmethod
+    def is_generic_quiz_title(cls, title: str | None, quiz_type: str | None = None) -> bool:
+        normalized_title = cls._normalize_title(title)
+        if not normalized_title:
+            return True
+        generic_titles = {"quiz history"}
+        if quiz_type:
+            generic_titles.add(cls._normalize_title(f"{quiz_type} Quiz"))
+        return normalized_title in generic_titles
+
+    @classmethod
+    def choose_preferred_title(
+        cls,
+        *,
+        title: str | None,
+        fallback_title: str | None = None,
+        quiz_type: str | None = None,
+        default: str = "Untitled Quiz",
+    ) -> str:
+        if title and not cls.is_generic_quiz_title(title, quiz_type):
+            return title.strip()
+        if fallback_title and fallback_title.strip():
+            return fallback_title.strip()
+        if title and title.strip():
+            return title.strip()
+        return default
 
     def _build_question_structure_fingerprint(self, *, quiz_type: str, questions: list[Any]) -> str:
         normalized_questions = self.canonical_service.normalize_questions(questions)
@@ -171,6 +204,12 @@ class LegacyQuizResolutionService:
             "legacy_source_collection": match.source_collection,
             "legacy_quiz_id": match.legacy_quiz_id,
             "title": self._candidate_display_title(match.document),
+        }
+
+    def _v2_candidate_log_payload(self, document: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "canonical_quiz_id": str(document["_id"]),
+            "title": document.get("title"),
         }
 
     def _select_preferred_candidate(
@@ -289,4 +328,55 @@ class LegacyQuizResolutionService:
         return await self.resolve_or_build_from_legacy_source_match(
             match,
             allow_create=allow_create,
+        )
+
+    async def resolve_existing_v2_from_question_structure(
+        self,
+        *,
+        title: str,
+        quiz_type: str,
+        questions: list[Any],
+    ):
+        target_fingerprint = self._build_question_structure_fingerprint(
+            quiz_type=quiz_type,
+            questions=questions,
+        )
+        candidates: list[dict[str, Any]] = []
+        async for document in self.canonical_service.repository.collection.find(
+            {"quiz_type": quiz_type, "status": {"$ne": "deleted"}},
+            {"_id": 1, "title": 1, "quiz_type": 1, "questions": 1},
+        ):
+            candidate_fingerprint = self._build_question_structure_fingerprint(
+                quiz_type=document.get("quiz_type") or "multichoice",
+                questions=document.get("questions", []),
+            )
+            if candidate_fingerprint != target_fingerprint:
+                continue
+            candidates.append(document)
+
+        if not candidates:
+            return None
+        if len(candidates) == 1:
+            return await self.canonical_service.get_quiz_v2_by_id(str(candidates[0]["_id"]))
+
+        normalized_title = self._normalize_title(title)
+        if normalized_title:
+            title_matches = [
+                candidate
+                for candidate in candidates
+                if self._normalize_title(candidate.get("title")) == normalized_title
+            ]
+            if len(title_matches) == 1:
+                return await self.canonical_service.get_quiz_v2_by_id(str(title_matches[0]["_id"]))
+            if len(title_matches) > 1:
+                raise LegacyQuizStructureConflictError(
+                    title=title,
+                    quiz_type=quiz_type,
+                    candidates=[self._v2_candidate_log_payload(candidate) for candidate in title_matches],
+                )
+
+        raise LegacyQuizStructureConflictError(
+            title=title,
+            quiz_type=quiz_type,
+            candidates=[self._v2_candidate_log_payload(candidate) for candidate in candidates],
         )

--- a/server/app/db/services/quiz_dual_write_service.py
+++ b/server/app/db/services/quiz_dual_write_service.py
@@ -69,6 +69,10 @@ class QuizDualWriteService:
     def dual_write_enabled(self) -> bool:
         return self.write_mode == "dual_write"
 
+    @property
+    def v2_only_enabled(self) -> bool:
+        return self.write_mode == "v2_only"
+
     def _log(self, event: str, **fields):
         if not settings.QUIZ_V2_STRUCTURED_LOGGING:
             return
@@ -172,6 +176,14 @@ class QuizDualWriteService:
     async def _resolve_canonical_from_source_quiz_id(self, source_quiz_id: str | None):
         return await self.legacy_resolution_service.resolve_from_source_quiz_id(source_quiz_id)
 
+    async def _resolve_canonical_from_any_quiz_id(self, quiz_id: str | None):
+        if not quiz_id:
+            return None
+        canonical_quiz = await self.canonical_service.get_quiz_v2_by_id(quiz_id)
+        if canonical_quiz:
+            return canonical_quiz
+        return await self._resolve_canonical_from_source_quiz_id(quiz_id)
+
 
     async def mirror_legacy_manual_quiz(self, legacy_quiz_id: str, legacy_quiz_doc: dict):
         return await self._run_fail_open(
@@ -221,7 +233,7 @@ class QuizDualWriteService:
                     legacy_saved_doc["canonical_quiz_id"]
                 )
             if not canonical_quiz:
-                canonical_quiz = await self._resolve_canonical_from_source_quiz_id(
+                canonical_quiz = await self._resolve_canonical_from_any_quiz_id(
                     legacy_saved_doc.get("quiz_id")
                 )
             if not canonical_quiz:
@@ -254,6 +266,65 @@ class QuizDualWriteService:
             return canonical_quiz
         return None
 
+    async def create_saved_quiz_v2(
+        self,
+        *,
+        user_id: str,
+        title: str,
+        question_type: str,
+        questions: list[Any],
+        quiz_id: str | None = None,
+        saved_at: datetime | None = None,
+    ) -> SavedQuizDocumentV2:
+        canonical_quiz = await self._resolve_canonical_from_any_quiz_id(quiz_id)
+        if not canonical_quiz:
+            canonical_quiz = await self._mirror_quiz_document(
+                title=title,
+                quiz_type=question_type,
+                owner_user_id=None,
+                source="legacy",
+                questions=questions,
+            )
+        reference = await self.reference_repository.upsert_saved_quiz(
+            SavedQuizDocumentV2(
+                user_id=user_id,
+                quiz_id=str(canonical_quiz.id),
+                display_title=title or canonical_quiz.title,
+                saved_at=saved_at or datetime.utcnow(),
+            )
+        )
+        self._log(
+            "quiz_v2_only_write_served",
+            operation="saved_quiz_create",
+            write_mode=self.write_mode,
+            user_id=user_id,
+            saved_quiz_id=str(reference.id),
+            canonical_quiz_id=str(canonical_quiz.id),
+        )
+        return reference
+
+    async def delete_saved_quiz_v2(self, *, saved_quiz_id: str, user_id: str) -> bool:
+        saved_reference = await self.reference_repository.get_saved_quiz_by_public_id(
+            saved_quiz_id,
+            user_id=user_id,
+        )
+        if saved_reference is None:
+            return False
+        deleted_count = await self.reference_repository.delete_saved_quiz_by_id(
+            str(saved_reference.id),
+            user_id=user_id,
+        )
+        deleted = deleted_count > 0
+        self._log(
+            "quiz_v2_only_write_served",
+            operation="saved_quiz_delete",
+            write_mode=self.write_mode,
+            user_id=user_id,
+            saved_quiz_id=saved_quiz_id,
+            deleted=deleted,
+        )
+        return deleted
+
     async def mirror_quiz_history(self, legacy_history_doc: dict):
         async def action():
             canonical_quiz = None
@@ -262,7 +333,7 @@ class QuizDualWriteService:
                     legacy_history_doc["canonical_quiz_id"]
                 )
             if not canonical_quiz:
-                canonical_quiz = await self._resolve_canonical_from_source_quiz_id(
+                canonical_quiz = await self._resolve_canonical_from_any_quiz_id(
                     legacy_history_doc.get("quiz_id")
                 )
             if not canonical_quiz:
@@ -307,6 +378,52 @@ class QuizDualWriteService:
             return canonical_quiz
         return None
 
+    async def create_quiz_history_v2(self, quiz_data: dict[str, Any]) -> QuizHistoryDocumentV2:
+        canonical_quiz = None
+        if quiz_data.get("canonical_quiz_id"):
+            canonical_quiz = await self.canonical_service.get_quiz_v2_by_id(
+                quiz_data["canonical_quiz_id"]
+            )
+        if not canonical_quiz:
+            canonical_quiz = await self._resolve_canonical_from_any_quiz_id(quiz_data.get("quiz_id"))
+        if not canonical_quiz:
+            canonical_quiz = await self._mirror_quiz_document(
+                title=self.legacy_resolution_service.choose_preferred_title(
+                    title=quiz_data.get("quiz_name"),
+                    fallback_title=quiz_data.get("profession"),
+                    quiz_type=quiz_data.get("question_type"),
+                    default="Quiz History",
+                ),
+                description=quiz_data.get("custom_instruction"),
+                quiz_type=quiz_data["question_type"],
+                owner_user_id=None,
+                source="legacy",
+                questions=quiz_data["questions"],
+            )
+        reference = await self.reference_repository.insert_quiz_history(
+            QuizHistoryDocumentV2(
+                user_id=quiz_data["user_id"],
+                quiz_id=str(canonical_quiz.id),
+                action="generated",
+                metadata={
+                    "source": canonical_quiz.source,
+                    "topic": quiz_data.get("profession") or canonical_quiz.title,
+                    "difficulty_level": quiz_data.get("difficulty_level"),
+                    "audience_type": quiz_data.get("audience_type"),
+                },
+                created_at=quiz_data.get("created_at", datetime.utcnow()),
+            )
+        )
+        self._log(
+            "quiz_v2_only_write_served",
+            operation="quiz_history_create",
+            write_mode=self.write_mode,
+            user_id=quiz_data["user_id"],
+            history_id=str(reference.id),
+            canonical_quiz_id=str(canonical_quiz.id),
+        )
+        return reference
+
     async def mirror_folder_create(self, legacy_folder_doc: dict):
         return await self._run_fail_open(
             operation="folder_create_or_update",
@@ -324,6 +441,58 @@ class QuizDualWriteService:
             ),
         )
 
+    async def create_folder_v2(
+        self,
+        *,
+        user_id: str,
+        name: str,
+        description: str | None = None,
+        created_at: datetime | None = None,
+        updated_at: datetime | None = None,
+    ) -> FolderDocumentV2:
+        folder = await self.reference_repository.insert_folder(
+            FolderDocumentV2(
+                user_id=user_id,
+                name=name,
+                description=description,
+                created_at=created_at or datetime.utcnow(),
+                updated_at=updated_at or datetime.utcnow(),
+            )
+        )
+        self._log(
+            "quiz_v2_only_write_served",
+            operation="folder_create",
+            write_mode=self.write_mode,
+            user_id=user_id,
+            folder_id=str(folder.id),
+        )
+        return folder
+
+    async def rename_folder_v2(
+        self,
+        *,
+        folder_id: str,
+        user_id: str,
+        new_name: str,
+    ) -> FolderDocumentV2 | None:
+        folder = await self.reference_repository.get_folder_by_public_id(folder_id)
+        if folder is None or folder.user_id != user_id:
+            return None
+        updated = await self.reference_repository.update_folder(
+            str(folder.id),
+            name=new_name,
+            updated_at=datetime.utcnow(),
+        )
+        self._log(
+            "quiz_v2_only_write_served",
+            operation="folder_rename",
+            write_mode=self.write_mode,
+            user_id=user_id,
+            folder_id=folder_id,
+            updated=updated is not None,
+        )
+        return updated
+
     async def mirror_folder_delete(self, legacy_folder_id: str):
         return await self._run_fail_open(
             operation="folder_delete",
@@ -333,6 +502,21 @@ class QuizDualWriteService:
                 legacy_folder_id
             ),
         )
+
+    async def delete_folder_v2(self, *, folder_id: str, user_id: str) -> bool:
+        folder = await self.reference_repository.get_folder_by_public_id(folder_id)
+        if folder is None or folder.user_id != user_id:
+            return False
+        await self.reference_repository.delete_folder_by_id(str(folder.id))
+        self._log(
+            "quiz_v2_only_write_served",
+            operation="folder_delete",
+            write_mode=self.write_mode,
+            user_id=user_id,
+            folder_id=folder_id,
+            deleted=True,
+        )
+        return True
 
     async def mirror_folder_item_add(self, legacy_folder_doc: dict, legacy_folder_item: dict):
         async def action():
@@ -357,6 +541,10 @@ class QuizDualWriteService:
                     legacy_folder_item.get("quiz_id")
                     or quiz_payload.get("quiz_id")
                 )
+                if not canonical_quiz:
+                    canonical_quiz = await self._resolve_canonical_from_any_quiz_id(
+                        legacy_folder_item.get("canonical_quiz_id")
+                    )
                 if not canonical_quiz:
                     canonical_quiz = await self._mirror_quiz_document(
                         title=legacy_folder_item.get("title") or quiz_payload.get("title") or "Untitled Quiz",
@@ -394,6 +582,50 @@ class QuizDualWriteService:
             coroutine_factory=action,
         )
 
+    async def add_saved_quiz_to_folder_v2(
+        self,
+        *,
+        folder_id: str,
+        saved_quiz_id: str,
+        user_id: str,
+    ) -> tuple[FolderDocumentV2, FolderItemDocumentV2]:
+        folder = await self.reference_repository.get_folder_by_public_id(folder_id)
+        if folder is None or folder.user_id != user_id:
+            raise PermissionError("Unauthorized access to folder")
+
+        saved_reference = await self.reference_repository.get_saved_quiz_by_public_id(
+            saved_quiz_id,
+            user_id=user_id,
+        )
+        if saved_reference is None:
+            raise ValueError("Saved quiz not found")
+
+        canonical_quiz = await self.canonical_service.get_quiz_v2_by_id(saved_reference.quiz_id)
+        if canonical_quiz is None:
+            raise ValueError("Canonical quiz not found")
+
+        existing_items = await self.reference_repository.list_folder_items_for_folder(str(folder.id))
+        folder_item = await self.reference_repository.upsert_folder_item_by_legacy_id(
+            FolderItemDocumentV2(
+                folder_id=str(folder.id),
+                quiz_id=str(canonical_quiz.id),
+                added_by=user_id,
+                position=len(existing_items),
+                display_title=saved_reference.display_title or canonical_quiz.title,
+                created_at=datetime.utcnow(),
+            )
+        )
+        self._log(
+            "quiz_v2_only_write_served",
+            operation="folder_item_add",
+            write_mode=self.write_mode,
+            user_id=user_id,
+            folder_id=folder_id,
+            folder_item_id=str(folder_item.id),
+            canonical_quiz_id=str(canonical_quiz.id),
+        )
+        return folder, folder_item
+
     async def mirror_folder_item_remove(self, legacy_folder_item_id: str):
         return await self._run_fail_open(
             operation="folder_item_remove",
@@ -403,6 +635,31 @@ class QuizDualWriteService:
                 legacy_folder_item_id
             ),
         )
+
+    async def remove_folder_item_v2(
+        self,
+        *,
+        folder_id: str,
+        folder_item_id: str,
+        user_id: str,
+    ) -> bool:
+        folder = await self.reference_repository.get_folder_by_public_id(folder_id)
+        if folder is None or folder.user_id != user_id:
+            return False
+        folder_item = await self.reference_repository.get_folder_item_by_public_id(folder_item_id)
+        if folder_item is None or folder_item.folder_id != str(folder.id):
+            return False
+        await self.reference_repository.delete_folder_item_by_id(str(folder_item.id))
+        self._log(
+            "quiz_v2_only_write_served",
+            operation="folder_item_remove",
+            write_mode=self.write_mode,
+            user_id=user_id,
+            folder_id=folder_id,
+            folder_item_id=folder_item_id,
+            deleted=True,
+        )
+        return True
 
     async def mirror_folder_item_move(
         self,
@@ -452,6 +709,46 @@ class QuizDualWriteService:
             legacy_id=legacy_folder_item_id,
             coroutine_factory=action,
         )
+
+    async def move_folder_item_v2(
+        self,
+        *,
+        folder_item_id: str,
+        source_folder_id: str,
+        target_folder_id: str,
+        user_id: str,
+    ) -> bool:
+        source_folder = await self.reference_repository.get_folder_by_public_id(source_folder_id)
+        target_folder = await self.reference_repository.get_folder_by_public_id(target_folder_id)
+        if (
+            source_folder is None
+            or target_folder is None
+            or source_folder.user_id != user_id
+            or target_folder.user_id != user_id
+        ):
+            return False
+
+        folder_item = await self.reference_repository.get_folder_item_by_public_id(folder_item_id)
+        if folder_item is None or folder_item.folder_id != str(source_folder.id):
+            return False
+
+        target_items = await self.reference_repository.list_folder_items_for_folder(str(target_folder.id))
+        updated = await self.reference_repository.update_folder_item(
+            str(folder_item.id),
+            folder_id=str(target_folder.id),
+            position=len(target_items),
+        )
+        self._log(
+            "quiz_v2_only_write_served",
+            operation="folder_item_move",
+            write_mode=self.write_mode,
+            user_id=user_id,
+            folder_item_id=folder_item_id,
+            source_folder_id=source_folder_id,
+            target_folder_id=target_folder_id,
+            updated=updated is not None,
+        )
+        return updated is not None
 
     async def _run_fail_open(
         self,

--- a/server/app/db/services/quiz_dual_write_service.py
+++ b/server/app/db/services/quiz_dual_write_service.py
@@ -236,6 +236,7 @@ class QuizDualWriteService:
                 SavedQuizDocumentV2(
                     user_id=legacy_saved_doc["user_id"],
                     quiz_id=str(canonical_quiz.id),
+                    display_title=legacy_saved_doc.get("title") or canonical_quiz.title,
                     legacy_saved_quiz_id=str(legacy_saved_doc["_id"]),
                     saved_at=legacy_saved_doc.get("created_at", datetime.utcnow()),
                 )
@@ -367,11 +368,20 @@ class QuizDualWriteService:
                         source="legacy",
                     )
                 canonical_quiz_id = str(canonical_quiz.id)
+            position = None
+            for index, item in enumerate(legacy_folder_doc.get("quizzes", [])):
+                if str(item.get("_id")) == str(legacy_folder_item.get("_id")):
+                    position = index
+                    break
             return await self.reference_repository.upsert_folder_item_by_legacy_id(
                 FolderItemDocumentV2(
                     folder_id=str(folder_v2.id),
                     quiz_id=canonical_quiz_id,
                     added_by=legacy_folder_doc.get("user_id"),
+                    position=position,
+                    display_title=legacy_folder_item.get("title")
+                    or quiz_payload.get("title")
+                    or None,
                     legacy_folder_item_id=legacy_folder_item["_id"],
                     created_at=legacy_folder_item.get("added_on", datetime.utcnow()),
                 )
@@ -419,12 +429,18 @@ class QuizDualWriteService:
                         updated_at=target_legacy_folder_doc.get("updated_at", datetime.utcnow()),
                     )
                 )
+            position = None
+            for index, item in enumerate(target_legacy_folder_doc.get("quizzes", [])):
+                if str(item.get("_id")) == str(legacy_folder_item_id):
+                    position = index
+                    break
             return await self.reference_repository.upsert_folder_item_by_legacy_id(
                 FolderItemDocumentV2(
                     folder_id=str(target_folder.id),
                     quiz_id=folder_item.quiz_id,
                     added_by=folder_item.added_by,
-                    position=folder_item.position,
+                    position=position if position is not None else folder_item.position,
+                    display_title=folder_item.display_title,
                     legacy_folder_item_id=legacy_folder_item_id,
                     created_at=folder_item.created_at,
                 )

--- a/server/app/db/services/quiz_dual_write_service.py
+++ b/server/app/db/services/quiz_dual_write_service.py
@@ -16,6 +16,7 @@ from server.app.db.core.connection import (
     get_saved_quizzes_v2_collection,
 )
 from server.app.db.crud.quiz_write_service import CanonicalQuizWriteService
+from server.app.db.services.legacy_quiz_resolution_service import LegacyQuizResolutionService
 from server.app.db.v2.models.reference_models import (
     FolderDocumentV2,
     FolderItemDocumentV2,
@@ -53,6 +54,11 @@ class QuizDualWriteService:
             quizzes_collection
             if quizzes_collection is not None
             else get_quizzes_collection()
+        )
+        self.legacy_resolution_service = LegacyQuizResolutionService(
+            canonical_service=self.canonical_service,
+            ai_generated_quizzes_collection=self.ai_generated_quizzes_collection,
+            quizzes_collection=self.quizzes_collection,
         )
 
     @property
@@ -126,6 +132,14 @@ class QuizDualWriteService:
             )
             if existing:
                 return existing
+            matched_legacy_quiz = await self.legacy_resolution_service.resolve_from_legacy_structure(
+                title=title,
+                quiz_type=quiz_type,
+                questions=questions,
+                allow_create=True,
+            )
+            if matched_legacy_quiz:
+                return matched_legacy_quiz
             raise ValueError("Cannot create canonical quiz without answer data")
         quiz_document = self.canonical_service.build_quiz_document(
             title=title,
@@ -142,41 +156,7 @@ class QuizDualWriteService:
         return await self.canonical_service.find_or_create_quiz_v2_by_fingerprint(quiz_document)
 
     async def _resolve_canonical_from_source_quiz_id(self, source_quiz_id: str | None):
-        if not source_quiz_id:
-            return None
-
-        canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
-            "ai_generated_quizzes",
-            source_quiz_id,
-        )
-        if canonical_quiz:
-            return canonical_quiz
-
-        canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
-            "quizzes",
-            source_quiz_id,
-        )
-        if canonical_quiz:
-            return canonical_quiz
-
-        legacy_ai_quiz = await self.ai_generated_quizzes_collection.find_one({"_id": source_quiz_id})
-        if legacy_ai_quiz and legacy_ai_quiz.get("canonical_quiz_id"):
-            return await self.canonical_service.get_quiz_v2_by_id(legacy_ai_quiz["canonical_quiz_id"])
-
-        try:
-            from bson import ObjectId
-            object_id = ObjectId(source_quiz_id)
-        except Exception:
-            object_id = None
-
-        if object_id is not None:
-            legacy_seeded_quiz = await self.quizzes_collection.find_one({"_id": object_id})
-            if legacy_seeded_quiz and legacy_seeded_quiz.get("canonical_quiz_id"):
-                return await self.canonical_service.get_quiz_v2_by_id(
-                    legacy_seeded_quiz["canonical_quiz_id"]
-                )
-
-        return None
+        return await self.legacy_resolution_service.resolve_from_source_quiz_id(source_quiz_id)
 
 
     async def mirror_legacy_manual_quiz(self, legacy_quiz_id: str, legacy_quiz_doc: dict):
@@ -481,6 +461,7 @@ class QuizDualWriteService:
             )
             return result
         except Exception as exc:
+            extra_fields = exc.to_log_fields() if hasattr(exc, "to_log_fields") else {}
             self._log(
                 "quiz_dual_write_v2_failed",
                 operation=operation,
@@ -488,6 +469,7 @@ class QuizDualWriteService:
                 legacy_id=legacy_id,
                 write_mode=self.write_mode,
                 error=str(exc),
+                **extra_fields,
             )
             if settings.QUIZ_V2_FAIL_OPEN:
                 return None

--- a/server/app/db/services/quiz_dual_write_service.py
+++ b/server/app/db/services/quiz_dual_write_service.py
@@ -291,7 +291,8 @@ class QuizDualWriteService:
                 quiz_id=str(canonical_quiz.id),
                 display_title=title or canonical_quiz.title,
                 saved_at=saved_at or datetime.utcnow(),
-            )
+            ),
+            revive_deleted=True,
         )
         self._log(
             "quiz_v2_only_write_served",
@@ -423,6 +424,22 @@ class QuizDualWriteService:
             canonical_quiz_id=str(canonical_quiz.id),
         )
         return reference
+
+    async def delete_quiz_history_v2(self, *, history_id: str, user_id: str) -> bool:
+        deleted_count = await self.reference_repository.soft_delete_quiz_history_by_id(
+            history_id,
+            user_id=user_id,
+        )
+        deleted = deleted_count > 0
+        self._log(
+            "quiz_v2_only_write_served",
+            operation="quiz_history_delete",
+            write_mode=self.write_mode,
+            user_id=user_id,
+            history_id=history_id,
+            deleted=deleted,
+        )
+        return deleted
 
     async def mirror_folder_create(self, legacy_folder_doc: dict):
         return await self._run_fail_open(
@@ -613,7 +630,8 @@ class QuizDualWriteService:
                 position=len(existing_items),
                 display_title=saved_reference.display_title or canonical_quiz.title,
                 created_at=datetime.utcnow(),
-            )
+            ),
+            revive_deleted=True,
         )
         self._log(
             "quiz_v2_only_write_served",

--- a/server/app/db/services/quiz_dual_write_service.py
+++ b/server/app/db/services/quiz_dual_write_service.py
@@ -140,6 +140,13 @@ class QuizDualWriteService:
             )
             if matched_legacy_quiz:
                 return matched_legacy_quiz
+            existing_v2 = await self.legacy_resolution_service.resolve_existing_v2_from_question_structure(
+                title=title,
+                quiz_type=quiz_type,
+                questions=questions,
+            )
+            if existing_v2:
+                return existing_v2
             raise ValueError("Cannot create canonical quiz without answer data")
         quiz_document = self.canonical_service.build_quiz_document(
             title=title,
@@ -151,6 +158,13 @@ class QuizDualWriteService:
             legacy_source_collection=legacy_source_collection,
             legacy_quiz_id=legacy_quiz_id,
         )
+        existing = await self.legacy_resolution_service.resolve_existing_v2_from_question_structure(
+            title=title,
+            quiz_type=quiz_type,
+            questions=normalized_questions,
+        )
+        if existing:
+            return existing
         if legacy_source_collection and legacy_quiz_id:
             return await self.canonical_service.upsert_quiz_v2_by_legacy_mapping(quiz_document)
         return await self.canonical_service.find_or_create_quiz_v2_by_fingerprint(quiz_document)
@@ -252,9 +266,12 @@ class QuizDualWriteService:
                 )
             if not canonical_quiz:
                 canonical_quiz = await self._mirror_quiz_document(
-                    title=legacy_history_doc.get("quiz_name")
-                    or legacy_history_doc.get("profession")
-                    or "Quiz History",
+                    title=self.legacy_resolution_service.choose_preferred_title(
+                        title=legacy_history_doc.get("quiz_name"),
+                        fallback_title=legacy_history_doc.get("profession"),
+                        quiz_type=legacy_history_doc.get("question_type"),
+                        default="Quiz History",
+                    ),
                     description=legacy_history_doc.get("custom_instruction"),
                     quiz_type=legacy_history_doc["question_type"],
                     owner_user_id=None,

--- a/server/app/db/services/quiz_user_library_read_service.py
+++ b/server/app/db/services/quiz_user_library_read_service.py
@@ -202,9 +202,12 @@ class QuizUserLibraryReadService:
                 continue
             payload.append(
                 {
+                    "id": str(reference.id),
+                    "legacy_id": reference.legacy_history_id,
                     "_id": reference.legacy_history_id or str(reference.id),
                     "user_id": reference.user_id,
-                    "quiz_id": quiz.legacy_quiz_id,
+                    "quiz_id": str(quiz.id),
+                    "legacy_quiz_id": quiz.legacy_quiz_id,
                     "canonical_quiz_id": str(quiz.id),
                     "quiz_name": quiz.title,
                     "question_type": quiz.quiz_type.value,
@@ -255,9 +258,12 @@ class QuizUserLibraryReadService:
 
     def _build_saved_payload(self, reference: SavedQuizDocumentV2, quiz: QuizDocumentV2) -> dict[str, Any]:
         return {
+            "id": str(reference.id),
+            "legacy_id": reference.legacy_saved_quiz_id,
             "_id": reference.legacy_saved_quiz_id or str(reference.id),
             "user_id": reference.user_id,
-            "quiz_id": quiz.legacy_quiz_id,
+            "quiz_id": str(quiz.id),
+            "legacy_quiz_id": quiz.legacy_quiz_id,
             "canonical_quiz_id": str(quiz.id),
             "title": reference.display_title or quiz.title,
             "question_type": quiz.quiz_type.value,
@@ -279,7 +285,7 @@ class QuizUserLibraryReadService:
         return payload
 
     async def _v2_get_saved_quiz(self, saved_quiz_id: str, user_id: str) -> Optional[dict[str, Any]]:
-        reference = await self.reference_repository.get_saved_quiz_by_legacy_id(saved_quiz_id, user_id=user_id)
+        reference = await self.reference_repository.get_saved_quiz_by_public_id(saved_quiz_id, user_id=user_id)
         if reference is None:
             return None
         quiz = await self.quiz_repository.find_by_id(reference.quiz_id)
@@ -355,8 +361,11 @@ class QuizUserLibraryReadService:
     ) -> dict[str, Any]:
         questions = self._serialize_saved_questions(quiz)
         return {
+            "id": str(item.id),
+            "legacy_id": item.legacy_folder_item_id,
             "_id": item.legacy_folder_item_id or str(item.id),
-            "quiz_id": quiz.legacy_quiz_id,
+            "quiz_id": str(quiz.id),
+            "legacy_quiz_id": quiz.legacy_quiz_id,
             "canonical_quiz_id": str(quiz.id),
             "title": item.display_title or quiz.title,
             "question_type": quiz.quiz_type.value,
@@ -366,7 +375,8 @@ class QuizUserLibraryReadService:
             "_position": item.position,
             "quiz_data": {
                 "_id": item.legacy_folder_item_id or str(item.id),
-                "quiz_id": quiz.legacy_quiz_id,
+                "quiz_id": str(quiz.id),
+                "legacy_quiz_id": quiz.legacy_quiz_id,
                 "canonical_quiz_id": str(quiz.id),
                 "title": item.display_title or quiz.title,
                 "question_type": quiz.quiz_type.value,
@@ -383,6 +393,8 @@ class QuizUserLibraryReadService:
             items = await self.reference_repository.list_folder_items_for_folder(str(folder.id))
             folder_payloads.append(
                 {
+                    "id": str(folder.id),
+                    "legacy_id": folder.legacy_folder_id,
                     "_id": folder.legacy_folder_id or str(folder.id),
                     "user_id": folder.user_id,
                     "name": folder.name,
@@ -394,7 +406,7 @@ class QuizUserLibraryReadService:
         return folder_payloads
 
     async def _v2_get_folder(self, folder_id: str) -> tuple[Optional[dict[str, Any]], Optional[str]]:
-        folder = await self.reference_repository.get_folder_by_legacy_id(folder_id)
+        folder = await self.reference_repository.get_folder_by_public_id(folder_id)
         if folder is None:
             return None, None
         items = await self.reference_repository.list_folder_items_for_folder(str(folder.id))
@@ -410,6 +422,8 @@ class QuizUserLibraryReadService:
             payload_item.pop("_position", None)
         return (
             {
+                "id": str(folder.id),
+                "legacy_id": folder.legacy_folder_id,
                 "_id": folder.legacy_folder_id or str(folder.id),
                 "user_id": folder.user_id,
                 "name": folder.name,

--- a/server/app/db/services/quiz_user_library_read_service.py
+++ b/server/app/db/services/quiz_user_library_read_service.py
@@ -1,0 +1,486 @@
+import logging
+from datetime import datetime
+from typing import Any, Awaitable, Callable, Literal, Optional
+
+from bson import ObjectId
+from bson.errors import InvalidId
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from server.app.db.core.config import settings
+from server.app.db.core.connection import (
+    get_folder_items_v2_collection,
+    get_folders_collection,
+    get_folders_v2_collection,
+    get_quiz_history_collection,
+    get_quiz_history_v2_collection,
+    get_quizzes_v2_collection,
+    get_saved_quizzes_collection,
+    get_saved_quizzes_v2_collection,
+)
+from server.app.db.v2.models.quiz_models import QuizDocumentV2
+from server.app.db.v2.models.reference_models import (
+    FolderDocumentV2,
+    FolderItemDocumentV2,
+    QuizHistoryDocumentV2,
+    SavedQuizDocumentV2,
+)
+from server.app.db.v2.repositories.quiz_repository import QuizV2Repository
+from server.app.db.v2.repositories.reference_repository import ReferenceV2Repository
+
+
+logger = logging.getLogger(__name__)
+
+ReadMode = Literal["legacy_only", "compare", "v2_only"]
+
+
+class QuizUserLibraryReadService:
+    def __init__(
+        self,
+        *,
+        saved_quizzes_collection: Optional[AsyncIOMotorCollection] = None,
+        quiz_history_collection: Optional[AsyncIOMotorCollection] = None,
+        folders_collection: Optional[AsyncIOMotorCollection] = None,
+        quiz_repository: Optional[QuizV2Repository] = None,
+        reference_repository: Optional[ReferenceV2Repository] = None,
+    ):
+        self.saved_quizzes_collection = (
+            saved_quizzes_collection
+            if saved_quizzes_collection is not None
+            else get_saved_quizzes_collection()
+        )
+        self.quiz_history_collection = (
+            quiz_history_collection
+            if quiz_history_collection is not None
+            else get_quiz_history_collection()
+        )
+        self.folders_collection = (
+            folders_collection if folders_collection is not None else get_folders_collection()
+        )
+        self.quiz_repository = (
+            quiz_repository if quiz_repository is not None else QuizV2Repository(get_quizzes_v2_collection())
+        )
+        self.reference_repository = (
+            reference_repository
+            if reference_repository is not None
+            else ReferenceV2Repository(
+                get_folders_v2_collection(),
+                get_folder_items_v2_collection(),
+                get_saved_quizzes_v2_collection(),
+                get_quiz_history_v2_collection(),
+            )
+        )
+
+    def _log(self, event: str, **fields):
+        if not settings.QUIZ_V2_STRUCTURED_LOGGING:
+            return
+        logger.info("%s | %s", event, fields)
+
+    @staticmethod
+    def _isoformat(value: Any) -> Any:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return value
+
+    @classmethod
+    def _serialize_legacy_document(cls, value: Any) -> Any:
+        if isinstance(value, dict):
+            return {key: cls._serialize_legacy_document(val) for key, val in value.items()}
+        if isinstance(value, list):
+            return [cls._serialize_legacy_document(item) for item in value]
+        if isinstance(value, ObjectId):
+            return str(value)
+        if isinstance(value, datetime):
+            return value.isoformat()
+        return value
+
+    @staticmethod
+    def _sort_by_created_desc(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return sorted(items, key=lambda item: item.get("created_at") or "", reverse=True)
+
+    @staticmethod
+    def _sort_folders(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        return sorted(items, key=lambda item: (item.get("created_at") or "", item.get("_id") or ""))
+
+    @staticmethod
+    def _sort_folder_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        def sort_key(item: dict[str, Any]):
+            position = item.get("_position")
+            if position is None:
+                position = 10**9
+            return (position, item.get("added_on") or item.get("created_at") or "", item.get("_id") or "")
+
+        return sorted(items, key=sort_key)
+
+    def _normalize_for_compare(self, value: Any) -> Any:
+        if isinstance(value, datetime):
+            return value.isoformat()
+        if isinstance(value, dict):
+            return {key: self._normalize_for_compare(val) for key, val in value.items()}
+        if isinstance(value, list):
+            return [self._normalize_for_compare(item) for item in value]
+        return value
+
+    async def _read_with_mode(
+        self,
+        *,
+        mode: ReadMode,
+        operation: str,
+        user_id: Optional[str],
+        legacy_reader: Callable[[], Awaitable[Any]],
+        v2_reader: Callable[[], Awaitable[Any]],
+        compare_normalizer: Callable[[Any], Any],
+    ):
+        if mode == "legacy_only":
+            data = await legacy_reader()
+            self._log("quiz_read_legacy_served", operation=operation, user_id=user_id, read_mode=mode)
+            return data
+
+        if mode == "v2_only":
+            data = await v2_reader()
+            self._log("quiz_read_v2_served", operation=operation, user_id=user_id, read_mode=mode)
+            return data
+
+        self._log("quiz_read_compare_started", operation=operation, user_id=user_id, read_mode=mode)
+        legacy_data = await legacy_reader()
+        v2_data = await v2_reader()
+        normalized_legacy = compare_normalizer(legacy_data)
+        normalized_v2 = compare_normalizer(v2_data)
+        if normalized_legacy == normalized_v2:
+            self._log("quiz_read_compare_match", operation=operation, user_id=user_id, read_mode=mode)
+        else:
+            self._log(
+                "quiz_read_compare_mismatch",
+                operation=operation,
+                user_id=user_id,
+                read_mode=mode,
+                legacy_shape=normalized_legacy,
+                v2_shape=normalized_v2,
+            )
+        self._log("quiz_read_legacy_served", operation=operation, user_id=user_id, read_mode=mode)
+        return legacy_data
+
+    async def _get_quizzes_by_ids(self, quiz_ids: list[str]) -> dict[str, QuizDocumentV2]:
+        quizzes = await self.quiz_repository.find_many_by_ids(quiz_ids)
+        return {str(quiz.id): quiz for quiz in quizzes}
+
+    @staticmethod
+    def _serialize_saved_questions(quiz: QuizDocumentV2) -> list[dict[str, Any]]:
+        return [
+            {
+                "question": question.question,
+                "options": question.options,
+                "question_type": quiz.quiz_type.value,
+                "correct_answer": question.correct_answer,
+            }
+            for question in quiz.questions
+        ]
+
+    @staticmethod
+    def _serialize_history_questions(quiz: QuizDocumentV2) -> list[dict[str, Any]]:
+        return [
+            {
+                "question": question.question,
+                "options": question.options,
+                "answer": question.correct_answer,
+                "question_type": quiz.quiz_type.value,
+            }
+            for question in quiz.questions
+        ]
+
+    async def _legacy_get_quiz_history(self, user_id: str, limit: int) -> list[dict[str, Any]]:
+        documents = await self.quiz_history_collection.find({"user_id": user_id}).sort("created_at", -1).to_list(limit)
+        return [self._serialize_legacy_document(document) for document in documents]
+
+    async def _v2_get_quiz_history(self, user_id: str, limit: int) -> list[dict[str, Any]]:
+        references = await self.reference_repository.list_quiz_history_for_user(user_id)
+        references = sorted(references, key=lambda reference: reference.created_at, reverse=True)[:limit]
+        quizzes_by_id = await self._get_quizzes_by_ids([reference.quiz_id for reference in references])
+        payload: list[dict[str, Any]] = []
+        for reference in references:
+            quiz = quizzes_by_id.get(reference.quiz_id)
+            if quiz is None:
+                continue
+            payload.append(
+                {
+                    "_id": reference.legacy_history_id or str(reference.id),
+                    "user_id": reference.user_id,
+                    "quiz_id": quiz.legacy_quiz_id,
+                    "canonical_quiz_id": str(quiz.id),
+                    "quiz_name": quiz.title,
+                    "question_type": quiz.quiz_type.value,
+                    "profession": reference.metadata.get("topic") or quiz.title,
+                    "difficulty_level": reference.metadata.get("difficulty_level"),
+                    "audience_type": reference.metadata.get("audience_type"),
+                    "questions": self._serialize_history_questions(quiz),
+                    "created_at": self._isoformat(reference.created_at),
+                }
+            )
+        return payload
+
+    @staticmethod
+    def _normalize_history_compare(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        normalized = [
+            {
+                "_id": item.get("_id"),
+                "created_at": item.get("created_at"),
+                "question_count": len(item.get("questions", [])),
+                "questions": [question.get("question") for question in item.get("questions", [])],
+            }
+            for item in items
+        ]
+        return sorted(normalized, key=lambda item: item["_id"])
+
+    async def get_quiz_history_for_user(self, user_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        mode = settings.QUIZ_V2_HISTORY_READ_MODE
+        return await self._read_with_mode(
+            mode=mode,
+            operation="quiz_history_list",
+            user_id=user_id,
+            legacy_reader=lambda: self._legacy_get_quiz_history(user_id, limit),
+            v2_reader=lambda: self._v2_get_quiz_history(user_id, limit),
+            compare_normalizer=self._normalize_history_compare,
+        )
+
+    async def _legacy_list_saved_quizzes(self, user_id: str, limit: int) -> list[dict[str, Any]]:
+        documents = await self.saved_quizzes_collection.find({"user_id": user_id}).sort("created_at", -1).to_list(limit)
+        return [self._serialize_legacy_document(document) for document in documents]
+
+    async def _legacy_get_saved_quiz(self, saved_quiz_id: str, user_id: str) -> Optional[dict[str, Any]]:
+        try:
+            object_id = ObjectId(saved_quiz_id)
+        except InvalidId:
+            return None
+        document = await self.saved_quizzes_collection.find_one({"_id": object_id, "user_id": user_id})
+        return self._serialize_legacy_document(document) if document else None
+
+    def _build_saved_payload(self, reference: SavedQuizDocumentV2, quiz: QuizDocumentV2) -> dict[str, Any]:
+        return {
+            "_id": reference.legacy_saved_quiz_id or str(reference.id),
+            "user_id": reference.user_id,
+            "quiz_id": quiz.legacy_quiz_id,
+            "canonical_quiz_id": str(quiz.id),
+            "title": reference.display_title or quiz.title,
+            "question_type": quiz.quiz_type.value,
+            "is_deleted": False,
+            "questions": self._serialize_saved_questions(quiz),
+            "created_at": self._isoformat(reference.saved_at),
+        }
+
+    async def _v2_list_saved_quizzes(self, user_id: str, limit: int) -> list[dict[str, Any]]:
+        references = await self.reference_repository.list_saved_quizzes_for_user(user_id)
+        references = sorted(references, key=lambda reference: reference.saved_at, reverse=True)[:limit]
+        quizzes_by_id = await self._get_quizzes_by_ids([reference.quiz_id for reference in references])
+        payload: list[dict[str, Any]] = []
+        for reference in references:
+            quiz = quizzes_by_id.get(reference.quiz_id)
+            if quiz is None:
+                continue
+            payload.append(self._build_saved_payload(reference, quiz))
+        return payload
+
+    async def _v2_get_saved_quiz(self, saved_quiz_id: str, user_id: str) -> Optional[dict[str, Any]]:
+        reference = await self.reference_repository.get_saved_quiz_by_legacy_id(saved_quiz_id, user_id=user_id)
+        if reference is None:
+            return None
+        quiz = await self.quiz_repository.find_by_id(reference.quiz_id)
+        if quiz is None:
+            return None
+        return self._build_saved_payload(reference, quiz)
+
+    @staticmethod
+    def _normalize_saved_compare(items: Any) -> Any:
+        if items is None:
+            return None
+        if isinstance(items, dict):
+            items = [items]
+            unwrap = True
+        else:
+            unwrap = False
+        normalized = [
+            {
+                "_id": item.get("_id"),
+                "title": item.get("title"),
+                "created_at": item.get("created_at"),
+                "question_type": item.get("question_type"),
+                "question_count": len(item.get("questions", [])),
+                "questions": [question.get("question") for question in item.get("questions", [])],
+            }
+            for item in items
+        ]
+        normalized = sorted(normalized, key=lambda item: item["_id"])
+        return normalized[0] if unwrap else normalized
+
+    async def get_saved_quizzes_for_user(self, user_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        mode = settings.QUIZ_V2_SAVED_READ_MODE
+        return await self._read_with_mode(
+            mode=mode,
+            operation="saved_quiz_list",
+            user_id=user_id,
+            legacy_reader=lambda: self._legacy_list_saved_quizzes(user_id, limit),
+            v2_reader=lambda: self._v2_list_saved_quizzes(user_id, limit),
+            compare_normalizer=self._normalize_saved_compare,
+        )
+
+    async def get_saved_quiz_by_id(self, saved_quiz_id: str, user_id: str) -> Optional[dict[str, Any]]:
+        mode = settings.QUIZ_V2_SAVED_READ_MODE
+        return await self._read_with_mode(
+            mode=mode,
+            operation="saved_quiz_detail",
+            user_id=user_id,
+            legacy_reader=lambda: self._legacy_get_saved_quiz(saved_quiz_id, user_id),
+            v2_reader=lambda: self._v2_get_saved_quiz(saved_quiz_id, user_id),
+            compare_normalizer=self._normalize_saved_compare,
+        )
+
+    async def _legacy_list_folders(self, user_id: str) -> list[dict[str, Any]]:
+        documents = await self.folders_collection.find({"user_id": user_id}).to_list(length=500)
+        return self._sort_folders([self._serialize_legacy_document(document) for document in documents])
+
+    async def _legacy_get_folder(self, folder_id: str) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+        try:
+            object_id = ObjectId(folder_id)
+        except InvalidId:
+            return None, None
+        document = await self.folders_collection.find_one({"_id": object_id})
+        if not document:
+            return None, None
+        folder = self._serialize_legacy_document(document)
+        return folder, folder.get("user_id")
+
+    def _build_folder_item_payload(
+        self,
+        *,
+        item: FolderItemDocumentV2,
+        quiz: QuizDocumentV2,
+    ) -> dict[str, Any]:
+        questions = self._serialize_saved_questions(quiz)
+        return {
+            "_id": item.legacy_folder_item_id or str(item.id),
+            "quiz_id": quiz.legacy_quiz_id,
+            "canonical_quiz_id": str(quiz.id),
+            "title": item.display_title or quiz.title,
+            "question_type": quiz.quiz_type.value,
+            "questions": questions,
+            "created_at": self._isoformat(item.created_at),
+            "added_on": self._isoformat(item.created_at),
+            "_position": item.position,
+            "quiz_data": {
+                "_id": item.legacy_folder_item_id or str(item.id),
+                "quiz_id": quiz.legacy_quiz_id,
+                "canonical_quiz_id": str(quiz.id),
+                "title": item.display_title or quiz.title,
+                "question_type": quiz.quiz_type.value,
+                "questions": questions,
+                "created_at": self._isoformat(quiz.created_at),
+            },
+        }
+
+    async def _v2_list_folders(self, user_id: str) -> list[dict[str, Any]]:
+        folders = await self.reference_repository.list_folders_for_user(user_id)
+        folders = sorted(folders, key=lambda folder: (folder.created_at, folder.legacy_folder_id or str(folder.id)))
+        folder_payloads: list[dict[str, Any]] = []
+        for folder in folders:
+            items = await self.reference_repository.list_folder_items_for_folder(str(folder.id))
+            folder_payloads.append(
+                {
+                    "_id": folder.legacy_folder_id or str(folder.id),
+                    "user_id": folder.user_id,
+                    "name": folder.name,
+                    "created_at": self._isoformat(folder.created_at),
+                    "updated_at": self._isoformat(folder.updated_at),
+                    "quizzes": [{"_id": item.legacy_folder_item_id or str(item.id)} for item in items],
+                }
+            )
+        return folder_payloads
+
+    async def _v2_get_folder(self, folder_id: str) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+        folder = await self.reference_repository.get_folder_by_legacy_id(folder_id)
+        if folder is None:
+            return None, None
+        items = await self.reference_repository.list_folder_items_for_folder(str(folder.id))
+        quiz_map = await self._get_quizzes_by_ids([item.quiz_id for item in items])
+        payload_items: list[dict[str, Any]] = []
+        for item in items:
+            quiz = quiz_map.get(item.quiz_id)
+            if quiz is None:
+                continue
+            payload_items.append(self._build_folder_item_payload(item=item, quiz=quiz))
+        payload_items = self._sort_folder_items(payload_items)
+        for payload_item in payload_items:
+            payload_item.pop("_position", None)
+        return (
+            {
+                "_id": folder.legacy_folder_id or str(folder.id),
+                "user_id": folder.user_id,
+                "name": folder.name,
+                "created_at": self._isoformat(folder.created_at),
+                "updated_at": self._isoformat(folder.updated_at),
+                "quizzes": payload_items,
+            },
+            folder.user_id,
+        )
+
+    @staticmethod
+    def _normalize_folder_compare(items: Any) -> Any:
+        if items is None:
+            return None
+        if isinstance(items, dict):
+            quizzes = items.get("quizzes", [])
+            return {
+                "_id": items.get("_id"),
+                "name": items.get("name"),
+                "quiz_ids": [quiz.get("_id") for quiz in quizzes],
+                "quiz_titles": [quiz.get("title") for quiz in quizzes],
+                "question_counts": [
+                    len(quiz.get("questions") or quiz.get("quiz_data", {}).get("questions", []))
+                    for quiz in quizzes
+                ],
+            }
+        normalized = [
+            {
+                "_id": item.get("_id"),
+                "name": item.get("name"),
+                "quiz_count": len(item.get("quizzes", [])),
+            }
+            for item in items
+        ]
+        return sorted(normalized, key=lambda item: item["_id"])
+
+    async def get_user_folders(self, user_id: str) -> list[dict[str, Any]]:
+        mode = settings.QUIZ_V2_FOLDER_READ_MODE
+        return await self._read_with_mode(
+            mode=mode,
+            operation="folder_list",
+            user_id=user_id,
+            legacy_reader=lambda: self._legacy_list_folders(user_id),
+            v2_reader=lambda: self._v2_list_folders(user_id),
+            compare_normalizer=self._normalize_folder_compare,
+        )
+
+    async def get_folder_by_id(self, folder_id: str, user_id: str) -> Optional[dict[str, Any]]:
+        mode = settings.QUIZ_V2_FOLDER_READ_MODE
+
+        async def legacy_reader():
+            folder, owner_id = await self._legacy_get_folder(folder_id)
+            if folder is None:
+                return None
+            if owner_id != user_id:
+                raise PermissionError("Unauthorized access to folder")
+            return folder
+
+        async def v2_reader():
+            folder, owner_id = await self._v2_get_folder(folder_id)
+            if folder is None:
+                return None
+            if owner_id != user_id:
+                raise PermissionError("Unauthorized access to folder")
+            return folder
+
+        return await self._read_with_mode(
+            mode=mode,
+            operation="folder_detail",
+            user_id=user_id,
+            legacy_reader=legacy_reader,
+            v2_reader=v2_reader,
+            compare_normalizer=self._normalize_folder_compare,
+        )

--- a/server/app/db/services/quiz_user_library_read_service.py
+++ b/server/app/db/services/quiz_user_library_read_service.py
@@ -1,20 +1,15 @@
 import logging
 from datetime import datetime
-from typing import Any, Awaitable, Callable, Literal, Optional
+from typing import Any, Optional
 
-from bson import ObjectId
-from bson.errors import InvalidId
 from motor.motor_asyncio import AsyncIOMotorCollection
 
 from server.app.db.core.config import settings
 from server.app.db.core.connection import (
     get_folder_items_v2_collection,
-    get_folders_collection,
     get_folders_v2_collection,
-    get_quiz_history_collection,
     get_quiz_history_v2_collection,
     get_quizzes_v2_collection,
-    get_saved_quizzes_collection,
     get_saved_quizzes_v2_collection,
 )
 from server.app.db.v2.models.quiz_models import QuizDocumentV2
@@ -30,8 +25,6 @@ from server.app.db.v2.repositories.reference_repository import ReferenceV2Reposi
 
 logger = logging.getLogger(__name__)
 
-ReadMode = Literal["legacy_only", "compare", "v2_only"]
-
 
 class QuizUserLibraryReadService:
     def __init__(
@@ -43,19 +36,6 @@ class QuizUserLibraryReadService:
         quiz_repository: Optional[QuizV2Repository] = None,
         reference_repository: Optional[ReferenceV2Repository] = None,
     ):
-        self.saved_quizzes_collection = (
-            saved_quizzes_collection
-            if saved_quizzes_collection is not None
-            else get_saved_quizzes_collection()
-        )
-        self.quiz_history_collection = (
-            quiz_history_collection
-            if quiz_history_collection is not None
-            else get_quiz_history_collection()
-        )
-        self.folders_collection = (
-            folders_collection if folders_collection is not None else get_folders_collection()
-        )
         self.quiz_repository = (
             quiz_repository if quiz_repository is not None else QuizV2Repository(get_quizzes_v2_collection())
         )
@@ -81,83 +61,15 @@ class QuizUserLibraryReadService:
             return value.isoformat()
         return value
 
-    @classmethod
-    def _serialize_legacy_document(cls, value: Any) -> Any:
-        if isinstance(value, dict):
-            return {key: cls._serialize_legacy_document(val) for key, val in value.items()}
-        if isinstance(value, list):
-            return [cls._serialize_legacy_document(item) for item in value]
-        if isinstance(value, ObjectId):
-            return str(value)
-        if isinstance(value, datetime):
-            return value.isoformat()
-        return value
-
-    @staticmethod
-    def _sort_by_created_desc(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        return sorted(items, key=lambda item: item.get("created_at") or "", reverse=True)
-
-    @staticmethod
-    def _sort_folders(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        return sorted(items, key=lambda item: (item.get("created_at") or "", item.get("_id") or ""))
-
     @staticmethod
     def _sort_folder_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
         def sort_key(item: dict[str, Any]):
             position = item.get("_position")
             if position is None:
                 position = 10**9
-            return (position, item.get("added_on") or item.get("created_at") or "", item.get("_id") or "")
+            return (position, item.get("added_on") or item.get("created_at") or "", item.get("id") or "")
 
         return sorted(items, key=sort_key)
-
-    def _normalize_for_compare(self, value: Any) -> Any:
-        if isinstance(value, datetime):
-            return value.isoformat()
-        if isinstance(value, dict):
-            return {key: self._normalize_for_compare(val) for key, val in value.items()}
-        if isinstance(value, list):
-            return [self._normalize_for_compare(item) for item in value]
-        return value
-
-    async def _read_with_mode(
-        self,
-        *,
-        mode: ReadMode,
-        operation: str,
-        user_id: Optional[str],
-        legacy_reader: Callable[[], Awaitable[Any]],
-        v2_reader: Callable[[], Awaitable[Any]],
-        compare_normalizer: Callable[[Any], Any],
-    ):
-        if mode == "legacy_only":
-            data = await legacy_reader()
-            self._log("quiz_read_legacy_served", operation=operation, user_id=user_id, read_mode=mode)
-            return data
-
-        if mode == "v2_only":
-            data = await v2_reader()
-            self._log("quiz_read_v2_served", operation=operation, user_id=user_id, read_mode=mode)
-            return data
-
-        self._log("quiz_read_compare_started", operation=operation, user_id=user_id, read_mode=mode)
-        legacy_data = await legacy_reader()
-        v2_data = await v2_reader()
-        normalized_legacy = compare_normalizer(legacy_data)
-        normalized_v2 = compare_normalizer(v2_data)
-        if normalized_legacy == normalized_v2:
-            self._log("quiz_read_compare_match", operation=operation, user_id=user_id, read_mode=mode)
-        else:
-            self._log(
-                "quiz_read_compare_mismatch",
-                operation=operation,
-                user_id=user_id,
-                read_mode=mode,
-                legacy_shape=normalized_legacy,
-                v2_shape=normalized_v2,
-            )
-        self._log("quiz_read_legacy_served", operation=operation, user_id=user_id, read_mode=mode)
-        return legacy_data
 
     async def _get_quizzes_by_ids(self, quiz_ids: list[str]) -> dict[str, QuizDocumentV2]:
         quizzes = await self.quiz_repository.find_many_by_ids(quiz_ids)
@@ -187,11 +99,7 @@ class QuizUserLibraryReadService:
             for question in quiz.questions
         ]
 
-    async def _legacy_get_quiz_history(self, user_id: str, limit: int) -> list[dict[str, Any]]:
-        documents = await self.quiz_history_collection.find({"user_id": user_id}).sort("created_at", -1).to_list(limit)
-        return [self._serialize_legacy_document(document) for document in documents]
-
-    async def _v2_get_quiz_history(self, user_id: str, limit: int) -> list[dict[str, Any]]:
+    async def get_quiz_history_for_user(self, user_id: str, limit: int = 100) -> list[dict[str, Any]]:
         references = await self.reference_repository.list_quiz_history_for_user(user_id)
         references = sorted(references, key=lambda reference: reference.created_at, reverse=True)[:limit]
         quizzes_by_id = await self._get_quizzes_by_ids([reference.quiz_id for reference in references])
@@ -203,12 +111,8 @@ class QuizUserLibraryReadService:
             payload.append(
                 {
                     "id": str(reference.id),
-                    "legacy_id": reference.legacy_history_id,
-                    "_id": reference.legacy_history_id or str(reference.id),
                     "user_id": reference.user_id,
                     "quiz_id": str(quiz.id),
-                    "legacy_quiz_id": quiz.legacy_quiz_id,
-                    "canonical_quiz_id": str(quiz.id),
                     "quiz_name": quiz.title,
                     "question_type": quiz.quiz_type.value,
                     "profession": reference.metadata.get("topic") or quiz.title,
@@ -218,53 +122,14 @@ class QuizUserLibraryReadService:
                     "created_at": self._isoformat(reference.created_at),
                 }
             )
+        self._log("quiz_read_v2_served", operation="quiz_history_list", user_id=user_id, read_mode="v2_only")
         return payload
-
-    @staticmethod
-    def _normalize_history_compare(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-        normalized = [
-            {
-                "_id": item.get("_id"),
-                "created_at": item.get("created_at"),
-                "question_count": len(item.get("questions", [])),
-                "questions": [question.get("question") for question in item.get("questions", [])],
-            }
-            for item in items
-        ]
-        return sorted(normalized, key=lambda item: item["_id"])
-
-    async def get_quiz_history_for_user(self, user_id: str, limit: int = 100) -> list[dict[str, Any]]:
-        mode = settings.QUIZ_V2_HISTORY_READ_MODE
-        return await self._read_with_mode(
-            mode=mode,
-            operation="quiz_history_list",
-            user_id=user_id,
-            legacy_reader=lambda: self._legacy_get_quiz_history(user_id, limit),
-            v2_reader=lambda: self._v2_get_quiz_history(user_id, limit),
-            compare_normalizer=self._normalize_history_compare,
-        )
-
-    async def _legacy_list_saved_quizzes(self, user_id: str, limit: int) -> list[dict[str, Any]]:
-        documents = await self.saved_quizzes_collection.find({"user_id": user_id}).sort("created_at", -1).to_list(limit)
-        return [self._serialize_legacy_document(document) for document in documents]
-
-    async def _legacy_get_saved_quiz(self, saved_quiz_id: str, user_id: str) -> Optional[dict[str, Any]]:
-        try:
-            object_id = ObjectId(saved_quiz_id)
-        except InvalidId:
-            return None
-        document = await self.saved_quizzes_collection.find_one({"_id": object_id, "user_id": user_id})
-        return self._serialize_legacy_document(document) if document else None
 
     def _build_saved_payload(self, reference: SavedQuizDocumentV2, quiz: QuizDocumentV2) -> dict[str, Any]:
         return {
             "id": str(reference.id),
-            "legacy_id": reference.legacy_saved_quiz_id,
-            "_id": reference.legacy_saved_quiz_id or str(reference.id),
             "user_id": reference.user_id,
             "quiz_id": str(quiz.id),
-            "legacy_quiz_id": quiz.legacy_quiz_id,
-            "canonical_quiz_id": str(quiz.id),
             "title": reference.display_title or quiz.title,
             "question_type": quiz.quiz_type.value,
             "is_deleted": False,
@@ -272,7 +137,7 @@ class QuizUserLibraryReadService:
             "created_at": self._isoformat(reference.saved_at),
         }
 
-    async def _v2_list_saved_quizzes(self, user_id: str, limit: int) -> list[dict[str, Any]]:
+    async def get_saved_quizzes_for_user(self, user_id: str, limit: int = 100) -> list[dict[str, Any]]:
         references = await self.reference_repository.list_saved_quizzes_for_user(user_id)
         references = sorted(references, key=lambda reference: reference.saved_at, reverse=True)[:limit]
         quizzes_by_id = await self._get_quizzes_by_ids([reference.quiz_id for reference in references])
@@ -282,76 +147,19 @@ class QuizUserLibraryReadService:
             if quiz is None:
                 continue
             payload.append(self._build_saved_payload(reference, quiz))
+        self._log("quiz_read_v2_served", operation="saved_quiz_list", user_id=user_id, read_mode="v2_only")
         return payload
 
-    async def _v2_get_saved_quiz(self, saved_quiz_id: str, user_id: str) -> Optional[dict[str, Any]]:
+    async def get_saved_quiz_by_id(self, saved_quiz_id: str, user_id: str) -> Optional[dict[str, Any]]:
         reference = await self.reference_repository.get_saved_quiz_by_public_id(saved_quiz_id, user_id=user_id)
         if reference is None:
             return None
         quiz = await self.quiz_repository.find_by_id(reference.quiz_id)
         if quiz is None:
             return None
-        return self._build_saved_payload(reference, quiz)
-
-    @staticmethod
-    def _normalize_saved_compare(items: Any) -> Any:
-        if items is None:
-            return None
-        if isinstance(items, dict):
-            items = [items]
-            unwrap = True
-        else:
-            unwrap = False
-        normalized = [
-            {
-                "_id": item.get("_id"),
-                "title": item.get("title"),
-                "created_at": item.get("created_at"),
-                "question_type": item.get("question_type"),
-                "question_count": len(item.get("questions", [])),
-                "questions": [question.get("question") for question in item.get("questions", [])],
-            }
-            for item in items
-        ]
-        normalized = sorted(normalized, key=lambda item: item["_id"])
-        return normalized[0] if unwrap else normalized
-
-    async def get_saved_quizzes_for_user(self, user_id: str, limit: int = 100) -> list[dict[str, Any]]:
-        mode = settings.QUIZ_V2_SAVED_READ_MODE
-        return await self._read_with_mode(
-            mode=mode,
-            operation="saved_quiz_list",
-            user_id=user_id,
-            legacy_reader=lambda: self._legacy_list_saved_quizzes(user_id, limit),
-            v2_reader=lambda: self._v2_list_saved_quizzes(user_id, limit),
-            compare_normalizer=self._normalize_saved_compare,
-        )
-
-    async def get_saved_quiz_by_id(self, saved_quiz_id: str, user_id: str) -> Optional[dict[str, Any]]:
-        mode = settings.QUIZ_V2_SAVED_READ_MODE
-        return await self._read_with_mode(
-            mode=mode,
-            operation="saved_quiz_detail",
-            user_id=user_id,
-            legacy_reader=lambda: self._legacy_get_saved_quiz(saved_quiz_id, user_id),
-            v2_reader=lambda: self._v2_get_saved_quiz(saved_quiz_id, user_id),
-            compare_normalizer=self._normalize_saved_compare,
-        )
-
-    async def _legacy_list_folders(self, user_id: str) -> list[dict[str, Any]]:
-        documents = await self.folders_collection.find({"user_id": user_id}).to_list(length=500)
-        return self._sort_folders([self._serialize_legacy_document(document) for document in documents])
-
-    async def _legacy_get_folder(self, folder_id: str) -> tuple[Optional[dict[str, Any]], Optional[str]]:
-        try:
-            object_id = ObjectId(folder_id)
-        except InvalidId:
-            return None, None
-        document = await self.folders_collection.find_one({"_id": object_id})
-        if not document:
-            return None, None
-        folder = self._serialize_legacy_document(document)
-        return folder, folder.get("user_id")
+        payload = self._build_saved_payload(reference, quiz)
+        self._log("quiz_read_v2_served", operation="saved_quiz_detail", user_id=user_id, read_mode="v2_only")
+        return payload
 
     def _build_folder_item_payload(
         self,
@@ -359,56 +167,43 @@ class QuizUserLibraryReadService:
         item: FolderItemDocumentV2,
         quiz: QuizDocumentV2,
     ) -> dict[str, Any]:
-        questions = self._serialize_saved_questions(quiz)
         return {
             "id": str(item.id),
-            "legacy_id": item.legacy_folder_item_id,
-            "_id": item.legacy_folder_item_id or str(item.id),
             "quiz_id": str(quiz.id),
-            "legacy_quiz_id": quiz.legacy_quiz_id,
-            "canonical_quiz_id": str(quiz.id),
             "title": item.display_title or quiz.title,
             "question_type": quiz.quiz_type.value,
-            "questions": questions,
+            "questions": self._serialize_saved_questions(quiz),
             "created_at": self._isoformat(item.created_at),
             "added_on": self._isoformat(item.created_at),
             "_position": item.position,
-            "quiz_data": {
-                "_id": item.legacy_folder_item_id or str(item.id),
-                "quiz_id": str(quiz.id),
-                "legacy_quiz_id": quiz.legacy_quiz_id,
-                "canonical_quiz_id": str(quiz.id),
-                "title": item.display_title or quiz.title,
-                "question_type": quiz.quiz_type.value,
-                "questions": questions,
-                "created_at": self._isoformat(quiz.created_at),
-            },
         }
 
-    async def _v2_list_folders(self, user_id: str) -> list[dict[str, Any]]:
+    async def get_user_folders(self, user_id: str) -> list[dict[str, Any]]:
         folders = await self.reference_repository.list_folders_for_user(user_id)
-        folders = sorted(folders, key=lambda folder: (folder.created_at, folder.legacy_folder_id or str(folder.id)))
+        folders = sorted(folders, key=lambda folder: (folder.created_at, str(folder.id)))
         folder_payloads: list[dict[str, Any]] = []
         for folder in folders:
             items = await self.reference_repository.list_folder_items_for_folder(str(folder.id))
             folder_payloads.append(
                 {
                     "id": str(folder.id),
-                    "legacy_id": folder.legacy_folder_id,
-                    "_id": folder.legacy_folder_id or str(folder.id),
                     "user_id": folder.user_id,
                     "name": folder.name,
                     "created_at": self._isoformat(folder.created_at),
                     "updated_at": self._isoformat(folder.updated_at),
-                    "quizzes": [{"_id": item.legacy_folder_item_id or str(item.id)} for item in items],
+                    "quizzes": [{"id": str(item.id)} for item in items],
+                    "quiz_count": len(items),
                 }
             )
+        self._log("quiz_read_v2_served", operation="folder_list", user_id=user_id, read_mode="v2_only")
         return folder_payloads
 
-    async def _v2_get_folder(self, folder_id: str) -> tuple[Optional[dict[str, Any]], Optional[str]]:
+    async def get_folder_by_id(self, folder_id: str, user_id: str) -> Optional[dict[str, Any]]:
         folder = await self.reference_repository.get_folder_by_public_id(folder_id)
         if folder is None:
-            return None, None
+            return None
+        if folder.user_id != user_id:
+            raise PermissionError("Unauthorized access to folder")
         items = await self.reference_repository.list_folder_items_for_folder(str(folder.id))
         quiz_map = await self._get_quizzes_by_ids([item.quiz_id for item in items])
         payload_items: list[dict[str, Any]] = []
@@ -420,81 +215,13 @@ class QuizUserLibraryReadService:
         payload_items = self._sort_folder_items(payload_items)
         for payload_item in payload_items:
             payload_item.pop("_position", None)
-        return (
-            {
-                "id": str(folder.id),
-                "legacy_id": folder.legacy_folder_id,
-                "_id": folder.legacy_folder_id or str(folder.id),
-                "user_id": folder.user_id,
-                "name": folder.name,
-                "created_at": self._isoformat(folder.created_at),
-                "updated_at": self._isoformat(folder.updated_at),
-                "quizzes": payload_items,
-            },
-            folder.user_id,
-        )
-
-    @staticmethod
-    def _normalize_folder_compare(items: Any) -> Any:
-        if items is None:
-            return None
-        if isinstance(items, dict):
-            quizzes = items.get("quizzes", [])
-            return {
-                "_id": items.get("_id"),
-                "name": items.get("name"),
-                "quiz_ids": [quiz.get("_id") for quiz in quizzes],
-                "quiz_titles": [quiz.get("title") for quiz in quizzes],
-                "question_counts": [
-                    len(quiz.get("questions") or quiz.get("quiz_data", {}).get("questions", []))
-                    for quiz in quizzes
-                ],
-            }
-        normalized = [
-            {
-                "_id": item.get("_id"),
-                "name": item.get("name"),
-                "quiz_count": len(item.get("quizzes", [])),
-            }
-            for item in items
-        ]
-        return sorted(normalized, key=lambda item: item["_id"])
-
-    async def get_user_folders(self, user_id: str) -> list[dict[str, Any]]:
-        mode = settings.QUIZ_V2_FOLDER_READ_MODE
-        return await self._read_with_mode(
-            mode=mode,
-            operation="folder_list",
-            user_id=user_id,
-            legacy_reader=lambda: self._legacy_list_folders(user_id),
-            v2_reader=lambda: self._v2_list_folders(user_id),
-            compare_normalizer=self._normalize_folder_compare,
-        )
-
-    async def get_folder_by_id(self, folder_id: str, user_id: str) -> Optional[dict[str, Any]]:
-        mode = settings.QUIZ_V2_FOLDER_READ_MODE
-
-        async def legacy_reader():
-            folder, owner_id = await self._legacy_get_folder(folder_id)
-            if folder is None:
-                return None
-            if owner_id != user_id:
-                raise PermissionError("Unauthorized access to folder")
-            return folder
-
-        async def v2_reader():
-            folder, owner_id = await self._v2_get_folder(folder_id)
-            if folder is None:
-                return None
-            if owner_id != user_id:
-                raise PermissionError("Unauthorized access to folder")
-            return folder
-
-        return await self._read_with_mode(
-            mode=mode,
-            operation="folder_detail",
-            user_id=user_id,
-            legacy_reader=legacy_reader,
-            v2_reader=v2_reader,
-            compare_normalizer=self._normalize_folder_compare,
-        )
+        payload = {
+            "id": str(folder.id),
+            "user_id": folder.user_id,
+            "name": folder.name,
+            "created_at": self._isoformat(folder.created_at),
+            "updated_at": self._isoformat(folder.updated_at),
+            "quizzes": payload_items,
+        }
+        self._log("quiz_read_v2_served", operation="folder_detail", user_id=user_id, read_mode="v2_only")
+        return payload

--- a/server/app/db/services/shared_quiz_read_service.py
+++ b/server/app/db/services/shared_quiz_read_service.py
@@ -1,0 +1,202 @@
+import logging
+from typing import Any, Optional
+
+from bson import ObjectId
+from bson.errors import InvalidId
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from server.app.db.core.config import settings
+from server.app.db.core.connection import (
+    get_ai_generated_quizzes_collection,
+    get_quizzes_collection,
+    get_quizzes_v2_collection,
+    get_saved_quizzes_collection,
+    get_saved_quizzes_v2_collection,
+    get_folder_items_v2_collection,
+    get_folders_v2_collection,
+    get_quiz_history_v2_collection,
+)
+from server.app.db.services.quiz_user_library_read_service import ReadMode
+from server.app.db.v2.models.quiz_models import QuizDocumentV2
+from server.app.db.v2.repositories.quiz_repository import QuizV2Repository
+from server.app.db.v2.repositories.reference_repository import ReferenceV2Repository
+
+
+logger = logging.getLogger(__name__)
+
+
+def build_default_description(topic: str) -> str:
+    return f"A quiz to test your knowledge on {topic}"
+
+
+class SharedQuizReadService:
+    def __init__(
+        self,
+        *,
+        quizzes_collection: Optional[AsyncIOMotorCollection] = None,
+        ai_generated_quizzes_collection: Optional[AsyncIOMotorCollection] = None,
+        saved_quizzes_collection: Optional[AsyncIOMotorCollection] = None,
+        quiz_repository: Optional[QuizV2Repository] = None,
+        reference_repository: Optional[ReferenceV2Repository] = None,
+    ):
+        self.quizzes_collection = (
+            quizzes_collection if quizzes_collection is not None else get_quizzes_collection()
+        )
+        self.ai_generated_quizzes_collection = (
+            ai_generated_quizzes_collection
+            if ai_generated_quizzes_collection is not None
+            else get_ai_generated_quizzes_collection()
+        )
+        self.saved_quizzes_collection = (
+            saved_quizzes_collection
+            if saved_quizzes_collection is not None
+            else get_saved_quizzes_collection()
+        )
+        self.quiz_repository = (
+            quiz_repository if quiz_repository is not None else QuizV2Repository(get_quizzes_v2_collection())
+        )
+        self.reference_repository = (
+            reference_repository
+            if reference_repository is not None
+            else ReferenceV2Repository(
+                get_folders_v2_collection(),
+                get_folder_items_v2_collection(),
+                get_saved_quizzes_v2_collection(),
+                get_quiz_history_v2_collection(),
+            )
+        )
+
+    def _log(self, event: str, **fields):
+        if not settings.QUIZ_V2_STRUCTURED_LOGGING:
+            return
+        logger.info("%s | %s", event, fields)
+
+    @staticmethod
+    def _normalize_legacy_quiz(
+        quiz_doc: dict[str, Any],
+        quiz_id: str,
+        source: str,
+    ) -> dict[str, Any]:
+        if source == "quizzes":
+            title = quiz_doc.get("title") or "General Knowledge"
+            description = quiz_doc.get("description") or build_default_description(title)
+            quiz_type = quiz_doc.get("quiz_type") or "multichoice"
+        elif source == "ai_generated_quizzes":
+            profession = quiz_doc.get("profession") or "General Knowledge"
+            title = profession
+            description = quiz_doc.get("description") or build_default_description(profession)
+            quiz_type = quiz_doc.get("question_type") or "multichoice"
+        elif source == "saved_quizzes":
+            title = quiz_doc.get("title") or "General Knowledge"
+            topic = quiz_doc.get("profession") or title
+            description = quiz_doc.get("description") or build_default_description(topic)
+            quiz_type = quiz_doc.get("question_type") or "multichoice"
+        else:
+            raise ValueError(f"Unsupported shared quiz source: {source}")
+
+        return {
+            "id": quiz_id,
+            "title": title,
+            "description": description,
+            "quiz_type": quiz_type,
+            "questions": quiz_doc.get("questions", []),
+        }
+
+    @staticmethod
+    def _normalize_v2_quiz(quiz_doc: QuizDocumentV2, requested_quiz_id: str) -> dict[str, Any]:
+        topic = quiz_doc.title or "General Knowledge"
+        return {
+            "id": requested_quiz_id,
+            "title": quiz_doc.title,
+            "description": quiz_doc.description or build_default_description(topic),
+            "quiz_type": quiz_doc.quiz_type.value,
+            "questions": [
+                {
+                    "question": question.question,
+                    "options": question.options,
+                    "correct_answer": question.correct_answer,
+                }
+                for question in quiz_doc.questions
+            ],
+        }
+
+    async def _legacy_resolve(self, quiz_id: str) -> Optional[dict[str, Any]]:
+        try:
+            object_id = ObjectId(quiz_id)
+        except InvalidId:
+            return None
+
+        regular_quiz = await self.quizzes_collection.find_one({"_id": object_id}, projection={"_id": 0})
+        if regular_quiz:
+            return self._normalize_legacy_quiz(regular_quiz, quiz_id, "quizzes")
+
+        ai_quiz = await self.ai_generated_quizzes_collection.find_one({"_id": object_id}, projection={"_id": 0})
+        if ai_quiz:
+            return self._normalize_legacy_quiz(ai_quiz, quiz_id, "ai_generated_quizzes")
+
+        saved_quiz = await self.saved_quizzes_collection.find_one({"_id": object_id}, projection={"_id": 0})
+        if saved_quiz:
+            return self._normalize_legacy_quiz(saved_quiz, quiz_id, "saved_quizzes")
+        return None
+
+    async def _v2_resolve(self, quiz_id: str) -> Optional[dict[str, Any]]:
+        quiz_doc = await self.quiz_repository.find_by_id(quiz_id)
+        if quiz_doc:
+            return self._normalize_v2_quiz(quiz_doc, quiz_id)
+
+        quiz_doc = await self.quiz_repository.find_by_legacy_mapping("quizzes", quiz_id)
+        if quiz_doc:
+            return self._normalize_v2_quiz(quiz_doc, quiz_id)
+
+        quiz_doc = await self.quiz_repository.find_by_legacy_mapping("ai_generated_quizzes", quiz_id)
+        if quiz_doc:
+            return self._normalize_v2_quiz(quiz_doc, quiz_id)
+
+        saved_reference = await self.reference_repository.get_saved_quiz_by_legacy_id(quiz_id)
+        if saved_reference:
+            quiz_doc = await self.quiz_repository.find_by_id(saved_reference.quiz_id)
+            if quiz_doc:
+                return self._normalize_v2_quiz(quiz_doc, quiz_id)
+        return None
+
+    @staticmethod
+    def _normalize_for_compare(payload: Optional[dict[str, Any]]) -> Any:
+        if payload is None:
+            return None
+        return {
+            "title": payload.get("title"),
+            "description": payload.get("description"),
+            "quiz_type": payload.get("quiz_type"),
+            "question_count": len(payload.get("questions", [])),
+            "questions": [question.get("question") for question in payload.get("questions", [])],
+        }
+
+    async def resolve_shared_quiz(self, quiz_id: str) -> Optional[dict[str, Any]]:
+        mode: ReadMode = settings.QUIZ_V2_SHARE_READ_MODE
+
+        if mode == "legacy_only":
+            payload = await self._legacy_resolve(quiz_id)
+            self._log("quiz_read_legacy_served", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
+            return payload
+
+        if mode == "v2_only":
+            payload = await self._v2_resolve(quiz_id)
+            self._log("quiz_read_v2_served", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
+            return payload
+
+        self._log("quiz_read_compare_started", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
+        legacy_payload = await self._legacy_resolve(quiz_id)
+        v2_payload = await self._v2_resolve(quiz_id)
+        if self._normalize_for_compare(legacy_payload) == self._normalize_for_compare(v2_payload):
+            self._log("quiz_read_compare_match", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
+        else:
+            self._log(
+                "quiz_read_compare_mismatch",
+                operation="shared_quiz_detail",
+                read_mode=mode,
+                quiz_id=quiz_id,
+                legacy_shape=self._normalize_for_compare(legacy_payload),
+                v2_shape=self._normalize_for_compare(v2_payload),
+            )
+        self._log("quiz_read_legacy_served", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
+        return legacy_payload

--- a/server/app/db/services/shared_quiz_read_service.py
+++ b/server/app/db/services/shared_quiz_read_service.py
@@ -106,7 +106,9 @@ class SharedQuizReadService:
     def _normalize_v2_quiz(quiz_doc: QuizDocumentV2, requested_quiz_id: str) -> dict[str, Any]:
         topic = quiz_doc.title or "General Knowledge"
         return {
-            "id": requested_quiz_id,
+            "id": str(quiz_doc.id),
+            "legacy_quiz_id": quiz_doc.legacy_quiz_id,
+            "requested_quiz_id": requested_quiz_id,
             "title": quiz_doc.title,
             "description": quiz_doc.description or build_default_description(topic),
             "quiz_type": quiz_doc.quiz_type.value,

--- a/server/app/db/services/shared_quiz_read_service.py
+++ b/server/app/db/services/shared_quiz_read_service.py
@@ -1,22 +1,16 @@
 import logging
 from typing import Any, Optional
 
-from bson import ObjectId
-from bson.errors import InvalidId
 from motor.motor_asyncio import AsyncIOMotorCollection
 
 from server.app.db.core.config import settings
 from server.app.db.core.connection import (
-    get_ai_generated_quizzes_collection,
-    get_quizzes_collection,
-    get_quizzes_v2_collection,
-    get_saved_quizzes_collection,
-    get_saved_quizzes_v2_collection,
     get_folder_items_v2_collection,
     get_folders_v2_collection,
     get_quiz_history_v2_collection,
+    get_quizzes_v2_collection,
+    get_saved_quizzes_v2_collection,
 )
-from server.app.db.services.quiz_user_library_read_service import ReadMode
 from server.app.db.v2.models.quiz_models import QuizDocumentV2
 from server.app.db.v2.repositories.quiz_repository import QuizV2Repository
 from server.app.db.v2.repositories.reference_repository import ReferenceV2Repository
@@ -39,19 +33,6 @@ class SharedQuizReadService:
         quiz_repository: Optional[QuizV2Repository] = None,
         reference_repository: Optional[ReferenceV2Repository] = None,
     ):
-        self.quizzes_collection = (
-            quizzes_collection if quizzes_collection is not None else get_quizzes_collection()
-        )
-        self.ai_generated_quizzes_collection = (
-            ai_generated_quizzes_collection
-            if ai_generated_quizzes_collection is not None
-            else get_ai_generated_quizzes_collection()
-        )
-        self.saved_quizzes_collection = (
-            saved_quizzes_collection
-            if saved_quizzes_collection is not None
-            else get_saved_quizzes_collection()
-        )
         self.quiz_repository = (
             quiz_repository if quiz_repository is not None else QuizV2Repository(get_quizzes_v2_collection())
         )
@@ -72,43 +53,10 @@ class SharedQuizReadService:
         logger.info("%s | %s", event, fields)
 
     @staticmethod
-    def _normalize_legacy_quiz(
-        quiz_doc: dict[str, Any],
-        quiz_id: str,
-        source: str,
-    ) -> dict[str, Any]:
-        if source == "quizzes":
-            title = quiz_doc.get("title") or "General Knowledge"
-            description = quiz_doc.get("description") or build_default_description(title)
-            quiz_type = quiz_doc.get("quiz_type") or "multichoice"
-        elif source == "ai_generated_quizzes":
-            profession = quiz_doc.get("profession") or "General Knowledge"
-            title = profession
-            description = quiz_doc.get("description") or build_default_description(profession)
-            quiz_type = quiz_doc.get("question_type") or "multichoice"
-        elif source == "saved_quizzes":
-            title = quiz_doc.get("title") or "General Knowledge"
-            topic = quiz_doc.get("profession") or title
-            description = quiz_doc.get("description") or build_default_description(topic)
-            quiz_type = quiz_doc.get("question_type") or "multichoice"
-        else:
-            raise ValueError(f"Unsupported shared quiz source: {source}")
-
-        return {
-            "id": quiz_id,
-            "title": title,
-            "description": description,
-            "quiz_type": quiz_type,
-            "questions": quiz_doc.get("questions", []),
-        }
-
-    @staticmethod
-    def _normalize_v2_quiz(quiz_doc: QuizDocumentV2, requested_quiz_id: str) -> dict[str, Any]:
+    def _normalize_v2_quiz(quiz_doc: QuizDocumentV2) -> dict[str, Any]:
         topic = quiz_doc.title or "General Knowledge"
         return {
             "id": str(quiz_doc.id),
-            "legacy_quiz_id": quiz_doc.legacy_quiz_id,
-            "requested_quiz_id": requested_quiz_id,
             "title": quiz_doc.title,
             "description": quiz_doc.description or build_default_description(topic),
             "quiz_type": quiz_doc.quiz_type.value,
@@ -122,83 +70,17 @@ class SharedQuizReadService:
             ],
         }
 
-    async def _legacy_resolve(self, quiz_id: str) -> Optional[dict[str, Any]]:
-        try:
-            object_id = ObjectId(quiz_id)
-        except InvalidId:
-            return None
-
-        regular_quiz = await self.quizzes_collection.find_one({"_id": object_id}, projection={"_id": 0})
-        if regular_quiz:
-            return self._normalize_legacy_quiz(regular_quiz, quiz_id, "quizzes")
-
-        ai_quiz = await self.ai_generated_quizzes_collection.find_one({"_id": object_id}, projection={"_id": 0})
-        if ai_quiz:
-            return self._normalize_legacy_quiz(ai_quiz, quiz_id, "ai_generated_quizzes")
-
-        saved_quiz = await self.saved_quizzes_collection.find_one({"_id": object_id}, projection={"_id": 0})
-        if saved_quiz:
-            return self._normalize_legacy_quiz(saved_quiz, quiz_id, "saved_quizzes")
-        return None
-
-    async def _v2_resolve(self, quiz_id: str) -> Optional[dict[str, Any]]:
-        quiz_doc = await self.quiz_repository.find_by_id(quiz_id)
-        if quiz_doc:
-            return self._normalize_v2_quiz(quiz_doc, quiz_id)
-
-        quiz_doc = await self.quiz_repository.find_by_legacy_mapping("quizzes", quiz_id)
-        if quiz_doc:
-            return self._normalize_v2_quiz(quiz_doc, quiz_id)
-
-        quiz_doc = await self.quiz_repository.find_by_legacy_mapping("ai_generated_quizzes", quiz_id)
-        if quiz_doc:
-            return self._normalize_v2_quiz(quiz_doc, quiz_id)
-
-        saved_reference = await self.reference_repository.get_saved_quiz_by_legacy_id(quiz_id)
-        if saved_reference:
-            quiz_doc = await self.quiz_repository.find_by_id(saved_reference.quiz_id)
-            if quiz_doc:
-                return self._normalize_v2_quiz(quiz_doc, quiz_id)
-        return None
-
-    @staticmethod
-    def _normalize_for_compare(payload: Optional[dict[str, Any]]) -> Any:
-        if payload is None:
-            return None
-        return {
-            "title": payload.get("title"),
-            "description": payload.get("description"),
-            "quiz_type": payload.get("quiz_type"),
-            "question_count": len(payload.get("questions", [])),
-            "questions": [question.get("question") for question in payload.get("questions", [])],
-        }
-
     async def resolve_shared_quiz(self, quiz_id: str) -> Optional[dict[str, Any]]:
-        mode: ReadMode = settings.QUIZ_V2_SHARE_READ_MODE
+        quiz_doc = await self.quiz_repository.find_by_id(quiz_id)
+        if not quiz_doc:
+            quiz_doc = await self.quiz_repository.find_by_legacy_mapping("quizzes", quiz_id)
+        if not quiz_doc:
+            quiz_doc = await self.quiz_repository.find_by_legacy_mapping("ai_generated_quizzes", quiz_id)
+        if not quiz_doc:
+            saved_reference = await self.reference_repository.get_saved_quiz_by_legacy_id(quiz_id)
+            if saved_reference:
+                quiz_doc = await self.quiz_repository.find_by_id(saved_reference.quiz_id)
 
-        if mode == "legacy_only":
-            payload = await self._legacy_resolve(quiz_id)
-            self._log("quiz_read_legacy_served", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
-            return payload
-
-        if mode == "v2_only":
-            payload = await self._v2_resolve(quiz_id)
-            self._log("quiz_read_v2_served", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
-            return payload
-
-        self._log("quiz_read_compare_started", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
-        legacy_payload = await self._legacy_resolve(quiz_id)
-        v2_payload = await self._v2_resolve(quiz_id)
-        if self._normalize_for_compare(legacy_payload) == self._normalize_for_compare(v2_payload):
-            self._log("quiz_read_compare_match", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
-        else:
-            self._log(
-                "quiz_read_compare_mismatch",
-                operation="shared_quiz_detail",
-                read_mode=mode,
-                quiz_id=quiz_id,
-                legacy_shape=self._normalize_for_compare(legacy_payload),
-                v2_shape=self._normalize_for_compare(v2_payload),
-            )
-        self._log("quiz_read_legacy_served", operation="shared_quiz_detail", read_mode=mode, quiz_id=quiz_id)
-        return legacy_payload
+        payload = self._normalize_v2_quiz(quiz_doc) if quiz_doc else None
+        self._log("quiz_read_v2_served", operation="shared_quiz_detail", read_mode="v2_only", quiz_id=quiz_id)
+        return payload

--- a/server/app/db/v2/indexes.py
+++ b/server/app/db/v2/indexes.py
@@ -1,6 +1,35 @@
 from motor.motor_asyncio import AsyncIOMotorCollection
 
 
+async def _ensure_partial_unique_index(
+    collection: AsyncIOMotorCollection,
+    *,
+    keys: list[tuple[str, int]],
+    name: str,
+    partial_filter_expression: dict,
+):
+    index_info = await collection.index_information()
+    existing = index_info.get(name)
+
+    if existing is not None:
+        existing_keys = existing.get("key")
+        existing_unique = existing.get("unique", False)
+        existing_partial = existing.get("partialFilterExpression")
+        if (
+            existing_keys != keys
+            or existing_unique is not True
+            or existing_partial != partial_filter_expression
+        ):
+            await collection.drop_index(name)
+
+    await collection.create_index(
+        keys,
+        name=name,
+        unique=True,
+        partialFilterExpression=partial_filter_expression,
+    )
+
+
 async def ensure_quizzes_v2_indexes(collection: AsyncIOMotorCollection):
     await collection.create_index([("owner_user_id", 1), ("created_at", -1)])
     await collection.create_index([("visibility", 1), ("created_at", -1)])
@@ -19,7 +48,12 @@ async def ensure_quizzes_v2_indexes(collection: AsyncIOMotorCollection):
 
 
 async def ensure_folders_v2_indexes(collection: AsyncIOMotorCollection):
-    await collection.create_index([("user_id", 1), ("name", 1)], unique=True)
+    await _ensure_partial_unique_index(
+        collection,
+        keys=[("user_id", 1), ("name", 1)],
+        name="user_id_1_name_1",
+        partial_filter_expression={"deleted_at": None},
+    )
     await collection.create_index(
         "legacy_folder_id",
         unique=True,
@@ -28,7 +62,12 @@ async def ensure_folders_v2_indexes(collection: AsyncIOMotorCollection):
 
 
 async def ensure_folder_items_v2_indexes(collection: AsyncIOMotorCollection):
-    await collection.create_index([("folder_id", 1), ("quiz_id", 1)], unique=True)
+    await _ensure_partial_unique_index(
+        collection,
+        keys=[("folder_id", 1), ("quiz_id", 1)],
+        name="folder_id_1_quiz_id_1",
+        partial_filter_expression={"deleted_at": None},
+    )
     await collection.create_index([("folder_id", 1), ("position", 1)])
     await collection.create_index(
         "legacy_folder_item_id",
@@ -38,7 +77,12 @@ async def ensure_folder_items_v2_indexes(collection: AsyncIOMotorCollection):
 
 
 async def ensure_saved_quizzes_v2_indexes(collection: AsyncIOMotorCollection):
-    await collection.create_index([("user_id", 1), ("quiz_id", 1)], unique=True)
+    await _ensure_partial_unique_index(
+        collection,
+        keys=[("user_id", 1), ("quiz_id", 1)],
+        name="user_id_1_quiz_id_1",
+        partial_filter_expression={"deleted_at": None},
+    )
     await collection.create_index([("user_id", 1), ("saved_at", -1)])
     await collection.create_index(
         "legacy_saved_quiz_id",

--- a/server/app/db/v2/migration.md
+++ b/server/app/db/v2/migration.md
@@ -15,7 +15,7 @@ The intended end state is:
 - V2 collections are the authoritative store for supported quiz flows
 - historical legacy data is backfilled into V2
 - live reads and writes operate through V2
-- legacy collections remain only for stabilization, rollback, audit, or archival until explicitly deprecated and removed
+- legacy collections remain only for audit, archival, or deliberate deprecation/removal work once the V2 path is fully settled
 
 ## V2 Collections
 
@@ -65,8 +65,7 @@ Important note:
 Completed:
 
 - saved quiz, history, folder, and share reads were cut over to V2-backed read services
-- read behavior was validated through compare-mode and then moved to `v2_only`
-- response compatibility was preserved while the frontend transition was still underway
+- read behavior was validated during migration rollout and then simplified to V2-only service paths
 - folder ordering and user-facing title parity were aligned in V2
 
 ### Stage 5: Final V2 Cutover
@@ -84,10 +83,6 @@ Completed:
 Current config defaults:
 
 - `QUIZ_V2_WRITE_MODE = "v2_only"`
-- `QUIZ_V2_SAVED_READ_MODE = "v2_only"`
-- `QUIZ_V2_HISTORY_READ_MODE = "v2_only"`
-- `QUIZ_V2_FOLDER_READ_MODE = "v2_only"`
-- `QUIZ_V2_SHARE_READ_MODE = "v2_only"`
 
 Current authoritative behavior:
 
@@ -116,35 +111,7 @@ The current implementation has achieved the main migration guarantees:
 
 The following items still remain if the goal is a fully completed migration and legacy deprecation process.
 
-### 1. Remove or Retire Migration Compatibility Branches
-
-The codebase still contains migration-era compatibility logic in some services, including:
-
-- legacy-read branches
-- compare-mode branches
-- legacy-id compatibility shaping
-
-These should be either:
-
-- removed after the stabilization window, or
-- explicitly retained as rollback-only logic with clear ownership and expiry
-
-### 2. Finalize Public ID Contract
-
-The migrated surfaces now expose V2 ids and canonical quiz ids, but some payloads still carry compatibility fields such as:
-
-- `_id`
-- `legacy_id`
-- `legacy_quiz_id`
-
-A final migration decision is still needed:
-
-- which of these fields remain intentionally supported
-- which are transitional and should be removed after stabilization
-
-This is migration-scoped because it determines when legacy-id support truly ends.
-
-### 3. Decide the Fate of Remaining Legacy-First Non-Core Routes
+### 1. Decide the Fate of Remaining Legacy-First Non-Core Routes
 
 Some non-core or test-oriented legacy CRUD paths still exist in the codebase, especially around manual/test quiz routes.
 
@@ -156,32 +123,30 @@ Migration follow-up is needed to decide whether they should:
 
 If they remain, they should not create ambiguity about whether legacy is still part of the normal production path.
 
-### 4. Add Final Legacy-Usage Guardrails
+### 2. Add Final Legacy-Usage Guardrails
 
-After V2-only stabilization, the migration should add stronger guarantees that unsupported legacy access does not silently continue.
+The main migrated paths are V2-only now, but the migration can still add stronger guarantees that unsupported legacy access does not silently continue.
 
 Examples:
 
 - warning/error logs if deprecated legacy repositories are invoked
 - assertions or tests for unsupported legacy write usage
-- startup validation for invalid migration flag combinations
+- startup validation for invalid migration flag combinations where migration-mode settings still exist
 
-### 5. Complete Legacy Deprecation Plan
+### 3. Complete Legacy Deprecation Plan
 
 The migration is not fully complete until legacy collections have a defined post-cutover lifecycle.
 
 A migration completion plan is still needed for:
 
-- stabilization window length
-- rollback expectations
 - legacy collection archival policy
 - final legacy collection removal plan
 
-### 6. Optional Index Hardening After Stabilization
+### 4. Optional Index Hardening After Duplicate Cleanup
 
 Code-level dedupe and merge protections are in place for several legacy-reference scenarios.
 
-After production stabilization and duplicate cleanup are confirmed, the migration can consider stronger DB-level enforcement for legacy reference uniqueness where appropriate.
+After duplicate cleanup is confirmed in target environments, the migration can consider stronger DB-level enforcement for legacy reference uniqueness where appropriate.
 
 This should only happen after verifying there is no conflicting legacy residue in existing environments.
 
@@ -200,11 +165,11 @@ To finish the migration cleanly, the next migration-scoped sequence should be:
 
 1. stabilize V2-only operation in target environments
 2. monitor for unexpected legacy-path usage
-3. decide which compatibility fields remain public and which are removed
-4. retire compare/legacy branches that are no longer needed
-5. document legacy archival/removal plan
+3. quarantine or migrate the remaining non-core legacy-first routes
+4. document legacy archival/removal plan
+5. add stronger guardrails for deprecated legacy access
 6. execute final legacy deprecation/removal in a follow-up cleanup stage
 
 ## Summary
 
-The migration has reached the point where V2 is operationally authoritative for the supported quiz-library flows. The remaining work is no longer about proving the V2 model; it is about finishing the deprecation and cleanup process so that legacy support becomes explicit, limited, and eventually removable.
+The migration has reached the point where V2 is operationally authoritative for the supported quiz-library flows. The remaining work is no longer about proving the V2 model; it is about finishing legacy deprecation deliberately so that the remaining legacy assets are explicit, limited, and eventually removable.

--- a/server/app/db/v2/migration.md
+++ b/server/app/db/v2/migration.md
@@ -1,0 +1,210 @@
+# V2 Migration Status
+
+## Purpose
+
+This document tracks the current state of the quiz-data migration to V2, what has been completed, what is now operationally authoritative, and what migration-scoped work still remains before the legacy path can be considered fully deprecated and cleaned up.
+
+This document is intentionally scoped to the database migration and cutover only. It does not cover unrelated application cleanup.
+
+## Migration Objective
+
+The migration introduced a normalized V2 data model so that quiz content, saved quiz references, quiz history, folders, and folder items can be managed through canonical V2 records rather than legacy duplicated payload storage.
+
+The intended end state is:
+
+- V2 collections are the authoritative store for supported quiz flows
+- historical legacy data is backfilled into V2
+- live reads and writes operate through V2
+- legacy collections remain only for stabilization, rollback, audit, or archival until explicitly deprecated and removed
+
+## V2 Collections
+
+The migration currently centers on these collections:
+
+- `quizzes_v2`
+- `saved_quizzes_v2`
+- `quiz_history_v2`
+- `folders_v2`
+- `folder_items_v2`
+
+## Completed Stages
+
+### Stage 1: V2 Foundation
+
+Completed:
+
+- V2 collections, validators, and indexes were introduced
+- canonical quiz and reference models were added
+- repository and write-service foundations were created
+
+### Stage 2: Dual Writes
+
+Completed:
+
+- legacy write flows were mirrored into V2
+- canonical/source mapping was introduced
+- live traffic could populate V2 while legacy remained active
+
+### Stage 3: Historical Backfill
+
+Completed:
+
+- historical legacy data was backfilled into V2
+- reruns were hardened for idempotency
+- stable fallback timestamps were introduced
+- legacy saved/folder records without answer payloads were resolved safely against full legacy/V2 sources
+- duplicate saved and folder-item convergence paths were hardened
+- parity reporting and structured backfill summaries were added
+
+Important note:
+
+- environments that previously ran Stage 3 needed a rerun after later Stage 4 parity changes so `display_title` and folder-item `position` could be populated in V2
+
+### Stage 4: Read Cutover
+
+Completed:
+
+- saved quiz, history, folder, and share reads were cut over to V2-backed read services
+- read behavior was validated through compare-mode and then moved to `v2_only`
+- response compatibility was preserved while the frontend transition was still underway
+- folder ordering and user-facing title parity were aligned in V2
+
+### Stage 5: Final V2 Cutover
+
+Completed:
+
+- V2 is now the default write path for migrated quiz-library flows
+- V2 is the default read path for saved/history/folder/share flows
+- generation/save/history/share flows now operate with canonical V2 quiz ids
+- frontend authenticated library flows were updated to consume V2 ids and canonical quiz ids
+- download-by-id was updated to resolve canonical V2 quizzes
+
+## Current Operational State
+
+Current config defaults:
+
+- `QUIZ_V2_WRITE_MODE = "v2_only"`
+- `QUIZ_V2_SAVED_READ_MODE = "v2_only"`
+- `QUIZ_V2_HISTORY_READ_MODE = "v2_only"`
+- `QUIZ_V2_FOLDER_READ_MODE = "v2_only"`
+- `QUIZ_V2_SHARE_READ_MODE = "v2_only"`
+
+Current authoritative behavior:
+
+- saved quiz writes: V2
+- history writes: V2
+- folder writes: V2
+- saved quiz reads: V2
+- history reads: V2
+- folder reads: V2
+- shared quiz reads: V2
+- generated quiz identity: canonical V2 id
+- download by quiz id: supports canonical V2 quiz ids
+
+## Migration Guarantees Achieved
+
+The current implementation has achieved the main migration guarantees:
+
+- historical data is migrated into V2
+- key legacy edge cases discovered during migration are handled explicitly
+- reruns are materially idempotent for supported backfill flows
+- user-library data is served from V2
+- supported library writes no longer require legacy persistence
+- canonical quiz identity is now usable across core flows
+
+## Remaining Migration-Scoped Work
+
+The following items still remain if the goal is a fully completed migration and legacy deprecation process.
+
+### 1. Remove or Retire Migration Compatibility Branches
+
+The codebase still contains migration-era compatibility logic in some services, including:
+
+- legacy-read branches
+- compare-mode branches
+- legacy-id compatibility shaping
+
+These should be either:
+
+- removed after the stabilization window, or
+- explicitly retained as rollback-only logic with clear ownership and expiry
+
+### 2. Finalize Public ID Contract
+
+The migrated surfaces now expose V2 ids and canonical quiz ids, but some payloads still carry compatibility fields such as:
+
+- `_id`
+- `legacy_id`
+- `legacy_quiz_id`
+
+A final migration decision is still needed:
+
+- which of these fields remain intentionally supported
+- which are transitional and should be removed after stabilization
+
+This is migration-scoped because it determines when legacy-id support truly ends.
+
+### 3. Decide the Fate of Remaining Legacy-First Non-Core Routes
+
+Some non-core or test-oriented legacy CRUD paths still exist in the codebase, especially around manual/test quiz routes.
+
+Migration follow-up is needed to decide whether they should:
+
+- be migrated to V2 as well
+- be explicitly marked legacy/test-only
+- be removed entirely
+
+If they remain, they should not create ambiguity about whether legacy is still part of the normal production path.
+
+### 4. Add Final Legacy-Usage Guardrails
+
+After V2-only stabilization, the migration should add stronger guarantees that unsupported legacy access does not silently continue.
+
+Examples:
+
+- warning/error logs if deprecated legacy repositories are invoked
+- assertions or tests for unsupported legacy write usage
+- startup validation for invalid migration flag combinations
+
+### 5. Complete Legacy Deprecation Plan
+
+The migration is not fully complete until legacy collections have a defined post-cutover lifecycle.
+
+A migration completion plan is still needed for:
+
+- stabilization window length
+- rollback expectations
+- legacy collection archival policy
+- final legacy collection removal plan
+
+### 6. Optional Index Hardening After Stabilization
+
+Code-level dedupe and merge protections are in place for several legacy-reference scenarios.
+
+After production stabilization and duplicate cleanup are confirmed, the migration can consider stronger DB-level enforcement for legacy reference uniqueness where appropriate.
+
+This should only happen after verifying there is no conflicting legacy residue in existing environments.
+
+## What Is Not Considered a Migration Blocker
+
+The following may still need work, but they are not by themselves evidence that the V2 migration failed:
+
+- unrelated app cleanup
+- generic refactors outside quiz-library migration surfaces
+- existing deprecation warnings not introduced by the migration
+- non-core UI polish issues
+
+## Recommended Migration Close-Out Sequence
+
+To finish the migration cleanly, the next migration-scoped sequence should be:
+
+1. stabilize V2-only operation in target environments
+2. monitor for unexpected legacy-path usage
+3. decide which compatibility fields remain public and which are removed
+4. retire compare/legacy branches that are no longer needed
+5. document legacy archival/removal plan
+6. execute final legacy deprecation/removal in a follow-up cleanup stage
+
+## Summary
+
+The migration has reached the point where V2 is operationally authoritative for the supported quiz-library flows. The remaining work is no longer about proving the V2 model; it is about finishing the deprecation and cleanup process so that legacy support becomes explicit, limited, and eventually removable.

--- a/server/app/db/v2/migration/__init__.py
+++ b/server/app/db/v2/migration/__init__.py
@@ -1,0 +1,1 @@
+"""Stage 3 backfill and parity tooling for V2 quiz data."""

--- a/server/app/db/v2/migration/backfill_engine.py
+++ b/server/app/db/v2/migration/backfill_engine.py
@@ -1,0 +1,562 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, AsyncIterator, Optional
+
+from bson import ObjectId
+from motor.motor_asyncio import AsyncIOMotorDatabase
+from pydantic import BaseModel
+
+from server.app.db.crud.quiz_write_service import CanonicalQuizWriteService
+from server.app.db.v2.models.reference_models import (
+    FolderDocumentV2,
+    FolderItemDocumentV2,
+    QuizHistoryDocumentV2,
+    SavedQuizDocumentV2,
+)
+from server.app.db.v2.repositories.quiz_repository import QuizV2Repository
+from server.app.db.v2.repositories.reference_repository import ReferenceV2Repository
+
+from .config import BackfillConfig
+from .lock import MigrationLockService
+from .logging import log_migration_event
+from .resolver import LegacyQuizResolver
+from .types import BackfillReport, CollectionMigrationSummary, ParitySummary, utcnow
+
+
+@dataclass
+class MigrationContext:
+    config: BackfillConfig
+    database: AsyncIOMotorDatabase
+    canonical_service: CanonicalQuizWriteService
+    reference_repository: ReferenceV2Repository
+    resolver: LegacyQuizResolver
+    lock_service: MigrationLockService
+    report_dir: Path
+
+
+def _documents_match(existing_document: dict[str, Any] | None, target_document: BaseModel) -> bool:
+    if existing_document is None:
+        return False
+    try:
+        existing_model = target_document.__class__(**existing_document)
+    except Exception:
+        return False
+    return _normalize_for_compare(
+        existing_model.model_dump(exclude={"id"})
+    ) == _normalize_for_compare(target_document.model_dump(exclude={"id"}))
+
+
+def _normalize_for_compare(value: Any) -> Any:
+    if isinstance(value, datetime):
+        if value.tzinfo is not None:
+            value = value.astimezone(timezone.utc).replace(tzinfo=None)
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: _normalize_for_compare(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_normalize_for_compare(item) for item in value]
+    return value
+
+
+def _stable_legacy_timestamp(document: dict[str, Any], *fields: str) -> datetime:
+    for field in fields:
+        value = document.get(field)
+        if value is not None:
+            return value
+    legacy_id = document.get("_id")
+    if isinstance(legacy_id, ObjectId):
+        return legacy_id.generation_time
+    return utcnow()
+
+
+def build_migration_context(
+    *,
+    config: BackfillConfig,
+    database: AsyncIOMotorDatabase,
+    report_dir: Path,
+) -> MigrationContext:
+    quiz_repository = QuizV2Repository(database["quizzes_v2"])
+    canonical_service = CanonicalQuizWriteService(quiz_repository)
+    reference_repository = ReferenceV2Repository(
+        database["folders_v2"],
+        database["folder_items_v2"],
+        database["saved_quizzes_v2"],
+        database["quiz_history_v2"],
+    )
+    resolver = LegacyQuizResolver(
+        canonical_service=canonical_service,
+        ai_generated_quizzes_collection=database["ai_generated_quizzes"],
+        quizzes_collection=database["quizzes"],
+        saved_quizzes_collection=database["saved_quizzes"],
+    )
+    return MigrationContext(
+        config=config,
+        database=database,
+        canonical_service=canonical_service,
+        reference_repository=reference_repository,
+        resolver=resolver,
+        lock_service=MigrationLockService(database),
+        report_dir=report_dir,
+    )
+
+
+async def iterate_batches(
+    collection,
+    *,
+    batch_size: int,
+    start_after_id: Optional[str] = None,
+    limit: Optional[int] = None,
+) -> AsyncIterator[list[dict[str, Any]]]:
+    processed = 0
+    last_id = ObjectId(start_after_id) if start_after_id else None
+    while True:
+        query = {"_id": {"$gt": last_id}} if last_id is not None else {}
+        remaining = None if limit is None else max(limit - processed, 0)
+        if remaining == 0:
+            return
+        current_batch_size = batch_size if remaining is None else min(batch_size, remaining)
+        cursor = collection.find(query).sort("_id", 1).limit(current_batch_size)
+        documents = await cursor.to_list(length=current_batch_size)
+        if not documents:
+            return
+        yield documents
+        processed += len(documents)
+        last_id = documents[-1]["_id"]
+
+
+async def backfill_quizzes(context: MigrationContext) -> CollectionMigrationSummary:
+    summary = CollectionMigrationSummary(
+        collection="quizzes",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+        start_after_id=context.config.start_after_id,
+    )
+
+    async def process_origin_collection(collection_name: str, source_name: str, title_field: str):
+        collection = context.database[collection_name]
+        log_migration_event(
+            "v2_backfill_collection_started",
+            collection=summary.collection,
+            source_collection=collection_name,
+            run_id=context.config.run_id,
+            dry_run=context.config.dry_run,
+        )
+        async for batch in iterate_batches(
+            collection,
+            batch_size=context.config.batch_size,
+            start_after_id=context.config.start_after_id if summary.batches == 0 else None,
+            limit=context.config.limit,
+        ):
+            summary.batches += 1
+            for doc in batch:
+                record_id = str(doc["_id"])
+                summary.scanned += 1
+                summary.last_processed_id = record_id
+                try:
+                    existing = await context.canonical_service.repository.find_by_legacy_mapping(
+                        source_name,
+                        record_id,
+                    )
+                    questions = doc.get("questions", [])
+                    quiz_document = context.canonical_service.build_quiz_document(
+                        title=doc.get(title_field) or "General Knowledge",
+                        description=doc.get("custom_instruction") or doc.get("description"),
+                        quiz_type=doc.get("question_type") or doc.get("quiz_type") or "multichoice",
+                        owner_user_id=doc.get("user_id") or doc.get("owner_id"),
+                        source="ai" if source_name == "ai_generated_quizzes" else "legacy",
+                        questions=questions,
+                        legacy_source_collection=source_name,
+                        legacy_quiz_id=record_id,
+                    )
+                except Exception as exc:
+                    summary.add_malformed(record_id=record_id, reason=str(exc))
+                    continue
+
+                if context.config.dry_run:
+                    if existing:
+                        summary.skipped += 1
+                    else:
+                        summary.inserted += 1
+                    continue
+
+                stored = await context.canonical_service.upsert_quiz_v2_by_legacy_mapping(quiz_document)
+                if existing is None:
+                    summary.inserted += 1
+                elif existing.model_dump(exclude={"updated_at", "created_at"}) != stored.model_dump(
+                    exclude={"updated_at", "created_at"}
+                ):
+                    summary.updated += 1
+                else:
+                    summary.skipped += 1
+
+            await context.lock_service.renew_lock(
+                migration_name="stage_3_backfill",
+                run_id=context.config.run_id,
+                lease_seconds=context.config.lock_lease_seconds,
+            )
+            log_migration_event(
+                "v2_backfill_batch_completed",
+                collection=summary.collection,
+                batch_number=summary.batches,
+                scanned=summary.scanned,
+                inserted=summary.inserted,
+                updated=summary.updated,
+                skipped=summary.skipped,
+                unresolved=summary.unresolved,
+                run_id=context.config.run_id,
+            )
+
+    await process_origin_collection("ai_generated_quizzes", "ai_generated_quizzes", "profession")
+    await process_origin_collection("quizzes", "quizzes", "title")
+    summary.finish()
+    return summary
+
+
+async def backfill_saved_quizzes(context: MigrationContext) -> CollectionMigrationSummary:
+    summary = CollectionMigrationSummary(
+        collection="saved",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+        start_after_id=context.config.start_after_id,
+    )
+    collection = context.database["saved_quizzes"]
+    log_migration_event(
+        "v2_backfill_collection_started",
+        collection=summary.collection,
+        source_collection="saved_quizzes",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+    )
+    async for batch in iterate_batches(
+        collection,
+        batch_size=context.config.batch_size,
+        start_after_id=context.config.start_after_id,
+        limit=context.config.limit,
+    ):
+        summary.batches += 1
+        for doc in batch:
+            record_id = str(doc["_id"])
+            summary.scanned += 1
+            summary.last_processed_id = record_id
+            if doc.get("is_deleted"):
+                summary.skipped += 1
+                continue
+            try:
+                canonical_quiz = await context.resolver.resolve_saved_quiz(doc)
+            except Exception as exc:
+                summary.add_malformed(record_id=record_id, reason=str(exc))
+                continue
+            if not canonical_quiz:
+                summary.add_unresolved(record_id=record_id, reason="No canonical quiz match for saved quiz")
+                continue
+            target_document = SavedQuizDocumentV2(
+                user_id=doc["user_id"],
+                quiz_id=str(canonical_quiz.id),
+                legacy_saved_quiz_id=record_id,
+                saved_at=_stable_legacy_timestamp(doc, "saved_at", "created_at"),
+            )
+            existing = await context.database["saved_quizzes_v2"].find_one(
+                {"user_id": doc["user_id"], "quiz_id": str(canonical_quiz.id)}
+            )
+            if context.config.dry_run:
+                if existing:
+                    summary.skipped += 1
+                else:
+                    summary.inserted += 1
+                continue
+            if existing is None:
+                await context.reference_repository.upsert_saved_quiz(target_document)
+                summary.inserted += 1
+            elif _documents_match(existing, target_document):
+                summary.skipped += 1
+            else:
+                await context.reference_repository.upsert_saved_quiz(target_document)
+                summary.updated += 1
+        await context.lock_service.renew_lock(
+            migration_name="stage_3_backfill",
+            run_id=context.config.run_id,
+            lease_seconds=context.config.lock_lease_seconds,
+        )
+        log_migration_event(
+            "v2_backfill_batch_completed",
+            collection=summary.collection,
+            batch_number=summary.batches,
+            scanned=summary.scanned,
+            inserted=summary.inserted,
+            updated=summary.updated,
+            skipped=summary.skipped,
+            unresolved=summary.unresolved,
+            run_id=context.config.run_id,
+        )
+    summary.finish()
+    return summary
+
+
+async def backfill_quiz_history(context: MigrationContext) -> CollectionMigrationSummary:
+    summary = CollectionMigrationSummary(
+        collection="history",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+        start_after_id=context.config.start_after_id,
+    )
+    collection = context.database["quiz_history"]
+    log_migration_event(
+        "v2_backfill_collection_started",
+        collection=summary.collection,
+        source_collection="quiz_history",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+    )
+    async for batch in iterate_batches(
+        collection,
+        batch_size=context.config.batch_size,
+        start_after_id=context.config.start_after_id,
+        limit=context.config.limit,
+    ):
+        summary.batches += 1
+        for doc in batch:
+            record_id = str(doc["_id"])
+            summary.scanned += 1
+            summary.last_processed_id = record_id
+            try:
+                canonical_quiz = await context.resolver.resolve_quiz_history(
+                    doc,
+                    allow_create=not context.config.dry_run,
+                )
+            except Exception as exc:
+                summary.add_malformed(record_id=record_id, reason=str(exc))
+                continue
+            if not canonical_quiz:
+                summary.add_unresolved(record_id=record_id, reason="No canonical quiz match for history")
+                continue
+            target_document = QuizHistoryDocumentV2(
+                user_id=doc["user_id"],
+                quiz_id=str(canonical_quiz.id),
+                action="generated",
+                metadata={
+                    "source": canonical_quiz.source,
+                    "topic": doc.get("profession") or canonical_quiz.title,
+                    "difficulty_level": doc.get("difficulty_level"),
+                    "audience_type": doc.get("audience_type"),
+                },
+                legacy_history_id=record_id,
+                created_at=_stable_legacy_timestamp(doc, "created_at"),
+            )
+            existing = await context.database["quiz_history_v2"].find_one({"legacy_history_id": record_id})
+            if context.config.dry_run:
+                if existing:
+                    summary.skipped += 1
+                else:
+                    summary.inserted += 1
+                continue
+            if existing is None:
+                await context.reference_repository.upsert_quiz_history(target_document)
+                summary.inserted += 1
+            elif _documents_match(existing, target_document):
+                summary.skipped += 1
+            else:
+                await context.reference_repository.upsert_quiz_history(target_document)
+                summary.updated += 1
+        await context.lock_service.renew_lock(
+            migration_name="stage_3_backfill",
+            run_id=context.config.run_id,
+            lease_seconds=context.config.lock_lease_seconds,
+        )
+        log_migration_event(
+            "v2_backfill_batch_completed",
+            collection=summary.collection,
+            batch_number=summary.batches,
+            scanned=summary.scanned,
+            inserted=summary.inserted,
+            updated=summary.updated,
+            skipped=summary.skipped,
+            unresolved=summary.unresolved,
+            run_id=context.config.run_id,
+        )
+    summary.finish()
+    return summary
+
+
+async def backfill_folders(context: MigrationContext) -> CollectionMigrationSummary:
+    summary = CollectionMigrationSummary(
+        collection="folders",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+        start_after_id=context.config.start_after_id,
+    )
+    folders_collection = context.database["folders"]
+    log_migration_event(
+        "v2_backfill_collection_started",
+        collection=summary.collection,
+        source_collection="folders",
+        run_id=context.config.run_id,
+        dry_run=context.config.dry_run,
+    )
+    async for batch in iterate_batches(
+        folders_collection,
+        batch_size=context.config.batch_size,
+        start_after_id=context.config.start_after_id,
+        limit=context.config.limit,
+    ):
+        summary.batches += 1
+        for folder in batch:
+            folder_id = str(folder["_id"])
+            summary.scanned += 1
+            summary.last_processed_id = folder_id
+            existing_folder = await context.reference_repository.get_folder_by_legacy_id(folder_id)
+            target_folder_created_at = _stable_legacy_timestamp(folder, "created_at")
+            target_folder = FolderDocumentV2(
+                user_id=folder["user_id"],
+                name=folder["name"],
+                description=folder.get("description"),
+                legacy_folder_id=folder_id,
+                created_at=target_folder_created_at,
+                updated_at=folder.get("updated_at") or target_folder_created_at,
+            )
+            if not context.config.dry_run:
+                if existing_folder is None:
+                    folder_v2 = await context.reference_repository.upsert_folder_by_legacy_id(target_folder)
+                    summary.inserted += 1
+                elif _documents_match(existing_folder.model_dump(by_alias=True), target_folder):
+                    folder_v2 = existing_folder
+                    summary.skipped += 1
+                else:
+                    folder_v2 = await context.reference_repository.upsert_folder_by_legacy_id(target_folder)
+                    summary.updated += 1
+            else:
+                folder_v2 = existing_folder or target_folder
+                if existing_folder:
+                    summary.skipped += 1
+                else:
+                    summary.inserted += 1
+            for item in folder.get("quizzes", []):
+                item_id = str(item.get("_id"))
+                canonical_quiz = await context.resolver.resolve_folder_item(item)
+                if not canonical_quiz:
+                    summary.add_unresolved(record_id=item_id, reason="No canonical quiz match for folder item")
+                    continue
+                target_item = FolderItemDocumentV2(
+                    folder_id=str(folder_v2.id),
+                    quiz_id=str(canonical_quiz.id),
+                    added_by=folder.get("user_id"),
+                    legacy_folder_item_id=item_id,
+                    created_at=item.get("added_on")
+                    or item.get("created_at")
+                    or target_folder.created_at,
+                )
+                existing_item = await context.database["folder_items_v2"].find_one(
+                    {"legacy_folder_item_id": item_id}
+                )
+                if context.config.dry_run:
+                    if existing_item:
+                        summary.skipped += 1
+                    else:
+                        summary.inserted += 1
+                    continue
+                if existing_item is None:
+                    await context.reference_repository.upsert_folder_item_by_legacy_id(target_item)
+                    summary.inserted += 1
+                elif _documents_match(existing_item, target_item):
+                    summary.skipped += 1
+                else:
+                    await context.reference_repository.upsert_folder_item_by_legacy_id(target_item)
+                    summary.updated += 1
+        await context.lock_service.renew_lock(
+            migration_name="stage_3_backfill",
+            run_id=context.config.run_id,
+            lease_seconds=context.config.lock_lease_seconds,
+        )
+        log_migration_event(
+            "v2_backfill_batch_completed",
+            collection=summary.collection,
+            batch_number=summary.batches,
+            scanned=summary.scanned,
+            inserted=summary.inserted,
+            updated=summary.updated,
+            skipped=summary.skipped,
+            unresolved=summary.unresolved,
+            run_id=context.config.run_id,
+        )
+    summary.finish()
+    return summary
+
+
+async def run_backfill(context: MigrationContext) -> BackfillReport:
+    report = BackfillReport(run_id=context.config.run_id, dry_run=context.config.dry_run)
+    backfill_map = {
+        "quizzes": backfill_quizzes,
+        "saved": backfill_saved_quizzes,
+        "history": backfill_quiz_history,
+        "folders": backfill_folders,
+    }
+    for collection_name in context.config.collections:
+        log_migration_event(
+            "v2_backfill_runner_selected",
+            requested_collection=collection_name,
+            run_id=context.config.run_id,
+            dry_run=context.config.dry_run,
+        )
+        runner = backfill_map[collection_name]
+        summary = await runner(context)
+        report.add_summary(summary)
+    report.finish()
+    return report
+
+
+async def run_parity_checks(context: MigrationContext) -> ParitySummary:
+    parity = ParitySummary(run_id=context.config.run_id)
+    quizzes_v2 = context.database["quizzes_v2"]
+    saved_v2 = context.database["saved_quizzes_v2"]
+    history_v2 = context.database["quiz_history_v2"]
+    folders_v2 = context.database["folders_v2"]
+    folder_items_v2 = context.database["folder_items_v2"]
+    legacy_folders = context.database["folders"]
+
+    embedded_folder_items = 0
+    async for folder in legacy_folders.find({}, {"quizzes": 1}):
+        embedded_folder_items += len(folder.get("quizzes", []))
+
+    parity.add_section(
+        "quizzes",
+        {
+            "legacy_ai_generated_count": await context.database["ai_generated_quizzes"].count_documents({}),
+            "legacy_manual_count": await context.database["quizzes"].count_documents({}),
+            "v2_count": await quizzes_v2.count_documents({}),
+        },
+    )
+    parity.add_section(
+        "saved",
+        {
+            "legacy_count": await context.database["saved_quizzes"].count_documents({"is_deleted": {"$ne": True}}),
+            "v2_count": await saved_v2.count_documents({}),
+            "orphaned_quiz_refs": await saved_v2.count_documents(
+                {"quiz_id": {"$nin": [str(doc["_id"]) async for doc in quizzes_v2.find({}, {"_id": 1})]}}
+            ),
+        },
+    )
+    v2_quiz_ids = [str(doc["_id"]) async for doc in quizzes_v2.find({}, {"_id": 1})]
+    v2_folder_ids = [str(doc["_id"]) async for doc in folders_v2.find({}, {"_id": 1})]
+    parity.add_section(
+        "history",
+        {
+            "legacy_count": await context.database["quiz_history"].count_documents({}),
+            "v2_count": await history_v2.count_documents({}),
+            "orphaned_quiz_refs": await history_v2.count_documents({"quiz_id": {"$nin": v2_quiz_ids}}),
+        },
+    )
+    parity.add_section(
+        "folders",
+        {
+            "legacy_folder_count": await legacy_folders.count_documents({}),
+            "legacy_embedded_item_count": embedded_folder_items,
+            "v2_folder_count": await folders_v2.count_documents({}),
+            "v2_folder_item_count": await folder_items_v2.count_documents({}),
+            "orphaned_folder_refs": await folder_items_v2.count_documents({"folder_id": {"$nin": v2_folder_ids}}),
+            "orphaned_quiz_refs": await folder_items_v2.count_documents({"quiz_id": {"$nin": v2_quiz_ids}}),
+        },
+    )
+    parity.finish()
+    return parity

--- a/server/app/db/v2/migration/backfill_engine.py
+++ b/server/app/db/v2/migration/backfill_engine.py
@@ -272,6 +272,7 @@ async def backfill_saved_quizzes(context: MigrationContext) -> CollectionMigrati
             target_document = SavedQuizDocumentV2(
                 user_id=doc["user_id"],
                 quiz_id=str(canonical_quiz.id),
+                display_title=doc.get("title") or canonical_quiz.title,
                 legacy_saved_quiz_id=record_id,
                 saved_at=_stable_legacy_timestamp(doc, "saved_at", "created_at"),
             )
@@ -460,7 +461,7 @@ async def backfill_folders(context: MigrationContext) -> CollectionMigrationSumm
                     summary.skipped += 1
                 else:
                     summary.inserted += 1
-            for item in folder.get("quizzes", []):
+            for position, item in enumerate(folder.get("quizzes", [])):
                 item_id = str(item.get("_id"))
                 try:
                     canonical_quiz = await context.resolver.resolve_folder_item(
@@ -485,6 +486,8 @@ async def backfill_folders(context: MigrationContext) -> CollectionMigrationSumm
                     folder_id=str(folder_v2.id),
                     quiz_id=str(canonical_quiz.id),
                     added_by=folder.get("user_id"),
+                    position=position,
+                    display_title=item.get("title") or None,
                     legacy_folder_item_id=item_id,
                     created_at=item.get("added_on")
                     or item.get("created_at")

--- a/server/app/db/v2/migration/backfill_engine.py
+++ b/server/app/db/v2/migration/backfill_engine.py
@@ -10,6 +10,9 @@ from motor.motor_asyncio import AsyncIOMotorDatabase
 from pydantic import BaseModel
 
 from server.app.db.crud.quiz_write_service import CanonicalQuizWriteService
+from server.app.db.services.legacy_quiz_resolution_service import (
+    LegacyQuizStructureConflictError,
+)
 from server.app.db.v2.models.reference_models import (
     FolderDocumentV2,
     FolderItemDocumentV2,
@@ -245,7 +248,21 @@ async def backfill_saved_quizzes(context: MigrationContext) -> CollectionMigrati
                 summary.skipped += 1
                 continue
             try:
-                canonical_quiz = await context.resolver.resolve_saved_quiz(doc)
+                canonical_quiz = await context.resolver.resolve_saved_quiz(
+                    doc,
+                    allow_create=not context.config.dry_run,
+                )
+            except LegacyQuizStructureConflictError as exc:
+                conflict_details = exc.to_log_fields()
+                summary.add_conflict(record_id=record_id, reason=str(exc), **conflict_details)
+                log_migration_event(
+                    "v2_backfill_record_conflict",
+                    collection=summary.collection,
+                    record_id=record_id,
+                    run_id=context.config.run_id,
+                    **conflict_details,
+                )
+                continue
             except Exception as exc:
                 summary.add_malformed(record_id=record_id, reason=str(exc))
                 continue
@@ -326,6 +343,17 @@ async def backfill_quiz_history(context: MigrationContext) -> CollectionMigratio
                     doc,
                     allow_create=not context.config.dry_run,
                 )
+            except LegacyQuizStructureConflictError as exc:
+                conflict_details = exc.to_log_fields()
+                summary.add_conflict(record_id=record_id, reason=str(exc), **conflict_details)
+                log_migration_event(
+                    "v2_backfill_record_conflict",
+                    collection=summary.collection,
+                    record_id=record_id,
+                    run_id=context.config.run_id,
+                    **conflict_details,
+                )
+                continue
             except Exception as exc:
                 summary.add_malformed(record_id=record_id, reason=str(exc))
                 continue
@@ -434,7 +462,22 @@ async def backfill_folders(context: MigrationContext) -> CollectionMigrationSumm
                     summary.inserted += 1
             for item in folder.get("quizzes", []):
                 item_id = str(item.get("_id"))
-                canonical_quiz = await context.resolver.resolve_folder_item(item)
+                try:
+                    canonical_quiz = await context.resolver.resolve_folder_item(
+                        item,
+                        allow_create=not context.config.dry_run,
+                    )
+                except LegacyQuizStructureConflictError as exc:
+                    conflict_details = exc.to_log_fields()
+                    summary.add_conflict(record_id=item_id, reason=str(exc), **conflict_details)
+                    log_migration_event(
+                        "v2_backfill_record_conflict",
+                        collection=summary.collection,
+                        record_id=item_id,
+                        run_id=context.config.run_id,
+                        **conflict_details,
+                    )
+                    continue
                 if not canonical_quiz:
                     summary.add_unresolved(record_id=item_id, reason="No canonical quiz match for folder item")
                     continue

--- a/server/app/db/v2/migration/backfill_engine.py
+++ b/server/app/db/v2/migration/backfill_engine.py
@@ -276,7 +276,7 @@ async def backfill_saved_quizzes(context: MigrationContext) -> CollectionMigrati
                 saved_at=_stable_legacy_timestamp(doc, "saved_at", "created_at"),
             )
             existing = await context.database["saved_quizzes_v2"].find_one(
-                {"user_id": doc["user_id"], "quiz_id": str(canonical_quiz.id)}
+                {"legacy_saved_quiz_id": record_id}
             )
             if context.config.dry_run:
                 if existing:

--- a/server/app/db/v2/migration/config.py
+++ b/server/app/db/v2/migration/config.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import uuid4
+
+from server.app.db.core.config import settings
+
+
+@dataclass
+class BackfillConfig:
+    run_id: str
+    dry_run: bool
+    batch_size: int
+    limit: Optional[int]
+    start_after_id: Optional[str]
+    collections: list[str]
+    lock_lease_seconds: int
+
+    @classmethod
+    def from_settings(
+        cls,
+        *,
+        dry_run: Optional[bool] = None,
+        batch_size: Optional[int] = None,
+        limit: Optional[int] = None,
+        start_after_id: Optional[str] = None,
+        collections: Optional[list[str]] = None,
+        run_id: Optional[str] = None,
+    ) -> "BackfillConfig":
+        raw_collections = collections or [
+            item.strip()
+            for item in settings.V2_BACKFILL_COLLECTIONS.split(",")
+            if item.strip()
+        ]
+        generated_run_id = run_id or settings.V2_BACKFILL_RUN_ID
+        if not generated_run_id:
+            timestamp = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+            generated_run_id = f"stage3-{timestamp}-{uuid4().hex[:8]}"
+        return cls(
+            run_id=generated_run_id,
+            dry_run=settings.V2_BACKFILL_DRY_RUN if dry_run is None else dry_run,
+            batch_size=batch_size or settings.V2_BACKFILL_BATCH_SIZE,
+            limit=settings.V2_BACKFILL_LIMIT if limit is None else limit,
+            start_after_id=settings.V2_BACKFILL_START_AFTER_ID if start_after_id is None else start_after_id,
+            collections=raw_collections,
+            lock_lease_seconds=settings.V2_BACKFILL_LOCK_LEASE_SECONDS,
+        )

--- a/server/app/db/v2/migration/lock.py
+++ b/server/app/db/v2/migration/lock.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import timedelta
+
+from pymongo.errors import DuplicateKeyError
+
+from .types import utcnow
+
+
+class MigrationLockError(RuntimeError):
+    pass
+
+
+class MigrationLockService:
+    def __init__(self, database):
+        self.database = database
+        self.locks = database["migration_locks"]
+        self.runs = database["migration_runs"]
+
+    async def ensure_indexes(self):
+        await self.locks.create_index("expires_at", expireAfterSeconds=0, name="expires_at_ttl")
+        await self.runs.create_index(
+            [("migration_name", 1), ("started_at", -1)],
+            name="migration_name_started_at_idx",
+        )
+
+    async def acquire_lock(
+        self,
+        *,
+        migration_name: str,
+        run_id: str,
+        dry_run: bool,
+        triggered_by: str,
+        lease_seconds: int,
+    ):
+        await self.ensure_indexes()
+        now = utcnow()
+        expires_at = now + timedelta(seconds=lease_seconds)
+        lock_doc = {
+            "_id": migration_name,
+            "run_id": run_id,
+            "dry_run": dry_run,
+            "triggered_by": triggered_by,
+            "started_at": now,
+            "expires_at": expires_at,
+        }
+        try:
+            await self.locks.insert_one(lock_doc)
+        except DuplicateKeyError as exc:
+            active = await self.locks.find_one({"_id": migration_name})
+            raise MigrationLockError(
+                f"Migration '{migration_name}' is already running with run_id={active.get('run_id')}"
+            ) from exc
+
+        await self.runs.insert_one(
+            {
+                "_id": run_id,
+                "migration_name": migration_name,
+                "status": "running",
+                "dry_run": dry_run,
+                "triggered_by": triggered_by,
+                "started_at": now,
+            }
+        )
+
+    async def renew_lock(self, *, migration_name: str, run_id: str, lease_seconds: int):
+        expires_at = utcnow() + timedelta(seconds=lease_seconds)
+        await self.locks.update_one(
+            {"_id": migration_name, "run_id": run_id},
+            {"$set": {"expires_at": expires_at}},
+        )
+
+    async def release_lock(
+        self,
+        *,
+        migration_name: str,
+        run_id: str,
+        status: str,
+        summary: dict | None = None,
+        error: str | None = None,
+    ):
+        now = utcnow()
+        await self.runs.update_one(
+            {"_id": run_id},
+            {
+                "$set": {
+                    "status": status,
+                    "completed_at": now,
+                    "summary": summary,
+                    "error": error,
+                }
+            },
+        )
+        await self.locks.delete_one({"_id": migration_name, "run_id": run_id})
+
+    async def get_last_run(self, migration_name: str):
+        return await self.runs.find_one(
+            {"migration_name": migration_name},
+            sort=[("started_at", -1)],
+        )

--- a/server/app/db/v2/migration/logging.py
+++ b/server/app/db/v2/migration/logging.py
@@ -1,0 +1,9 @@
+import json
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def log_migration_event(event: str, **fields):
+    logger.info("%s | %s", event, json.dumps(fields, default=str, sort_keys=True))

--- a/server/app/db/v2/migration/resolver.py
+++ b/server/app/db/v2/migration/resolver.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from server.app.db.crud.quiz_write_service import CanonicalQuizWriteService
+
+
+class LegacyQuizResolver:
+    def __init__(
+        self,
+        *,
+        canonical_service: CanonicalQuizWriteService,
+        ai_generated_quizzes_collection: AsyncIOMotorCollection,
+        quizzes_collection: AsyncIOMotorCollection,
+        saved_quizzes_collection: AsyncIOMotorCollection,
+    ):
+        self.canonical_service = canonical_service
+        self.ai_generated_quizzes_collection = ai_generated_quizzes_collection
+        self.quizzes_collection = quizzes_collection
+        self.saved_quizzes_collection = saved_quizzes_collection
+
+    def _build_structure_fingerprint(self, *, title: str, quiz_type: str, questions: list[Any]) -> str:
+        normalized_questions = self.canonical_service.normalize_questions(questions)
+        structure_payload = {
+            "title": title.strip(),
+            "quiz_type": quiz_type,
+            "questions": [
+                {
+                    "question": question.get("question"),
+                    "options": question.get("options"),
+                }
+                for question in normalized_questions
+            ],
+        }
+        return self.canonical_service.build_content_fingerprint(structure_payload)
+
+    async def resolve_from_canonical_backref(self, canonical_quiz_id: str | None):
+        if not canonical_quiz_id:
+            return None
+        return await self.canonical_service.get_quiz_v2_by_id(canonical_quiz_id)
+
+    async def resolve_from_source_quiz_id(self, source_quiz_id: str | None):
+        if not source_quiz_id:
+            return None
+
+        canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
+            "ai_generated_quizzes",
+            source_quiz_id,
+        )
+        if canonical_quiz:
+            return canonical_quiz
+
+        canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
+            "quizzes",
+            source_quiz_id,
+        )
+        if canonical_quiz:
+            return canonical_quiz
+
+        legacy_ai = await self.ai_generated_quizzes_collection.find_one({"_id": source_quiz_id})
+        if legacy_ai and legacy_ai.get("canonical_quiz_id"):
+            return await self.resolve_from_canonical_backref(legacy_ai["canonical_quiz_id"])
+
+        try:
+            from bson import ObjectId
+            object_id = ObjectId(source_quiz_id)
+        except Exception:
+            object_id = None
+
+        if object_id is not None:
+            legacy_manual = await self.quizzes_collection.find_one({"_id": object_id})
+            if legacy_manual and legacy_manual.get("canonical_quiz_id"):
+                return await self.resolve_from_canonical_backref(legacy_manual["canonical_quiz_id"])
+        return None
+
+    async def resolve_from_payload(
+        self,
+        *,
+        title: str,
+        quiz_type: str,
+        questions: list[Any],
+        description: str | None = None,
+        allow_create: bool = False,
+    ):
+        normalized_questions = self.canonical_service.normalize_questions(questions)
+        has_complete_answers = all(question.get("correct_answer") for question in normalized_questions)
+        if not has_complete_answers:
+            structure_fingerprint = self._build_structure_fingerprint(
+                title=title,
+                quiz_type=quiz_type,
+                questions=questions,
+            )
+            return await self.canonical_service.repository.find_by_structure_fingerprint(structure_fingerprint)
+
+        quiz_document = self.canonical_service.build_quiz_document(
+            title=title,
+            description=description,
+            quiz_type=quiz_type,
+            questions=questions,
+            source="legacy",
+        )
+        existing = await self.canonical_service.repository.find_by_content_fingerprint(
+            quiz_document.content_fingerprint
+        )
+        if existing:
+            return existing
+        existing = await self.canonical_service.repository.find_by_structure_fingerprint(
+            quiz_document.structure_fingerprint
+        )
+        if existing:
+            return existing
+        if allow_create:
+            return await self.canonical_service.find_or_create_quiz_v2_by_fingerprint(quiz_document)
+        return None
+
+    async def resolve_saved_quiz(self, legacy_saved_doc: dict):
+        canonical_quiz = await self.resolve_from_canonical_backref(
+            legacy_saved_doc.get("canonical_quiz_id")
+        )
+        if canonical_quiz:
+            return canonical_quiz
+        canonical_quiz = await self.resolve_from_source_quiz_id(legacy_saved_doc.get("quiz_id"))
+        if canonical_quiz:
+            return canonical_quiz
+        return await self.resolve_from_payload(
+            title=legacy_saved_doc["title"],
+            quiz_type=legacy_saved_doc["question_type"],
+            questions=legacy_saved_doc["questions"],
+            allow_create=False,
+        )
+
+    async def resolve_quiz_history(self, legacy_history_doc: dict, *, allow_create: bool = True):
+        canonical_quiz = await self.resolve_from_canonical_backref(
+            legacy_history_doc.get("canonical_quiz_id")
+        )
+        if canonical_quiz:
+            return canonical_quiz
+        canonical_quiz = await self.resolve_from_source_quiz_id(legacy_history_doc.get("quiz_id"))
+        if canonical_quiz:
+            return canonical_quiz
+        return await self.resolve_from_payload(
+            title=legacy_history_doc.get("quiz_name")
+            or legacy_history_doc.get("profession")
+            or "Quiz History",
+            description=legacy_history_doc.get("custom_instruction"),
+            quiz_type=legacy_history_doc["question_type"],
+            questions=legacy_history_doc["questions"],
+            allow_create=allow_create,
+        )
+
+    async def resolve_folder_item(self, legacy_folder_item: dict):
+        canonical_quiz = await self.resolve_from_canonical_backref(
+            legacy_folder_item.get("canonical_quiz_id")
+        )
+        if canonical_quiz:
+            return canonical_quiz
+
+        for source_id in (
+            legacy_folder_item.get("quiz_id"),
+            legacy_folder_item.get("quiz_data", {}).get("quiz_id"),
+        ):
+            canonical_quiz = await self.resolve_from_source_quiz_id(source_id)
+            if canonical_quiz:
+                return canonical_quiz
+
+        original_saved_quiz_id = legacy_folder_item.get("original_quiz_id")
+        if original_saved_quiz_id:
+            from bson import ObjectId
+            try:
+                saved_doc = await self.saved_quizzes_collection.find_one(
+                    {"_id": ObjectId(original_saved_quiz_id)}
+                )
+            except Exception:
+                saved_doc = None
+            if saved_doc:
+                canonical_quiz = await self.resolve_saved_quiz(saved_doc)
+                if canonical_quiz:
+                    return canonical_quiz
+
+        quiz_payload = legacy_folder_item.get("quiz_data", {})
+        return await self.resolve_from_payload(
+            title=legacy_folder_item.get("title") or quiz_payload.get("title") or "Untitled Quiz",
+            quiz_type=legacy_folder_item.get("question_type")
+            or quiz_payload.get("question_type")
+            or "multichoice",
+            questions=legacy_folder_item.get("questions")
+            or quiz_payload.get("questions", []),
+            allow_create=False,
+        )

--- a/server/app/db/v2/migration/resolver.py
+++ b/server/app/db/v2/migration/resolver.py
@@ -5,6 +5,9 @@ from typing import Any, Optional
 from motor.motor_asyncio import AsyncIOMotorCollection
 
 from server.app.db.crud.quiz_write_service import CanonicalQuizWriteService
+from server.app.db.services.legacy_quiz_resolution_service import (
+    LegacyQuizResolutionService,
+)
 
 
 class LegacyQuizResolver:
@@ -20,6 +23,11 @@ class LegacyQuizResolver:
         self.ai_generated_quizzes_collection = ai_generated_quizzes_collection
         self.quizzes_collection = quizzes_collection
         self.saved_quizzes_collection = saved_quizzes_collection
+        self.legacy_resolution_service = LegacyQuizResolutionService(
+            canonical_service=canonical_service,
+            ai_generated_quizzes_collection=ai_generated_quizzes_collection,
+            quizzes_collection=quizzes_collection,
+        )
 
     def _build_structure_fingerprint(self, *, title: str, quiz_type: str, questions: list[Any]) -> str:
         normalized_questions = self.canonical_service.normalize_questions(questions)
@@ -37,43 +45,10 @@ class LegacyQuizResolver:
         return self.canonical_service.build_content_fingerprint(structure_payload)
 
     async def resolve_from_canonical_backref(self, canonical_quiz_id: str | None):
-        if not canonical_quiz_id:
-            return None
-        return await self.canonical_service.get_quiz_v2_by_id(canonical_quiz_id)
+        return await self.legacy_resolution_service.resolve_from_canonical_backref(canonical_quiz_id)
 
     async def resolve_from_source_quiz_id(self, source_quiz_id: str | None):
-        if not source_quiz_id:
-            return None
-
-        canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
-            "ai_generated_quizzes",
-            source_quiz_id,
-        )
-        if canonical_quiz:
-            return canonical_quiz
-
-        canonical_quiz = await self.canonical_service.repository.find_by_legacy_mapping(
-            "quizzes",
-            source_quiz_id,
-        )
-        if canonical_quiz:
-            return canonical_quiz
-
-        legacy_ai = await self.ai_generated_quizzes_collection.find_one({"_id": source_quiz_id})
-        if legacy_ai and legacy_ai.get("canonical_quiz_id"):
-            return await self.resolve_from_canonical_backref(legacy_ai["canonical_quiz_id"])
-
-        try:
-            from bson import ObjectId
-            object_id = ObjectId(source_quiz_id)
-        except Exception:
-            object_id = None
-
-        if object_id is not None:
-            legacy_manual = await self.quizzes_collection.find_one({"_id": object_id})
-            if legacy_manual and legacy_manual.get("canonical_quiz_id"):
-                return await self.resolve_from_canonical_backref(legacy_manual["canonical_quiz_id"])
-        return None
+        return await self.legacy_resolution_service.resolve_from_source_quiz_id(source_quiz_id)
 
     async def resolve_from_payload(
         self,
@@ -87,6 +62,14 @@ class LegacyQuizResolver:
         normalized_questions = self.canonical_service.normalize_questions(questions)
         has_complete_answers = all(question.get("correct_answer") for question in normalized_questions)
         if not has_complete_answers:
+            canonical_quiz = await self.legacy_resolution_service.resolve_from_legacy_structure(
+                title=title,
+                quiz_type=quiz_type,
+                questions=questions,
+                allow_create=allow_create,
+            )
+            if canonical_quiz:
+                return canonical_quiz
             structure_fingerprint = self._build_structure_fingerprint(
                 title=title,
                 quiz_type=quiz_type,
@@ -115,13 +98,21 @@ class LegacyQuizResolver:
             return await self.canonical_service.find_or_create_quiz_v2_by_fingerprint(quiz_document)
         return None
 
-    async def resolve_saved_quiz(self, legacy_saved_doc: dict):
+    async def resolve_saved_quiz(self, legacy_saved_doc: dict, *, allow_create: bool = False):
         canonical_quiz = await self.resolve_from_canonical_backref(
             legacy_saved_doc.get("canonical_quiz_id")
         )
         if canonical_quiz:
             return canonical_quiz
         canonical_quiz = await self.resolve_from_source_quiz_id(legacy_saved_doc.get("quiz_id"))
+        if canonical_quiz:
+            return canonical_quiz
+        canonical_quiz = await self.legacy_resolution_service.resolve_from_legacy_structure(
+            title=legacy_saved_doc["title"],
+            quiz_type=legacy_saved_doc["question_type"],
+            questions=legacy_saved_doc["questions"],
+            allow_create=allow_create,
+        )
         if canonical_quiz:
             return canonical_quiz
         return await self.resolve_from_payload(
@@ -150,7 +141,7 @@ class LegacyQuizResolver:
             allow_create=allow_create,
         )
 
-    async def resolve_folder_item(self, legacy_folder_item: dict):
+    async def resolve_folder_item(self, legacy_folder_item: dict, *, allow_create: bool = False):
         canonical_quiz = await self.resolve_from_canonical_backref(
             legacy_folder_item.get("canonical_quiz_id")
         )
@@ -175,7 +166,7 @@ class LegacyQuizResolver:
             except Exception:
                 saved_doc = None
             if saved_doc:
-                canonical_quiz = await self.resolve_saved_quiz(saved_doc)
+                canonical_quiz = await self.resolve_saved_quiz(saved_doc, allow_create=allow_create)
                 if canonical_quiz:
                     return canonical_quiz
 
@@ -187,5 +178,5 @@ class LegacyQuizResolver:
             or "multichoice",
             questions=legacy_folder_item.get("questions")
             or quiz_payload.get("questions", []),
-            allow_create=False,
+            allow_create=allow_create,
         )

--- a/server/app/db/v2/migration/resolver.py
+++ b/server/app/db/v2/migration/resolver.py
@@ -70,6 +70,13 @@ class LegacyQuizResolver:
             )
             if canonical_quiz:
                 return canonical_quiz
+            canonical_quiz = await self.legacy_resolution_service.resolve_existing_v2_from_question_structure(
+                title=title,
+                quiz_type=quiz_type,
+                questions=questions,
+            )
+            if canonical_quiz:
+                return canonical_quiz
             structure_fingerprint = self._build_structure_fingerprint(
                 title=title,
                 quiz_type=quiz_type,
@@ -86,6 +93,13 @@ class LegacyQuizResolver:
         )
         existing = await self.canonical_service.repository.find_by_content_fingerprint(
             quiz_document.content_fingerprint
+        )
+        if existing:
+            return existing
+        existing = await self.legacy_resolution_service.resolve_existing_v2_from_question_structure(
+            title=title,
+            quiz_type=quiz_type,
+            questions=questions,
         )
         if existing:
             return existing
@@ -132,9 +146,12 @@ class LegacyQuizResolver:
         if canonical_quiz:
             return canonical_quiz
         return await self.resolve_from_payload(
-            title=legacy_history_doc.get("quiz_name")
-            or legacy_history_doc.get("profession")
-            or "Quiz History",
+            title=self.legacy_resolution_service.choose_preferred_title(
+                title=legacy_history_doc.get("quiz_name"),
+                fallback_title=legacy_history_doc.get("profession"),
+                quiz_type=legacy_history_doc.get("question_type"),
+                default="Quiz History",
+            ),
             description=legacy_history_doc.get("custom_instruction"),
             quiz_type=legacy_history_doc["question_type"],
             questions=legacy_history_doc["questions"],

--- a/server/app/db/v2/migration/summary.py
+++ b/server/app/db/v2/migration/summary.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def write_summary_json(path: Path, payload: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, default=str, indent=2), encoding="utf-8")

--- a/server/app/db/v2/migration/types.py
+++ b/server/app/db/v2/migration/types.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+def utcnow() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass
+class CollectionMigrationSummary:
+    collection: str
+    run_id: str
+    dry_run: bool
+    scanned: int = 0
+    inserted: int = 0
+    updated: int = 0
+    skipped: int = 0
+    unresolved: int = 0
+    malformed: int = 0
+    conflicts: int = 0
+    validation_failures: int = 0
+    batches: int = 0
+    start_after_id: Optional[str] = None
+    last_processed_id: Optional[str] = None
+    started_at: datetime = field(default_factory=utcnow)
+    ended_at: Optional[datetime] = None
+    unresolved_examples: list[dict[str, Any]] = field(default_factory=list)
+    malformed_examples: list[dict[str, Any]] = field(default_factory=list)
+    conflict_examples: list[dict[str, Any]] = field(default_factory=list)
+
+    def finish(self):
+        self.ended_at = utcnow()
+
+    def add_unresolved(self, *, record_id: str, reason: str):
+        self.unresolved += 1
+        if len(self.unresolved_examples) < 25:
+            self.unresolved_examples.append({"record_id": record_id, "reason": reason})
+
+    def add_malformed(self, *, record_id: str, reason: str):
+        self.malformed += 1
+        if len(self.malformed_examples) < 25:
+            self.malformed_examples.append({"record_id": record_id, "reason": reason})
+
+    def add_conflict(self, *, record_id: str, reason: str):
+        self.conflicts += 1
+        if len(self.conflict_examples) < 25:
+            self.conflict_examples.append({"record_id": record_id, "reason": reason})
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["started_at"] = self.started_at.isoformat()
+        data["ended_at"] = self.ended_at.isoformat() if self.ended_at else None
+        return data
+
+
+@dataclass
+class BackfillReport:
+    run_id: str
+    dry_run: bool
+    started_at: datetime = field(default_factory=utcnow)
+    ended_at: Optional[datetime] = None
+    collections: dict[str, CollectionMigrationSummary] = field(default_factory=dict)
+
+    def add_summary(self, summary: CollectionMigrationSummary):
+        self.collections[summary.collection] = summary
+
+    def finish(self):
+        self.ended_at = utcnow()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "dry_run": self.dry_run,
+            "started_at": self.started_at.isoformat(),
+            "ended_at": self.ended_at.isoformat() if self.ended_at else None,
+            "collections": {name: summary.to_dict() for name, summary in self.collections.items()},
+        }
+
+
+@dataclass
+class ParitySummary:
+    run_id: str
+    started_at: datetime = field(default_factory=utcnow)
+    ended_at: Optional[datetime] = None
+    sections: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def add_section(self, name: str, data: dict[str, Any]):
+        self.sections[name] = data
+
+    def finish(self):
+        self.ended_at = utcnow()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "run_id": self.run_id,
+            "started_at": self.started_at.isoformat(),
+            "ended_at": self.ended_at.isoformat() if self.ended_at else None,
+            "sections": self.sections,
+        }

--- a/server/app/db/v2/migration/types.py
+++ b/server/app/db/v2/migration/types.py
@@ -34,20 +34,20 @@ class CollectionMigrationSummary:
     def finish(self):
         self.ended_at = utcnow()
 
-    def add_unresolved(self, *, record_id: str, reason: str):
+    def add_unresolved(self, *, record_id: str, reason: str, **details: Any):
         self.unresolved += 1
         if len(self.unresolved_examples) < 25:
-            self.unresolved_examples.append({"record_id": record_id, "reason": reason})
+            self.unresolved_examples.append({"record_id": record_id, "reason": reason, **details})
 
-    def add_malformed(self, *, record_id: str, reason: str):
+    def add_malformed(self, *, record_id: str, reason: str, **details: Any):
         self.malformed += 1
         if len(self.malformed_examples) < 25:
-            self.malformed_examples.append({"record_id": record_id, "reason": reason})
+            self.malformed_examples.append({"record_id": record_id, "reason": reason, **details})
 
-    def add_conflict(self, *, record_id: str, reason: str):
+    def add_conflict(self, *, record_id: str, reason: str, **details: Any):
         self.conflicts += 1
         if len(self.conflict_examples) < 25:
-            self.conflict_examples.append({"record_id": record_id, "reason": reason})
+            self.conflict_examples.append({"record_id": record_id, "reason": reason, **details})
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)

--- a/server/app/db/v2/models/reference_models.py
+++ b/server/app/db/v2/models/reference_models.py
@@ -20,6 +20,7 @@ class FolderDocumentV2(BaseModel):
     legacy_folder_id: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
     updated_at: datetime = Field(default_factory=datetime.utcnow)
+    deleted_at: Optional[datetime] = None
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -47,6 +48,7 @@ class FolderItemDocumentV2(BaseModel):
     display_title: Optional[str] = None
     legacy_folder_item_id: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
+    deleted_at: Optional[datetime] = None
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -70,6 +72,7 @@ class SavedQuizDocumentV2(BaseModel):
     display_title: Optional[str] = None
     legacy_saved_quiz_id: Optional[str] = None
     saved_at: datetime = Field(default_factory=datetime.utcnow)
+    deleted_at: Optional[datetime] = None
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -96,6 +99,7 @@ class QuizHistoryDocumentV2(BaseModel):
     metadata: Dict[str, Any] = Field(default_factory=dict)
     legacy_history_id: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
+    deleted_at: Optional[datetime] = None
 
     model_config = ConfigDict(
         populate_by_name=True,

--- a/server/app/db/v2/models/reference_models.py
+++ b/server/app/db/v2/models/reference_models.py
@@ -44,6 +44,7 @@ class FolderItemDocumentV2(BaseModel):
     quiz_id: str
     added_by: Optional[str] = None
     position: Optional[int] = None
+    display_title: Optional[str] = None
     legacy_folder_item_id: Optional[str] = None
     created_at: datetime = Field(default_factory=datetime.utcnow)
 
@@ -66,6 +67,7 @@ class SavedQuizDocumentV2(BaseModel):
     id: ObjectId = Field(default_factory=ObjectId, alias="_id")
     user_id: str
     quiz_id: str
+    display_title: Optional[str] = None
     legacy_saved_quiz_id: Optional[str] = None
     saved_at: datetime = Field(default_factory=datetime.utcnow)
 

--- a/server/app/db/v2/repositories/quiz_repository.py
+++ b/server/app/db/v2/repositories/quiz_repository.py
@@ -88,6 +88,22 @@ class QuizV2Repository:
             return None
         return QuizDocumentV2(**document) if document else None
 
+    async def find_many_by_ids(self, quiz_ids: list[str]) -> list[QuizDocumentV2]:
+        object_ids: list[ObjectId] = []
+        order: list[ObjectId] = []
+        for quiz_id in quiz_ids:
+            try:
+                object_id = ObjectId(quiz_id)
+            except InvalidId:
+                continue
+            object_ids.append(object_id)
+            order.append(object_id)
+        if not object_ids:
+            return []
+        documents = await self.collection.find({"_id": {"$in": object_ids}}).to_list(length=len(object_ids))
+        by_id = {document["_id"]: document for document in documents}
+        return [QuizDocumentV2(**by_id[object_id]) for object_id in order if object_id in by_id]
+
     async def update_metadata(
         self,
         quiz_id: str,

--- a/server/app/db/v2/repositories/reference_repository.py
+++ b/server/app/db/v2/repositories/reference_repository.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Optional
 
 from motor.motor_asyncio import AsyncIOMotorCollection
 from pymongo import ReturnDocument
@@ -29,6 +30,13 @@ class ReferenceV2Repository:
         if value.tzinfo is not None:
             return value.astimezone(timezone.utc).replace(tzinfo=None)
         return value
+
+    @staticmethod
+    def _merge_position(*values: Optional[int]) -> Optional[int]:
+        valid_values = [value for value in values if value is not None]
+        if not valid_values:
+            return None
+        return min(valid_values)
 
     async def insert_folder(self, folder: FolderDocumentV2) -> FolderDocumentV2:
         payload = folder.model_dump(by_alias=True)
@@ -69,6 +77,10 @@ class ReferenceV2Repository:
         document = await self.folders_collection.find_one({"legacy_folder_id": legacy_folder_id})
         return FolderDocumentV2(**document) if document else None
 
+    async def list_folders_for_user(self, user_id: str) -> list[FolderDocumentV2]:
+        documents = await self.folders_collection.find({"user_id": user_id}).to_list(length=500)
+        return [FolderDocumentV2(**document) for document in documents]
+
     async def delete_folder_by_legacy_id(self, legacy_folder_id: str):
         folder = await self.get_folder_by_legacy_id(legacy_folder_id)
         if folder:
@@ -94,13 +106,25 @@ class ReferenceV2Repository:
                 self._normalize_datetime(legacy_match.get("created_at", created_at)),
                 self._normalize_datetime(target_match.get("created_at", created_at)),
             )
+            merged_position = self._merge_position(
+                payload.get("position"),
+                legacy_match.get("position"),
+                target_match.get("position"),
+            )
             target_legacy_item_id = target_match.get("legacy_folder_item_id")
+            merged_display_title = (
+                payload.get("display_title")
+                or target_match.get("display_title")
+                or legacy_match.get("display_title")
+            )
             updated = await self.folder_items_collection.find_one_and_update(
                 {"_id": target_match["_id"]},
                 {
                     "$set": {
                         **payload,
                         "created_at": merged_created_at,
+                        "position": merged_position,
+                        "display_title": merged_display_title,
                         "legacy_folder_item_id": target_legacy_item_id or folder_item.legacy_folder_item_id,
                     }
                 },
@@ -115,6 +139,8 @@ class ReferenceV2Repository:
             filter_query = {"_id": target_match["_id"]}
             if target_match.get("legacy_folder_item_id"):
                 payload["legacy_folder_item_id"] = target_match["legacy_folder_item_id"]
+            payload["position"] = self._merge_position(payload.get("position"), target_match.get("position"))
+            payload["display_title"] = payload.get("display_title") or target_match.get("display_title")
         else:
             filter_query = (
                 {"legacy_folder_item_id": folder_item.legacy_folder_item_id}
@@ -134,6 +160,10 @@ class ReferenceV2Repository:
             {"legacy_folder_item_id": legacy_folder_item_id}
         )
         return FolderItemDocumentV2(**document) if document else None
+
+    async def list_folder_items_for_folder(self, folder_id: str) -> list[FolderItemDocumentV2]:
+        documents = await self.folder_items_collection.find({"folder_id": folder_id}).to_list(length=1000)
+        return [FolderItemDocumentV2(**document) for document in documents]
 
     async def delete_folder_item_by_legacy_id(self, legacy_folder_item_id: str):
         await self.folder_items_collection.delete_one({"legacy_folder_item_id": legacy_folder_item_id})
@@ -157,11 +187,17 @@ class ReferenceV2Repository:
                 self._normalize_datetime(legacy_match.get("saved_at", saved_at)),
                 self._normalize_datetime(target_match.get("saved_at", saved_at)),
             )
+            merged_display_title = (
+                payload.get("display_title")
+                or target_match.get("display_title")
+                or legacy_match.get("display_title")
+            )
             updated = await self.saved_quizzes_collection.find_one_and_update(
                 {"_id": target_match["_id"]},
                 {
                     "$set": {
                         **payload,
+                        "display_title": merged_display_title,
                         "saved_at": merged_saved_at,
                     }
                 },
@@ -174,6 +210,7 @@ class ReferenceV2Repository:
             filter_query = {"_id": legacy_match["_id"]}
         elif target_match is not None:
             filter_query = {"_id": target_match["_id"]}
+            payload["display_title"] = payload.get("display_title") or target_match.get("display_title")
         else:
             filter_query = (
                 {"legacy_saved_quiz_id": saved_quiz.legacy_saved_quiz_id}
@@ -188,6 +225,24 @@ class ReferenceV2Repository:
         )
         return SavedQuizDocumentV2(**updated)
 
+    async def list_saved_quizzes_for_user(self, user_id: str) -> list[SavedQuizDocumentV2]:
+        documents = await self.saved_quizzes_collection.find({"user_id": user_id}).to_list(length=500)
+        return [SavedQuizDocumentV2(**document) for document in documents]
+
+    async def get_saved_quiz_by_legacy_id(
+        self,
+        legacy_saved_quiz_id: str,
+        user_id: Optional[str] = None,
+    ) -> SavedQuizDocumentV2 | None:
+        query: dict[str, str] = {"legacy_saved_quiz_id": legacy_saved_quiz_id}
+        if user_id is not None:
+            query["user_id"] = user_id
+        document = await self.saved_quizzes_collection.find_one(query)
+        return SavedQuizDocumentV2(**document) if document else None
+
+    async def delete_saved_quiz(self, user_id: str, quiz_id: str):
+        await self.saved_quizzes_collection.delete_one({"user_id": user_id, "quiz_id": quiz_id})
+
     async def upsert_quiz_history(self, quiz_history: QuizHistoryDocumentV2) -> QuizHistoryDocumentV2:
         payload = quiz_history.model_dump(by_alias=True)
         payload.pop("_id", None)
@@ -199,3 +254,7 @@ class ReferenceV2Repository:
             return_document=ReturnDocument.AFTER,
         )
         return QuizHistoryDocumentV2(**updated)
+
+    async def list_quiz_history_for_user(self, user_id: str) -> list[QuizHistoryDocumentV2]:
+        documents = await self.quiz_history_collection.find({"user_id": user_id}).to_list(length=500)
+        return [QuizHistoryDocumentV2(**document) for document in documents]

--- a/server/app/db/v2/repositories/reference_repository.py
+++ b/server/app/db/v2/repositories/reference_repository.py
@@ -40,10 +40,39 @@ class ReferenceV2Repository:
             return None
         return min(valid_values)
 
+    @staticmethod
+    def _active_query() -> dict:
+        return {"$or": [{"deleted_at": {"$exists": False}}, {"deleted_at": None}]}
+
     async def insert_folder(self, folder: FolderDocumentV2) -> FolderDocumentV2:
         payload = folder.model_dump(by_alias=True)
-        result = await self.folders_collection.insert_one(payload)
+        payload.pop("_id", None)
+        created_at = payload.pop("created_at")
+        updated_at = payload.pop("updated_at")
+        existing = await self.folders_collection.find_one({"user_id": folder.user_id, "name": folder.name})
+        if existing and existing.get("deleted_at") is not None:
+            updates = {
+                **payload,
+                "created_at": existing.get("created_at", created_at),
+                "updated_at": updated_at,
+            }
+            updates["deleted_at"] = None
+            updated = await self.folders_collection.find_one_and_update(
+                {"_id": existing["_id"]},
+                {"$set": updates},
+                return_document=ReturnDocument.AFTER,
+            )
+            return FolderDocumentV2(**updated)
+        result = await self.folders_collection.insert_one(
+            {
+                **payload,
+                "created_at": created_at,
+                "updated_at": updated_at,
+            }
+        )
         payload["_id"] = result.inserted_id
+        payload["created_at"] = created_at
+        payload["updated_at"] = updated_at
         return FolderDocumentV2(**payload)
 
     async def insert_folder_item(self, folder_item: FolderItemDocumentV2) -> FolderItemDocumentV2:
@@ -67,6 +96,9 @@ class ReferenceV2Repository:
     async def upsert_folder_by_legacy_id(self, folder: FolderDocumentV2) -> FolderDocumentV2:
         payload = folder.model_dump(by_alias=True)
         payload.pop("_id", None)
+        existing = await self.folders_collection.find_one({"legacy_folder_id": folder.legacy_folder_id})
+        if existing is not None and existing.get("deleted_at") is not None:
+            payload["deleted_at"] = existing["deleted_at"]
         updated = await self.folders_collection.find_one_and_update(
             {"legacy_folder_id": folder.legacy_folder_id},
             {"$set": payload},
@@ -76,12 +108,16 @@ class ReferenceV2Repository:
         return FolderDocumentV2(**updated)
 
     async def get_folder_by_legacy_id(self, legacy_folder_id: str) -> FolderDocumentV2 | None:
-        document = await self.folders_collection.find_one({"legacy_folder_id": legacy_folder_id})
+        document = await self.folders_collection.find_one(
+            {"$and": [{"legacy_folder_id": legacy_folder_id}, self._active_query()]}
+        )
         return FolderDocumentV2(**document) if document else None
 
     async def get_folder_by_id(self, folder_id: str) -> FolderDocumentV2 | None:
         try:
-            document = await self.folders_collection.find_one({"_id": ObjectId(folder_id)})
+            document = await self.folders_collection.find_one(
+                {"$and": [{"_id": ObjectId(folder_id)}, self._active_query()]}
+            )
         except InvalidId:
             return None
         return FolderDocumentV2(**document) if document else None
@@ -90,7 +126,9 @@ class ReferenceV2Repository:
         return await self.get_folder_by_legacy_id(folder_id) or await self.get_folder_by_id(folder_id)
 
     async def list_folders_for_user(self, user_id: str) -> list[FolderDocumentV2]:
-        documents = await self.folders_collection.find({"user_id": user_id}).to_list(length=500)
+        documents = await self.folders_collection.find(
+            {"$and": [{"user_id": user_id}, self._active_query()]}
+        ).to_list(length=500)
         return [FolderDocumentV2(**document) for document in documents]
 
     async def update_folder(
@@ -121,28 +159,48 @@ class ReferenceV2Repository:
         return FolderDocumentV2(**updated) if updated else None
 
     async def delete_folder_by_legacy_id(self, legacy_folder_id: str):
-        folder = await self.get_folder_by_legacy_id(legacy_folder_id)
+        folder = await self.folders_collection.find_one({"legacy_folder_id": legacy_folder_id})
         if folder:
-            await self.folder_items_collection.delete_many({"folder_id": str(folder.id)})
-        await self.folders_collection.delete_one({"legacy_folder_id": legacy_folder_id})
+            deleted_at = datetime.utcnow()
+            await self.folder_items_collection.update_many(
+                {"folder_id": str(folder["_id"]), **self._active_query()},
+                {"$set": {"deleted_at": deleted_at}},
+            )
+            await self.folders_collection.update_one(
+                {"_id": folder["_id"]},
+                {"$set": {"deleted_at": deleted_at, "updated_at": deleted_at}},
+            )
 
     async def delete_folder_by_id(self, folder_id: str):
         try:
             object_id = ObjectId(folder_id)
         except InvalidId:
             return
-        await self.folder_items_collection.delete_many({"folder_id": folder_id})
-        await self.folders_collection.delete_one({"_id": object_id})
+        deleted_at = datetime.utcnow()
+        await self.folder_items_collection.update_many(
+            {"folder_id": folder_id, **self._active_query()},
+            {"$set": {"deleted_at": deleted_at}},
+        )
+        await self.folders_collection.update_one(
+            {"_id": object_id, **self._active_query()},
+            {"$set": {"deleted_at": deleted_at, "updated_at": deleted_at}},
+        )
 
     async def delete_folder_by_public_id(self, folder_id: str):
         folder = await self.get_folder_by_public_id(folder_id)
         if folder:
             await self.delete_folder_by_id(str(folder.id))
 
-    async def upsert_folder_item_by_legacy_id(self, folder_item: FolderItemDocumentV2) -> FolderItemDocumentV2:
+    async def upsert_folder_item_by_legacy_id(
+        self,
+        folder_item: FolderItemDocumentV2,
+        *,
+        revive_deleted: bool = False,
+    ) -> FolderItemDocumentV2:
         payload = folder_item.model_dump(by_alias=True)
         payload.pop("_id", None)
         created_at = payload.pop("created_at")
+        deleted_at = payload.pop("deleted_at", None)
         legacy_match = None
         if folder_item.legacy_folder_item_id:
             legacy_match = await self.folder_items_collection.find_one(
@@ -169,6 +227,9 @@ class ReferenceV2Repository:
                 or target_match.get("display_title")
                 or legacy_match.get("display_title")
             )
+            merged_deleted_at = target_match.get("deleted_at")
+            if revive_deleted:
+                merged_deleted_at = None
             updated = await self.folder_items_collection.find_one_and_update(
                 {"_id": target_match["_id"]},
                 {
@@ -178,6 +239,7 @@ class ReferenceV2Repository:
                         "position": merged_position,
                         "display_title": merged_display_title,
                         "legacy_folder_item_id": target_legacy_item_id or folder_item.legacy_folder_item_id,
+                        "deleted_at": merged_deleted_at,
                     }
                 },
                 return_document=ReturnDocument.AFTER,
@@ -199,6 +261,14 @@ class ReferenceV2Repository:
                 if folder_item.legacy_folder_item_id
                 else {"folder_id": folder_item.folder_id, "quiz_id": folder_item.quiz_id}
             )
+        if revive_deleted:
+            payload["deleted_at"] = None
+        elif legacy_match is not None and legacy_match.get("deleted_at") is not None:
+            payload["deleted_at"] = legacy_match.get("deleted_at")
+        elif target_match is not None and target_match.get("deleted_at") is not None:
+            payload["deleted_at"] = target_match.get("deleted_at")
+        elif deleted_at is not None:
+            payload["deleted_at"] = deleted_at
         updated = await self.folder_items_collection.find_one_and_update(
             filter_query,
             {"$set": payload, "$setOnInsert": {"created_at": created_at}},
@@ -209,13 +279,15 @@ class ReferenceV2Repository:
 
     async def get_folder_item_by_legacy_id(self, legacy_folder_item_id: str) -> FolderItemDocumentV2 | None:
         document = await self.folder_items_collection.find_one(
-            {"legacy_folder_item_id": legacy_folder_item_id}
+            {"$and": [{"legacy_folder_item_id": legacy_folder_item_id}, self._active_query()]}
         )
         return FolderItemDocumentV2(**document) if document else None
 
     async def get_folder_item_by_id(self, folder_item_id: str) -> FolderItemDocumentV2 | None:
         try:
-            document = await self.folder_items_collection.find_one({"_id": ObjectId(folder_item_id)})
+            document = await self.folder_items_collection.find_one(
+                {"$and": [{"_id": ObjectId(folder_item_id)}, self._active_query()]}
+            )
         except InvalidId:
             return None
         return FolderItemDocumentV2(**document) if document else None
@@ -226,11 +298,16 @@ class ReferenceV2Repository:
         )
 
     async def list_folder_items_for_folder(self, folder_id: str) -> list[FolderItemDocumentV2]:
-        documents = await self.folder_items_collection.find({"folder_id": folder_id}).to_list(length=1000)
+        documents = await self.folder_items_collection.find(
+            {"$and": [{"folder_id": folder_id}, self._active_query()]}
+        ).to_list(length=1000)
         return [FolderItemDocumentV2(**document) for document in documents]
 
     async def delete_folder_item_by_legacy_id(self, legacy_folder_item_id: str):
-        await self.folder_items_collection.delete_one({"legacy_folder_item_id": legacy_folder_item_id})
+        await self.folder_items_collection.update_one(
+            {"legacy_folder_item_id": legacy_folder_item_id, **self._active_query()},
+            {"$set": {"deleted_at": datetime.utcnow()}},
+        )
 
     async def update_folder_item(
         self,
@@ -268,17 +345,26 @@ class ReferenceV2Repository:
             object_id = ObjectId(folder_item_id)
         except InvalidId:
             return
-        await self.folder_items_collection.delete_one({"_id": object_id})
+        await self.folder_items_collection.update_one(
+            {"_id": object_id, **self._active_query()},
+            {"$set": {"deleted_at": datetime.utcnow()}},
+        )
 
     async def delete_folder_item_by_public_id(self, folder_item_id: str):
         item = await self.get_folder_item_by_public_id(folder_item_id)
         if item:
             await self.delete_folder_item_by_id(str(item.id))
 
-    async def upsert_saved_quiz(self, saved_quiz: SavedQuizDocumentV2) -> SavedQuizDocumentV2:
+    async def upsert_saved_quiz(
+        self,
+        saved_quiz: SavedQuizDocumentV2,
+        *,
+        revive_deleted: bool = False,
+    ) -> SavedQuizDocumentV2:
         payload = saved_quiz.model_dump(by_alias=True)
         payload.pop("_id", None)
         saved_at = payload.pop("saved_at")
+        deleted_at = payload.pop("deleted_at", None)
         legacy_match = None
         if saved_quiz.legacy_saved_quiz_id:
             legacy_match = await self.saved_quizzes_collection.find_one(
@@ -299,6 +385,9 @@ class ReferenceV2Repository:
                 or target_match.get("display_title")
                 or legacy_match.get("display_title")
             )
+            merged_deleted_at = target_match.get("deleted_at")
+            if revive_deleted:
+                merged_deleted_at = None
             updated = await self.saved_quizzes_collection.find_one_and_update(
                 {"_id": target_match["_id"]},
                 {
@@ -306,6 +395,7 @@ class ReferenceV2Repository:
                         **payload,
                         "display_title": merged_display_title,
                         "saved_at": merged_saved_at,
+                        "deleted_at": merged_deleted_at,
                     }
                 },
                 return_document=ReturnDocument.AFTER,
@@ -324,6 +414,14 @@ class ReferenceV2Repository:
                 if saved_quiz.legacy_saved_quiz_id
                 else {"user_id": saved_quiz.user_id, "quiz_id": saved_quiz.quiz_id}
             )
+        if revive_deleted:
+            payload["deleted_at"] = None
+        elif legacy_match is not None and legacy_match.get("deleted_at") is not None:
+            payload["deleted_at"] = legacy_match.get("deleted_at")
+        elif target_match is not None and target_match.get("deleted_at") is not None:
+            payload["deleted_at"] = target_match.get("deleted_at")
+        elif deleted_at is not None:
+            payload["deleted_at"] = deleted_at
         updated = await self.saved_quizzes_collection.find_one_and_update(
             filter_query,
             {"$set": payload, "$setOnInsert": {"saved_at": saved_at}},
@@ -333,7 +431,9 @@ class ReferenceV2Repository:
         return SavedQuizDocumentV2(**updated)
 
     async def list_saved_quizzes_for_user(self, user_id: str) -> list[SavedQuizDocumentV2]:
-        documents = await self.saved_quizzes_collection.find({"user_id": user_id}).to_list(length=500)
+        documents = await self.saved_quizzes_collection.find(
+            {"$and": [{"user_id": user_id}, self._active_query()]}
+        ).to_list(length=500)
         return [SavedQuizDocumentV2(**document) for document in documents]
 
     async def get_saved_quiz_by_legacy_id(
@@ -344,7 +444,7 @@ class ReferenceV2Repository:
         query: dict[str, str] = {"legacy_saved_quiz_id": legacy_saved_quiz_id}
         if user_id is not None:
             query["user_id"] = user_id
-        document = await self.saved_quizzes_collection.find_one(query)
+        document = await self.saved_quizzes_collection.find_one({"$and": [query, self._active_query()]})
         return SavedQuizDocumentV2(**document) if document else None
 
     async def get_saved_quiz_by_id(
@@ -359,7 +459,7 @@ class ReferenceV2Repository:
             return None
         if user_id is not None:
             query["user_id"] = user_id
-        document = await self.saved_quizzes_collection.find_one(query)
+        document = await self.saved_quizzes_collection.find_one({"$and": [query, self._active_query()]})
         return SavedQuizDocumentV2(**document) if document else None
 
     async def get_saved_quiz_by_public_id(
@@ -373,7 +473,10 @@ class ReferenceV2Repository:
         )
 
     async def delete_saved_quiz(self, user_id: str, quiz_id: str):
-        await self.saved_quizzes_collection.delete_one({"user_id": user_id, "quiz_id": quiz_id})
+        await self.saved_quizzes_collection.update_one(
+            {"user_id": user_id, "quiz_id": quiz_id, **self._active_query()},
+            {"$set": {"deleted_at": datetime.utcnow()}},
+        )
 
     async def delete_saved_quiz_by_id(
         self,
@@ -388,13 +491,19 @@ class ReferenceV2Repository:
             return 0
         if user_id is not None:
             query["user_id"] = user_id
-        result = await self.saved_quizzes_collection.delete_one(query)
-        return result.deleted_count
+        result = await self.saved_quizzes_collection.update_one(
+            {"$and": [query, self._active_query()]},
+            {"$set": {"deleted_at": datetime.utcnow()}},
+        )
+        return result.modified_count
 
     async def upsert_quiz_history(self, quiz_history: QuizHistoryDocumentV2) -> QuizHistoryDocumentV2:
         payload = quiz_history.model_dump(by_alias=True)
         payload.pop("_id", None)
         created_at = payload.pop("created_at")
+        existing = await self.quiz_history_collection.find_one({"legacy_history_id": quiz_history.legacy_history_id})
+        if existing is not None and existing.get("deleted_at") is not None:
+            payload["deleted_at"] = existing["deleted_at"]
         updated = await self.quiz_history_collection.find_one_and_update(
             {"legacy_history_id": quiz_history.legacy_history_id},
             {"$set": payload, "$setOnInsert": {"created_at": created_at}},
@@ -404,5 +513,26 @@ class ReferenceV2Repository:
         return QuizHistoryDocumentV2(**updated)
 
     async def list_quiz_history_for_user(self, user_id: str) -> list[QuizHistoryDocumentV2]:
-        documents = await self.quiz_history_collection.find({"user_id": user_id}).to_list(length=500)
+        documents = await self.quiz_history_collection.find(
+            {"$and": [{"user_id": user_id}, self._active_query()]}
+        ).to_list(length=500)
         return [QuizHistoryDocumentV2(**document) for document in documents]
+
+    async def soft_delete_quiz_history_by_id(
+        self,
+        history_id: str,
+        *,
+        user_id: Optional[str] = None,
+    ) -> int:
+        query: dict[str, object] = {}
+        try:
+            query["_id"] = ObjectId(history_id)
+        except InvalidId:
+            return 0
+        if user_id is not None:
+            query["user_id"] = user_id
+        result = await self.quiz_history_collection.update_one(
+            {"$and": [query, self._active_query()]},
+            {"$set": {"deleted_at": datetime.utcnow()}},
+        )
+        return result.modified_count

--- a/server/app/db/v2/repositories/reference_repository.py
+++ b/server/app/db/v2/repositories/reference_repository.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 from motor.motor_asyncio import AsyncIOMotorCollection
 from pymongo import ReturnDocument
 
@@ -21,6 +23,12 @@ class ReferenceV2Repository:
         self.folder_items_collection = folder_items_collection
         self.saved_quizzes_collection = saved_quizzes_collection
         self.quiz_history_collection = quiz_history_collection
+
+    @staticmethod
+    def _normalize_datetime(value: datetime) -> datetime:
+        if value.tzinfo is not None:
+            return value.astimezone(timezone.utc).replace(tzinfo=None)
+        return value
 
     async def insert_folder(self, folder: FolderDocumentV2) -> FolderDocumentV2:
         payload = folder.model_dump(by_alias=True)
@@ -91,8 +99,46 @@ class ReferenceV2Repository:
         payload = saved_quiz.model_dump(by_alias=True)
         payload.pop("_id", None)
         saved_at = payload.pop("saved_at")
+        legacy_match = None
+        if saved_quiz.legacy_saved_quiz_id:
+            legacy_match = await self.saved_quizzes_collection.find_one(
+                {"legacy_saved_quiz_id": saved_quiz.legacy_saved_quiz_id}
+            )
+        target_match = await self.saved_quizzes_collection.find_one(
+            {"user_id": saved_quiz.user_id, "quiz_id": saved_quiz.quiz_id}
+        )
+
+        if legacy_match and target_match and legacy_match["_id"] != target_match["_id"]:
+            merged_saved_at = min(
+                self._normalize_datetime(saved_at),
+                self._normalize_datetime(legacy_match.get("saved_at", saved_at)),
+                self._normalize_datetime(target_match.get("saved_at", saved_at)),
+            )
+            updated = await self.saved_quizzes_collection.find_one_and_update(
+                {"_id": target_match["_id"]},
+                {
+                    "$set": {
+                        **payload,
+                        "saved_at": merged_saved_at,
+                    }
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+            await self.saved_quizzes_collection.delete_one({"_id": legacy_match["_id"]})
+            return SavedQuizDocumentV2(**updated)
+
+        if legacy_match is not None:
+            filter_query = {"_id": legacy_match["_id"]}
+        elif target_match is not None:
+            filter_query = {"_id": target_match["_id"]}
+        else:
+            filter_query = (
+                {"legacy_saved_quiz_id": saved_quiz.legacy_saved_quiz_id}
+                if saved_quiz.legacy_saved_quiz_id
+                else {"user_id": saved_quiz.user_id, "quiz_id": saved_quiz.quiz_id}
+            )
         updated = await self.saved_quizzes_collection.find_one_and_update(
-            {"user_id": saved_quiz.user_id, "quiz_id": saved_quiz.quiz_id},
+            filter_query,
             {"$set": payload, "$setOnInsert": {"saved_at": saved_at}},
             upsert=True,
             return_document=ReturnDocument.AFTER,

--- a/server/app/db/v2/repositories/reference_repository.py
+++ b/server/app/db/v2/repositories/reference_repository.py
@@ -78,9 +78,52 @@ class ReferenceV2Repository:
     async def upsert_folder_item_by_legacy_id(self, folder_item: FolderItemDocumentV2) -> FolderItemDocumentV2:
         payload = folder_item.model_dump(by_alias=True)
         payload.pop("_id", None)
+        created_at = payload.pop("created_at")
+        legacy_match = None
+        if folder_item.legacy_folder_item_id:
+            legacy_match = await self.folder_items_collection.find_one(
+                {"legacy_folder_item_id": folder_item.legacy_folder_item_id}
+            )
+        target_match = await self.folder_items_collection.find_one(
+            {"folder_id": folder_item.folder_id, "quiz_id": folder_item.quiz_id}
+        )
+
+        if legacy_match and target_match and legacy_match["_id"] != target_match["_id"]:
+            merged_created_at = min(
+                self._normalize_datetime(created_at),
+                self._normalize_datetime(legacy_match.get("created_at", created_at)),
+                self._normalize_datetime(target_match.get("created_at", created_at)),
+            )
+            target_legacy_item_id = target_match.get("legacy_folder_item_id")
+            updated = await self.folder_items_collection.find_one_and_update(
+                {"_id": target_match["_id"]},
+                {
+                    "$set": {
+                        **payload,
+                        "created_at": merged_created_at,
+                        "legacy_folder_item_id": target_legacy_item_id or folder_item.legacy_folder_item_id,
+                    }
+                },
+                return_document=ReturnDocument.AFTER,
+            )
+            await self.folder_items_collection.delete_one({"_id": legacy_match["_id"]})
+            return FolderItemDocumentV2(**updated)
+
+        if legacy_match is not None:
+            filter_query = {"_id": legacy_match["_id"]}
+        elif target_match is not None:
+            filter_query = {"_id": target_match["_id"]}
+            if target_match.get("legacy_folder_item_id"):
+                payload["legacy_folder_item_id"] = target_match["legacy_folder_item_id"]
+        else:
+            filter_query = (
+                {"legacy_folder_item_id": folder_item.legacy_folder_item_id}
+                if folder_item.legacy_folder_item_id
+                else {"folder_id": folder_item.folder_id, "quiz_id": folder_item.quiz_id}
+            )
         updated = await self.folder_items_collection.find_one_and_update(
-            {"legacy_folder_item_id": folder_item.legacy_folder_item_id},
-            {"$set": payload},
+            filter_query,
+            {"$set": payload, "$setOnInsert": {"created_at": created_at}},
             upsert=True,
             return_document=ReturnDocument.AFTER,
         )

--- a/server/app/db/v2/repositories/reference_repository.py
+++ b/server/app/db/v2/repositories/reference_repository.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
 from typing import Optional
 
+from bson import ObjectId
+from bson.errors import InvalidId
 from motor.motor_asyncio import AsyncIOMotorCollection
 from pymongo import ReturnDocument
 
@@ -77,15 +79,65 @@ class ReferenceV2Repository:
         document = await self.folders_collection.find_one({"legacy_folder_id": legacy_folder_id})
         return FolderDocumentV2(**document) if document else None
 
+    async def get_folder_by_id(self, folder_id: str) -> FolderDocumentV2 | None:
+        try:
+            document = await self.folders_collection.find_one({"_id": ObjectId(folder_id)})
+        except InvalidId:
+            return None
+        return FolderDocumentV2(**document) if document else None
+
+    async def get_folder_by_public_id(self, folder_id: str) -> FolderDocumentV2 | None:
+        return await self.get_folder_by_legacy_id(folder_id) or await self.get_folder_by_id(folder_id)
+
     async def list_folders_for_user(self, user_id: str) -> list[FolderDocumentV2]:
         documents = await self.folders_collection.find({"user_id": user_id}).to_list(length=500)
         return [FolderDocumentV2(**document) for document in documents]
+
+    async def update_folder(
+        self,
+        folder_id: str,
+        *,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        updated_at: Optional[datetime] = None,
+    ) -> FolderDocumentV2 | None:
+        updates = {
+            key: value
+            for key, value in {
+                "name": name,
+                "description": description,
+                "updated_at": updated_at or datetime.utcnow(),
+            }.items()
+            if value is not None
+        }
+        try:
+            updated = await self.folders_collection.find_one_and_update(
+                {"_id": ObjectId(folder_id)},
+                {"$set": updates},
+                return_document=ReturnDocument.AFTER,
+            )
+        except InvalidId:
+            return None
+        return FolderDocumentV2(**updated) if updated else None
 
     async def delete_folder_by_legacy_id(self, legacy_folder_id: str):
         folder = await self.get_folder_by_legacy_id(legacy_folder_id)
         if folder:
             await self.folder_items_collection.delete_many({"folder_id": str(folder.id)})
         await self.folders_collection.delete_one({"legacy_folder_id": legacy_folder_id})
+
+    async def delete_folder_by_id(self, folder_id: str):
+        try:
+            object_id = ObjectId(folder_id)
+        except InvalidId:
+            return
+        await self.folder_items_collection.delete_many({"folder_id": folder_id})
+        await self.folders_collection.delete_one({"_id": object_id})
+
+    async def delete_folder_by_public_id(self, folder_id: str):
+        folder = await self.get_folder_by_public_id(folder_id)
+        if folder:
+            await self.delete_folder_by_id(str(folder.id))
 
     async def upsert_folder_item_by_legacy_id(self, folder_item: FolderItemDocumentV2) -> FolderItemDocumentV2:
         payload = folder_item.model_dump(by_alias=True)
@@ -161,12 +213,67 @@ class ReferenceV2Repository:
         )
         return FolderItemDocumentV2(**document) if document else None
 
+    async def get_folder_item_by_id(self, folder_item_id: str) -> FolderItemDocumentV2 | None:
+        try:
+            document = await self.folder_items_collection.find_one({"_id": ObjectId(folder_item_id)})
+        except InvalidId:
+            return None
+        return FolderItemDocumentV2(**document) if document else None
+
+    async def get_folder_item_by_public_id(self, folder_item_id: str) -> FolderItemDocumentV2 | None:
+        return await self.get_folder_item_by_legacy_id(folder_item_id) or await self.get_folder_item_by_id(
+            folder_item_id
+        )
+
     async def list_folder_items_for_folder(self, folder_id: str) -> list[FolderItemDocumentV2]:
         documents = await self.folder_items_collection.find({"folder_id": folder_id}).to_list(length=1000)
         return [FolderItemDocumentV2(**document) for document in documents]
 
     async def delete_folder_item_by_legacy_id(self, legacy_folder_item_id: str):
         await self.folder_items_collection.delete_one({"legacy_folder_item_id": legacy_folder_item_id})
+
+    async def update_folder_item(
+        self,
+        folder_item_id: str,
+        *,
+        folder_id: Optional[str] = None,
+        quiz_id: Optional[str] = None,
+        added_by: Optional[str] = None,
+        position: Optional[int] = None,
+        display_title: Optional[str] = None,
+    ) -> FolderItemDocumentV2 | None:
+        updates = {
+            key: value
+            for key, value in {
+                "folder_id": folder_id,
+                "quiz_id": quiz_id,
+                "added_by": added_by,
+                "position": position,
+                "display_title": display_title,
+            }.items()
+            if value is not None
+        }
+        try:
+            updated = await self.folder_items_collection.find_one_and_update(
+                {"_id": ObjectId(folder_item_id)},
+                {"$set": updates},
+                return_document=ReturnDocument.AFTER,
+            )
+        except InvalidId:
+            return None
+        return FolderItemDocumentV2(**updated) if updated else None
+
+    async def delete_folder_item_by_id(self, folder_item_id: str):
+        try:
+            object_id = ObjectId(folder_item_id)
+        except InvalidId:
+            return
+        await self.folder_items_collection.delete_one({"_id": object_id})
+
+    async def delete_folder_item_by_public_id(self, folder_item_id: str):
+        item = await self.get_folder_item_by_public_id(folder_item_id)
+        if item:
+            await self.delete_folder_item_by_id(str(item.id))
 
     async def upsert_saved_quiz(self, saved_quiz: SavedQuizDocumentV2) -> SavedQuizDocumentV2:
         payload = saved_quiz.model_dump(by_alias=True)
@@ -240,8 +347,49 @@ class ReferenceV2Repository:
         document = await self.saved_quizzes_collection.find_one(query)
         return SavedQuizDocumentV2(**document) if document else None
 
+    async def get_saved_quiz_by_id(
+        self,
+        saved_quiz_id: str,
+        user_id: Optional[str] = None,
+    ) -> SavedQuizDocumentV2 | None:
+        query: dict[str, object] = {}
+        try:
+            query["_id"] = ObjectId(saved_quiz_id)
+        except InvalidId:
+            return None
+        if user_id is not None:
+            query["user_id"] = user_id
+        document = await self.saved_quizzes_collection.find_one(query)
+        return SavedQuizDocumentV2(**document) if document else None
+
+    async def get_saved_quiz_by_public_id(
+        self,
+        saved_quiz_id: str,
+        user_id: Optional[str] = None,
+    ) -> SavedQuizDocumentV2 | None:
+        return await self.get_saved_quiz_by_legacy_id(saved_quiz_id, user_id=user_id) or await self.get_saved_quiz_by_id(
+            saved_quiz_id,
+            user_id=user_id,
+        )
+
     async def delete_saved_quiz(self, user_id: str, quiz_id: str):
         await self.saved_quizzes_collection.delete_one({"user_id": user_id, "quiz_id": quiz_id})
+
+    async def delete_saved_quiz_by_id(
+        self,
+        saved_quiz_id: str,
+        *,
+        user_id: Optional[str] = None,
+    ) -> int:
+        query: dict[str, object] = {}
+        try:
+            query["_id"] = ObjectId(saved_quiz_id)
+        except InvalidId:
+            return 0
+        if user_id is not None:
+            query["user_id"] = user_id
+        result = await self.saved_quizzes_collection.delete_one(query)
+        return result.deleted_count
 
     async def upsert_quiz_history(self, quiz_history: QuizHistoryDocumentV2) -> QuizHistoryDocumentV2:
         payload = quiz_history.model_dump(by_alias=True)

--- a/server/app/db/v2/validators.py
+++ b/server/app/db/v2/validators.py
@@ -70,6 +70,7 @@ def get_v2_collection_validators() -> dict[str, dict]:
                     "legacy_folder_id": {"bsonType": ["string", "null"]},
                     "created_at": {"bsonType": "date"},
                     "updated_at": {"bsonType": "date"},
+                    "deleted_at": {"bsonType": ["date", "null"]},
                 },
             }
         },
@@ -85,6 +86,7 @@ def get_v2_collection_validators() -> dict[str, dict]:
                     "display_title": {"bsonType": ["string", "null"]},
                     "legacy_folder_item_id": {"bsonType": ["string", "null"]},
                     "created_at": {"bsonType": "date"},
+                    "deleted_at": {"bsonType": ["date", "null"]},
                 },
             }
         },
@@ -98,6 +100,7 @@ def get_v2_collection_validators() -> dict[str, dict]:
                     "display_title": {"bsonType": ["string", "null"]},
                     "legacy_saved_quiz_id": {"bsonType": ["string", "null"]},
                     "saved_at": {"bsonType": "date"},
+                    "deleted_at": {"bsonType": ["date", "null"]},
                 },
             }
         },
@@ -112,6 +115,7 @@ def get_v2_collection_validators() -> dict[str, dict]:
                     "metadata": {"bsonType": ["object", "null"]},
                     "legacy_history_id": {"bsonType": ["string", "null"]},
                     "created_at": {"bsonType": "date"},
+                    "deleted_at": {"bsonType": ["date", "null"]},
                 },
             }
         },

--- a/server/app/db/v2/validators.py
+++ b/server/app/db/v2/validators.py
@@ -82,6 +82,7 @@ def get_v2_collection_validators() -> dict[str, dict]:
                     "quiz_id": {"bsonType": "string", "minLength": 1},
                     "added_by": {"bsonType": ["string", "null"]},
                     "position": {"bsonType": ["int", "null"]},
+                    "display_title": {"bsonType": ["string", "null"]},
                     "legacy_folder_item_id": {"bsonType": ["string", "null"]},
                     "created_at": {"bsonType": "date"},
                 },
@@ -94,6 +95,7 @@ def get_v2_collection_validators() -> dict[str, dict]:
                 "properties": {
                     "user_id": {"bsonType": "string", "minLength": 1},
                     "quiz_id": {"bsonType": "string", "minLength": 1},
+                    "display_title": {"bsonType": ["string", "null"]},
                     "legacy_saved_quiz_id": {"bsonType": ["string", "null"]},
                     "saved_at": {"bsonType": "date"},
                 },

--- a/server/app/share/routes/share_routes.py
+++ b/server/app/share/routes/share_routes.py
@@ -11,8 +11,10 @@ from ...db.core.connection import (
     get_quizzes_collection,
     get_ai_generated_quizzes_collection,
     get_saved_quizzes_collection,
+    get_quizzes_v2_collection,
 )
 from ...db.crud.quiz_crud import list_quizzes
+from ...db.core.config import settings
 from ...db.services.shared_quiz_read_service import SharedQuizReadService
 from ...db.schemas.quiz_schemas import QuizSchema
 from .share_schemas import (
@@ -97,8 +99,27 @@ async def resolve_shared_quiz(quiz_id: str) -> Optional[Dict[str, Any]]:
 
 
 @router.get("/get-quiz-id", response_model=QuizSchema)
-async def get_random_quiz_id(quizzes_collection: AsyncIOMotorCollection = Depends(get_quizzes_collection)):
+async def get_random_quiz_id(
+    quizzes_collection: AsyncIOMotorCollection = Depends(get_quizzes_collection),
+    quizzes_v2_collection: AsyncIOMotorCollection = Depends(get_quizzes_v2_collection),
+):
     try:
+        if settings.QUIZ_V2_SHARE_READ_MODE == "v2_only":
+            quiz_list = await quizzes_v2_collection.find({"status": {"$ne": "deleted"}}).to_list(length=50)
+            if not quiz_list:
+                raise HTTPException(detail="Unable to fetch from database!", status_code=404)
+            selected_quiz = random.choice(quiz_list)
+            return QuizSchema(
+                id=str(selected_quiz["_id"]),
+                title=selected_quiz["title"],
+                description=selected_quiz.get("description"),
+                quiz_type=selected_quiz["quiz_type"],
+                owner_id=selected_quiz.get("owner_user_id"),
+                canonical_quiz_id=str(selected_quiz["_id"]),
+                created_at=selected_quiz["created_at"],
+                updated_at=selected_quiz["updated_at"],
+                questions=selected_quiz["questions"],
+            )
         quiz_List = await list_quizzes(quizzes_collection)
         selected_quiz = random.choice(quiz_List)
         return selected_quiz

--- a/server/app/share/routes/share_routes.py
+++ b/server/app/share/routes/share_routes.py
@@ -1,30 +1,23 @@
-from fastapi import APIRouter, HTTPException, Depends, status
-import random
-from motor.motor_asyncio import AsyncIOMotorCollection
-import os
+from fastapi import APIRouter, Depends, HTTPException, status
 import logging
-from typing import Any, Dict, Optional
-from bson import ObjectId
-from bson.errors import InvalidId
+import os
+import random
+
 from dotenv import load_dotenv
-from ...db.core.connection import (
-    get_quizzes_collection,
-    get_ai_generated_quizzes_collection,
-    get_saved_quizzes_collection,
-    get_quizzes_v2_collection,
-)
-from ...db.crud.quiz_crud import list_quizzes
-from ...db.core.config import settings
-from ...db.services.shared_quiz_read_service import SharedQuizReadService
+from motor.motor_asyncio import AsyncIOMotorCollection
+
+from ...db.core.connection import get_quizzes_v2_collection
 from ...db.schemas.quiz_schemas import QuizSchema
+from ...db.services.shared_quiz_read_service import SharedQuizReadService
 from .share_schemas import (
-    ShareQuizResponse,
     ShareEmailRequest,
     ShareEmailResponse,
+    ShareQuizResponse,
     SharedQuizDataResponse,
 )
-from server.app.email_platform.service import EmailService
 from server.app.email_platform.deps import get_email_service
+from server.app.email_platform.service import EmailService
+
 
 logger = logging.getLogger(__name__)
 
@@ -39,105 +32,42 @@ if not share_url:
 router = APIRouter()
 shared_quiz_read_service = SharedQuizReadService()
 
-def build_default_description(topic: str) -> str:
-    return f"A quiz to test your knowledge on {topic}"
-
-
-def normalize_shared_quiz(
-    quiz_doc: Dict[str, Any],
-    quiz_id: str,
-    source: str,
-) -> Dict[str, Any]:
-    if source == "quizzes":
-        title = quiz_doc.get("title") or "General Knowledge"
-        description = quiz_doc.get("description") or build_default_description(title)
-        quiz_type = quiz_doc.get("quiz_type") or "multichoice"
-    elif source == "ai_generated_quizzes":
-        profession = quiz_doc.get("profession") or "General Knowledge"
-        title = profession
-        description = quiz_doc.get("description") or build_default_description(profession)
-        quiz_type = quiz_doc.get("question_type") or "multichoice"
-    elif source == "saved_quizzes":
-        title = quiz_doc.get("title") or "General Knowledge"
-        topic = quiz_doc.get("profession") or title
-        description = quiz_doc.get("description") or build_default_description(topic)
-        quiz_type = quiz_doc.get("question_type") or "multichoice"
-    else:
-        raise ValueError(f"Unsupported source for shared quiz normalization: {source}")
-
-    return {
-        "id": quiz_id,
-        "title": title,
-        "description": description,
-        "quiz_type": quiz_type,
-        "questions": quiz_doc.get("questions", []),
-    }
-
-
-async def resolve_shared_quiz(quiz_id: str) -> Optional[Dict[str, Any]]:
-    try:
-        object_id = ObjectId(quiz_id)
-    except InvalidId:
-        return None
-
-    quizzes_collection = get_quizzes_collection()
-    ai_collection = get_ai_generated_quizzes_collection()
-    saved_collection = get_saved_quizzes_collection()
-
-    regular_quiz = await quizzes_collection.find_one({"_id": object_id}, projection={"_id": 0})
-    if regular_quiz:
-        return normalize_shared_quiz(regular_quiz, quiz_id, "quizzes")
-
-    ai_quiz = await ai_collection.find_one({"_id": object_id}, projection={"_id": 0})
-    if ai_quiz:
-        return normalize_shared_quiz(ai_quiz, quiz_id, "ai_generated_quizzes")
-
-    saved_quiz = await saved_collection.find_one({"_id": object_id}, projection={"_id": 0})
-    if saved_quiz:
-        return normalize_shared_quiz(saved_quiz, quiz_id, "saved_quizzes")
-    return None
-
 
 @router.get("/get-quiz-id", response_model=QuizSchema)
 async def get_random_quiz_id(
-    quizzes_collection: AsyncIOMotorCollection = Depends(get_quizzes_collection),
     quizzes_v2_collection: AsyncIOMotorCollection = Depends(get_quizzes_v2_collection),
 ):
     try:
-        if settings.QUIZ_V2_SHARE_READ_MODE == "v2_only":
-            quiz_list = await quizzes_v2_collection.find({"status": {"$ne": "deleted"}}).to_list(length=50)
-            if not quiz_list:
-                raise HTTPException(detail="Unable to fetch from database!", status_code=404)
-            selected_quiz = random.choice(quiz_list)
-            return QuizSchema(
-                id=str(selected_quiz["_id"]),
-                title=selected_quiz["title"],
-                description=selected_quiz.get("description"),
-                quiz_type=selected_quiz["quiz_type"],
-                owner_id=selected_quiz.get("owner_user_id"),
-                canonical_quiz_id=str(selected_quiz["_id"]),
-                created_at=selected_quiz["created_at"],
-                updated_at=selected_quiz["updated_at"],
-                questions=selected_quiz["questions"],
-            )
-        quiz_List = await list_quizzes(quizzes_collection)
-        selected_quiz = random.choice(quiz_List)
-        return selected_quiz
-
-    except Exception as e:
-        logger.info(f"Error occured while fetching quiz from database: {e}")
-        raise HTTPException(detail=f"Unable to fetch from database!", status_code=404)
+        quiz_list = await quizzes_v2_collection.find({"status": {"$ne": "deleted"}}).to_list(length=50)
+        if not quiz_list:
+            raise HTTPException(detail="Unable to fetch from database!", status_code=404)
+        selected_quiz = random.choice(quiz_list)
+        return QuizSchema(
+            id=str(selected_quiz["_id"]),
+            title=selected_quiz["title"],
+            description=selected_quiz.get("description"),
+            quiz_type=selected_quiz["quiz_type"],
+            owner_id=selected_quiz.get("owner_user_id"),
+            canonical_quiz_id=str(selected_quiz["_id"]),
+            created_at=selected_quiz["created_at"],
+            updated_at=selected_quiz["updated_at"],
+            questions=selected_quiz["questions"],
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.info("Error occured while fetching quiz from database: %s", exc)
+        raise HTTPException(detail="Unable to fetch from database!", status_code=404)
 
 
 @router.get("/share-quiz/{quiz_id}", response_model=ShareQuizResponse)
 async def get_share_link(quiz_id: str):
     try:
         shareable_link = f"{share_url}/share/{quiz_id}"
-        logger.info(f"shareable link generated successfully")
+        logger.info("shareable link generated successfully")
         return {"link": shareable_link}
-
-    except Exception as e:
-        logger.info(f"Unable to generate shareable link: {e}")
+    except Exception as exc:
+        logger.info("Unable to generate shareable link: %s", exc)
         raise HTTPException(detail="Failed to generate shareable link", status_code=500)
 
 
@@ -150,8 +80,8 @@ async def get_shared_quiz_data(quiz_id: str):
         return shared_quiz
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"Unable to fetch shared quiz data for {quiz_id}: {e}", exc_info=True)
+    except Exception as exc:
+        logger.error("Unable to fetch shared quiz data for %s: %s", quiz_id, exc, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to fetch shared quiz data.",
@@ -167,7 +97,7 @@ async def share_quiz_via_email(
         shared_quiz = await shared_quiz_read_service.resolve_shared_quiz(query.quiz_id)
         if not shared_quiz:
             raise HTTPException(status_code=404, detail="Quiz not found")
-        
+
         await email_svc.send_email(
             to=query.recipient_email,
             template_id="quiz_link",
@@ -179,14 +109,13 @@ async def share_quiz_via_email(
             purpose="quiz_link",
             priority="default",
         )
-        logger.info(f"[API] Share email pipeline triggered for {query.recipient_email} and quiz ID {query.quiz_id}")
+        logger.info("[API] Share email pipeline triggered for %s and quiz ID %s", query.recipient_email, query.quiz_id)
         return {"message": "Email sent successfully!"}
-    
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error(f"[API Error] Share email pipeline failed: {e}", exc_info=True)
+    except Exception as exc:
+        logger.error("[API Error] Share email pipeline failed: %s", exc, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to send email. Please try again later."
+            detail="Failed to send email. Please try again later.",
         )

--- a/server/app/share/routes/share_routes.py
+++ b/server/app/share/routes/share_routes.py
@@ -13,6 +13,7 @@ from ...db.core.connection import (
     get_saved_quizzes_collection,
 )
 from ...db.crud.quiz_crud import list_quizzes
+from ...db.services.shared_quiz_read_service import SharedQuizReadService
 from ...db.schemas.quiz_schemas import QuizSchema
 from .share_schemas import (
     ShareQuizResponse,
@@ -34,6 +35,7 @@ if not share_url:
 
 
 router = APIRouter()
+shared_quiz_read_service = SharedQuizReadService()
 
 def build_default_description(topic: str) -> str:
     return f"A quiz to test your knowledge on {topic}"
@@ -121,7 +123,7 @@ async def get_share_link(quiz_id: str):
 @router.get("/shared-quiz/{quiz_id}", response_model=SharedQuizDataResponse)
 async def get_shared_quiz_data(quiz_id: str):
     try:
-        shared_quiz = await resolve_shared_quiz(quiz_id)
+        shared_quiz = await shared_quiz_read_service.resolve_shared_quiz(quiz_id)
         if not shared_quiz:
             raise HTTPException(status_code=404, detail="Quiz not found")
         return shared_quiz
@@ -141,7 +143,7 @@ async def share_quiz_via_email(
     email_svc: EmailService = Depends(get_email_service),
 ):
     try:
-        shared_quiz = await resolve_shared_quiz(query.quiz_id)
+        shared_quiz = await shared_quiz_read_service.resolve_shared_quiz(query.quiz_id)
         if not shared_quiz:
             raise HTTPException(status_code=404, detail="Quiz not found")
         
@@ -167,4 +169,3 @@ async def share_quiz_via_email(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to send email. Please try again later."
         )
-

--- a/server/main.py
+++ b/server/main.py
@@ -1,67 +1,57 @@
-from fastapi.responses import StreamingResponse
-from .api import healthcheck
 import logging
 import os
-from redis.asyncio import Redis
 from contextlib import asynccontextmanager
-from typing import Dict, Any, List
-from fastapi import FastAPI, Body, HTTPException, Depends, Query, Request, Response
+from typing import Any, Dict, List
+
 import redis
-from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
-from slowapi import _rate_limit_exceeded_handler
+from fastapi import Body, Depends, FastAPI, HTTPException, Request, Response
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
+from redis.asyncio import Redis
 from slowapi.errors import RateLimitExceeded
 
 from .api import healthcheck
 from .api.v1.crud import generate_quiz, get_user_quiz_history
 from .api.v1.crud.download.download_quiz import download_mock_quiz, download_quiz_by_id
-from .app.db.routes import router as db_router
-from .app.db.core.connection import startUp, database
+from .app.auth.routes import router as auth_router
+from .app.db.core.config import settings
 from .app.db.core.connection import (
-    startUp, 
-    get_users_collection, 
-    get_quizzes_collection, 
-    get_blacklisted_tokens_collection
+    database,
+    get_blacklisted_tokens_collection,
+    get_quizzes_collection,
+    get_users_collection,
+    startUp,
 )
-from server.app.quiz.routers.quiz import router as quiz_router
-from server.app.auth.routes import router as auth_router
-from server.app.db.routes.save_quiz_history import router as save_quiz_router
-from server.app.db.routes.get_quiz_history import router as get_quiz_history_router
-from .app.db.routes.get_categories import router as get_categories_router
+from .app.db.core.rate_limiter import limiter, rate_limit_handler
+from .app.db.models.user_models import UserOut
+from .app.db.routes import router as db_router
+from .app.db.routes import saved_quizzes, token_router
 from .app.db.routes.folder_routes import router as folder_routes
-from .app.db.routes import saved_quizzes
-
-from .app.db.core.connection import startUp
-from .app.db.routes import token_router
+from .app.db.routes.get_categories import router as get_categories_router
+from .app.db.routes.get_quiz_history import router as get_quiz_history_router
+from .app.db.routes.save_quiz_history import router as save_quiz_router
+from .app.dependancies import get_current_user
 from .app.quiz.routers.quiz import router as quiz_router
 from .app.share.routes.share_routes import router as share_router
-from .schemas.model import UserModel, LoginRequestModel, LoginResponseModel
-from .schemas.query import (
-    GenerateQuizQuery,
-    DownloadQuizQuery,
-    GetUserQuizHistoryQuery
-)
+from .schemas.query import DownloadQuizQuery, GenerateQuizQuery, GetUserQuizHistoryQuery
 
-# Import rate limiter
-from .app.db.core.rate_limiter import limiter, rate_limit_handler
-from .app.db.core.config import settings
-from .app.dependancies import get_current_user
-from .app.db.models.user_models import UserOut
 
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-    handlers=[logging.StreamHandler()]
+    handlers=[logging.StreamHandler()],
 )
 logger = logging.getLogger(__name__)
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 load_dotenv(os.path.join(BASE_DIR, ".env"))
-
 load_dotenv()
+
 redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 raw_origins = os.getenv("ALLOWED_ORIGINS", "").split(",")
 origins = [origin.strip() for origin in raw_origins if origin.strip() and origin.strip() != "*"]
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -71,19 +61,16 @@ async def lifespan(app: FastAPI):
     app.state.users_collection = get_users_collection()
     app.state.quizzes_collection = get_quizzes_collection()
     app.state.blacklisted_tokens_collection = get_blacklisted_tokens_collection()
-    
+
     yield
-    
+
     get_users_collection().database.client.close()
     await redis_client.close()
 
-app = FastAPI(lifespan=lifespan)
 
-# CRITICAL: Add rate limiter state and exception handler
+app = FastAPI(lifespan=lifespan)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, rate_limit_handler)
-
-# Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
@@ -92,7 +79,6 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Include routers
 app.include_router(db_router)
 app.include_router(quiz_router, prefix="/api", tags=["quiz"])
 app.include_router(share_router, prefix="/share", tags=["share"])
@@ -101,69 +87,21 @@ app.include_router(auth_router, prefix="/auth", tags=["authentication"])
 app.include_router(token_router.router, prefix="/api", tags=["Token"])
 app.include_router(saved_quizzes.router, prefix="/api", tags=["Saved Quizzes"])
 app.include_router(folder_routes, prefix="/api/folders", tags=["Folders"])
-app.database = database
-
-
-@app.get("/api")
-def read_root():
-    logger.info("Root endpoint accessed")
-    return {"message": "Welcome to the Quiz App API!"}
-
-
-@app.get("/users")
-async def get_users(request: Request):
-    users_collection = request.app.state.users_collection
-    users = await users_collection.find().to_list(length=100)
-    return users
-
-@app.post("/generate-quiz")
-async def generate_quiz_handler(query: GenerateQuizQuery = Body(...)) -> Dict[str, Any]:
-    logger.info("Received query: %s", query)
-    return generate_quiz(query.user_id, query.question_type, query.num_question)
-
-@app.post("/get-user-quiz-history")
-def get_user_quiz_history_handler(query: GetUserQuizHistoryQuery = Body(...)) -> List[Any]:
-    logger.info("Received query: %s", query)
-    return get_user_quiz_history(query.user_id)
-
-
-@app.get("/download-quiz")
-@limiter.limit("20/minute")
-async def download_quiz_handler(
-    request: Request,
-    response: Response,
-    query: DownloadQuizQuery = Depends()) -> StreamingResponse:
-    logger.info("Received query: %s", query)
-
-    if query.quiz_id:
-        return await download_quiz_by_id(
-            quiz_id=query.quiz_id,
-            file_format=query.format,
-            user_id=query.user_id
-        )
-
-    return download_mock_quiz(
-        query.format,
-        query.question_type,
-        query.num_question
-    )
-
-
 app.include_router(save_quiz_router, prefix="/api")
 app.include_router(get_quiz_history_router, prefix="/api")
 app.include_router(get_categories_router, prefix="/api")
-
 app.database = database
 
-# Apply rate limits to main endpoints
+
 @app.get("/api")
 @limiter.limit("100/minute")
 async def read_root(request: Request, response: Response):
     logger.info("Root endpoint accessed")
     return {"message": "Welcome to the Quiz App API!"}
 
+
 @app.get("/users")
-@limiter.limit("30/minute")  # Restrictive for user listing
+@limiter.limit("30/minute")
 async def get_users(
     request: Request,
     response: Response,
@@ -183,38 +121,53 @@ async def get_users(
     ).to_list(length=100)
     return users
 
+
 @app.post("/generate-quiz")
-@limiter.limit("10/minute;50/hour")  # Resource-intensive operation
+@limiter.limit("10/minute;50/hour")
 async def generate_quiz_handler(
     request: Request,
     response: Response,
-    query: GenerateQuizQuery = Body(...)
+    query: GenerateQuizQuery = Body(...),
 ) -> Dict[str, Any]:
     logger.info("Received query: %s", query)
     return generate_quiz(query.user_id, query.question_type, query.num_question)
+
 
 @app.post("/get-user-quiz-history")
 @limiter.limit("50/minute")
 async def get_user_quiz_history_handler(
     request: Request,
     response: Response,
-    query: GetUserQuizHistoryQuery = Body(...)
+    query: GetUserQuizHistoryQuery = Body(...),
 ) -> List[Any]:
     logger.info("Received query: %s", query)
     return get_user_quiz_history(query.user_id)
+
 
 @app.get("/download-quiz")
 @limiter.limit("20/minute")
 async def download_quiz_handler(
     request: Request,
     response: Response,
-    query: DownloadQuizQuery = Depends()
+    query: DownloadQuizQuery = Depends(),
 ) -> StreamingResponse:
     logger.info("Received query: %s", query)
-    return download_quiz(query.format, query.question_type, query.num_question)
+
+    if query.quiz_id:
+        return await download_quiz_by_id(
+            quiz_id=query.quiz_id,
+            file_format=query.format,
+        )
+
+    return download_mock_quiz(
+        query.format,
+        query.question_type,
+        query.num_question,
+    )
+
 
 @app.get("/ping-redis")
 @limiter.limit("10/minute")
 async def ping_redis(request: Request, response: Response):
-    r = redis.Redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379/0"))
-    return {"pong": r.ping()}
+    redis_client = redis.Redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379/0"))
+    return {"pong": redis_client.ping()}

--- a/server/schemas/query/download_quiz_query.py
+++ b/server/schemas/query/download_quiz_query.py
@@ -6,7 +6,6 @@ from .query_patterns import QueryPattern
 
 class DownloadQuizQuery(BaseModel):
     pattern: Optional[str] = Field(QueryPattern.DOWNLOAD_QUIZ)
-    user_id: Optional[str] = Field(..., description="User's id")
     format: str = Field("txt", description="File format for the quiz data (txt, csv, pdf, docx)")
     quiz_id: Optional[str] = Field(
         None,

--- a/server/scripts/v2_backfill/__init__.py
+++ b/server/scripts/v2_backfill/__init__.py
@@ -1,0 +1,1 @@
+"""CLI entrypoints for Stage 3 V2 backfill and parity checks."""

--- a/server/scripts/v2_backfill/run_full_v2_backfill.py
+++ b/server/scripts/v2_backfill/run_full_v2_backfill.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+from server.app.db.core.connection import database
+from server.app.db.v2.migration.backfill_engine import (
+    build_migration_context,
+    run_backfill,
+    run_parity_checks,
+)
+from server.app.db.v2.migration.config import BackfillConfig
+from server.app.db.v2.migration.lock import MigrationLockError
+from server.app.db.v2.migration.logging import log_migration_event
+from server.app.db.v2.migration.summary import write_summary_json
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run Stage 3 full V2 backfill plus parity checks")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="Run backfill and parity without writing to V2")
+    mode.add_argument("--commit", action="store_true", help="Run backfill with writes enabled, then parity checks")
+    parser.add_argument("--batch-size", type=int, default=None)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--start-after-id", type=str, default=None)
+    parser.add_argument("--collections", type=str, default=None)
+    parser.add_argument("--run-id", type=str, default=None)
+    return parser.parse_args()
+
+
+def configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+
+
+async def main():
+    configure_logging()
+    args = parse_args()
+    config = BackfillConfig.from_settings(
+        dry_run=False if args.commit else True,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        start_after_id=args.start_after_id,
+        collections=args.collections.split(",") if args.collections else None,
+        run_id=args.run_id,
+    )
+    context = build_migration_context(
+        config=config,
+        database=database,
+        report_dir=Path(__file__).resolve().parents[2] / "tmp",
+    )
+    try:
+        await context.lock_service.acquire_lock(
+            migration_name="stage_3_backfill",
+            run_id=config.run_id,
+            dry_run=config.dry_run,
+            triggered_by="cli",
+            lease_seconds=config.lock_lease_seconds,
+        )
+    except MigrationLockError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    status = "completed"
+    try:
+        log_migration_event(
+            "v2_backfill_started",
+            run_id=config.run_id,
+            dry_run=config.dry_run,
+            batch_size=config.batch_size,
+            limit=config.limit,
+            start_after_id=config.start_after_id,
+            collections=context.config.collections,
+        )
+        backfill_report = await run_backfill(context)
+        parity_report = await run_parity_checks(context)
+        write_summary_json(
+            context.report_dir / f"v2_backfill_summary_{config.run_id}.json",
+            backfill_report.to_dict(),
+        )
+        write_summary_json(
+            context.report_dir / f"v2_parity_summary_{config.run_id}.json",
+            parity_report.to_dict(),
+        )
+        log_migration_event(
+            "v2_backfill_completed",
+            run_id=config.run_id,
+            backfill_summary_path=str(context.report_dir / f"v2_backfill_summary_{config.run_id}.json"),
+            parity_summary_path=str(context.report_dir / f"v2_parity_summary_{config.run_id}.json"),
+        )
+    except Exception as exc:
+        status = "failed"
+        await context.lock_service.release_lock(
+            migration_name="stage_3_backfill",
+            run_id=config.run_id,
+            status=status,
+            error=str(exc),
+        )
+        raise
+    else:
+        await context.lock_service.release_lock(
+            migration_name="stage_3_backfill",
+            run_id=config.run_id,
+            status=status,
+            summary={"backfill": backfill_report.to_dict(), "parity": parity_report.to_dict()},
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/scripts/v2_backfill/run_v2_backfill.py
+++ b/server/scripts/v2_backfill/run_v2_backfill.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+from server.app.db.core.connection import database
+from server.app.db.v2.migration.backfill_engine import build_migration_context, run_backfill
+from server.app.db.v2.migration.config import BackfillConfig
+from server.app.db.v2.migration.lock import MigrationLockError
+from server.app.db.v2.migration.logging import log_migration_event
+from server.app.db.v2.migration.summary import write_summary_json
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run Stage 3 V2 backfill")
+    parser.add_argument("--dry-run", action="store_true", help="Run without writing to V2 collections")
+    parser.add_argument("--batch-size", type=int, default=None)
+    parser.add_argument("--limit", type=int, default=None)
+    parser.add_argument("--start-after-id", type=str, default=None)
+    parser.add_argument("--collections", type=str, default=None)
+    parser.add_argument("--run-id", type=str, default=None)
+    return parser.parse_args()
+
+
+def configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+
+
+async def main():
+    configure_logging()
+    args = parse_args()
+    config = BackfillConfig.from_settings(
+        dry_run=args.dry_run if args.dry_run else None,
+        batch_size=args.batch_size,
+        limit=args.limit,
+        start_after_id=args.start_after_id,
+        collections=args.collections.split(",") if args.collections else None,
+        run_id=args.run_id,
+    )
+    context = build_migration_context(
+        config=config,
+        database=database,
+        report_dir=Path(__file__).resolve().parents[2] / "tmp",
+    )
+    try:
+        await context.lock_service.acquire_lock(
+            migration_name="stage_3_backfill",
+            run_id=config.run_id,
+            dry_run=config.dry_run,
+            triggered_by="cli",
+            lease_seconds=config.lock_lease_seconds,
+        )
+    except MigrationLockError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    status = "completed"
+    report = None
+    try:
+        log_migration_event(
+            "v2_backfill_started",
+            run_id=config.run_id,
+            dry_run=config.dry_run,
+            batch_size=config.batch_size,
+            limit=config.limit,
+            start_after_id=config.start_after_id,
+            collections=context.config.collections,
+        )
+        report = await run_backfill(context)
+        summary_path = context.report_dir / f"v2_backfill_summary_{config.run_id}.json"
+        write_summary_json(summary_path, report.to_dict())
+        log_migration_event(
+            "v2_backfill_completed",
+            run_id=config.run_id,
+            summary_path=str(summary_path),
+            collections=context.config.collections,
+        )
+    except Exception as exc:
+        status = "failed"
+        await context.lock_service.release_lock(
+            migration_name="stage_3_backfill",
+            run_id=config.run_id,
+            status=status,
+            error=str(exc),
+        )
+        raise
+    else:
+        await context.lock_service.release_lock(
+            migration_name="stage_3_backfill",
+            run_id=config.run_id,
+            status=status,
+            summary=report.to_dict() if report else None,
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/scripts/v2_backfill/run_v2_parity_checks.py
+++ b/server/scripts/v2_backfill/run_v2_parity_checks.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from pathlib import Path
+
+from server.app.db.core.connection import database
+from server.app.db.v2.migration.backfill_engine import build_migration_context, run_parity_checks
+from server.app.db.v2.migration.config import BackfillConfig
+from server.app.db.v2.migration.logging import log_migration_event
+from server.app.db.v2.migration.summary import write_summary_json
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Run Stage 3 V2 parity checks")
+    parser.add_argument("--run-id", type=str, default=None)
+    return parser.parse_args()
+
+
+def configure_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )
+
+
+async def main():
+    configure_logging()
+    args = parse_args()
+    config = BackfillConfig.from_settings(run_id=args.run_id)
+    context = build_migration_context(
+        config=config,
+        database=database,
+        report_dir=Path(__file__).resolve().parents[2] / "tmp",
+    )
+    log_migration_event("v2_parity_check_started", run_id=config.run_id)
+    report = await run_parity_checks(context)
+    summary_path = context.report_dir / f"v2_parity_summary_{config.run_id}.json"
+    write_summary_json(summary_path, report.to_dict())
+    log_migration_event(
+        "v2_parity_check_completed",
+        run_id=config.run_id,
+        summary_path=str(summary_path),
+    )
+    print(summary_path)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/server/tests/test_download.py
+++ b/server/tests/test_download.py
@@ -2,17 +2,20 @@ import pytest
 
 from unittest.mock import patch
 from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 from bson import ObjectId
+from pydantic import ValidationError
 
 from fastapi import HTTPException
+from fastapi import Response
 
 from fastapi.responses import StreamingResponse
 
-from fastapi.testclient import TestClient
-
 from io import BytesIO
 
-from server.main import app
+from server.main import download_quiz_handler
+from server.main import limiter
+from server.schemas.query import DownloadQuizQuery
 
 from docx import Document
 
@@ -28,7 +31,14 @@ from server.api.v1.crud.generate_pdf import generate_pdf
 from server.api.v1.crud.generate_txt import generate_txt
 
 
-client = TestClient(app)
+@pytest.fixture(autouse=True)
+def disable_rate_limiter():
+    original_enabled = limiter.enabled
+    limiter.enabled = False
+    try:
+        yield
+    finally:
+        limiter.enabled = original_enabled
 
 
 def mock_generate_file(data):
@@ -122,34 +132,28 @@ def test_download_quiz_invalid_format(format):
 
 ])
 
-def test_download_quiz_api_valid(format, question_type, num_question):
+@pytest.mark.asyncio
+async def test_download_quiz_api_valid(format, question_type, num_question):
 
-    response = client.get(
-
-        "/download-quiz",
-
-        params={
-
-            "format": format,
-
-            "question_type": question_type,
-
-            "num_question": num_question,
-
-            "user_id": "test_user"
-
-        }
-
+    response = await download_quiz_handler(
+        request=MagicMock(),
+        response=Response(),
+        query=DownloadQuizQuery(
+            format=format,
+            question_type=question_type,
+            num_question=num_question,
+        ),
     )
 
-
-    assert response.status_code == 200
-
+    assert isinstance(response, StreamingResponse)
+    assert response.media_type == {
+        "txt": "text/plain",
+        "csv": "text/csv",
+        "pdf": "application/pdf",
+        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    }[format]
     assert "Content-Disposition" in response.headers
-
     assert f"attachment; filename=quiz_data.{format}" in response.headers["Content-Disposition"]
-
-    assert response.content
 
 
 
@@ -161,33 +165,31 @@ def test_download_quiz_api_valid(format, question_type, num_question):
     ("csv", "true-false", 0, 422),
 
 ])
+@pytest.mark.asyncio
+async def test_download_quiz_api_invalid(format, question_type, num_question, expected_status):
+    if expected_status == 422:
+        with pytest.raises(ValidationError):
+            DownloadQuizQuery(
+                format=format,
+                question_type=question_type,
+                num_question=num_question,
+            )
+        return
 
-def test_download_quiz_api_invalid(format, question_type, num_question, expected_status):
+    with pytest.raises(HTTPException) as exc:
+        await download_quiz_handler(
+            request=MagicMock(),
+            response=Response(),
+            query=DownloadQuizQuery(
+                format=format,
+                question_type=question_type,
+                num_question=num_question,
+            ),
+        )
 
-    response = client.get(
-
-        "/download-quiz",
-
-        params={
-
-            "format": format,
-
-            "question_type": question_type,
-
-            "num_question": num_question,
-
-            "user_id": "test_user"
-
-        }
-
-    )
-
-
-    assert response.status_code == expected_status
-
-    assert "application/json" in response.headers["content-type"]
-
-    assert "detail" in response.json()
+    assert exc.value.status_code == expected_status
+    assert exc.value.detail
+    assert exc.value.detail
 
 
 
@@ -391,7 +393,6 @@ async def test_download_quiz_by_id_reads_canonical_v2_quiz_and_normalizes_answer
         response = await download_quiz_by_id(
             quiz_id="69e78f93594339fd166131ea",
             file_format="txt",
-            user_id="defaultUserId",
         )
 
     assert isinstance(response, StreamingResponse)

--- a/server/tests/test_download.py
+++ b/server/tests/test_download.py
@@ -1,6 +1,8 @@
 import pytest
 
 from unittest.mock import patch
+from unittest.mock import AsyncMock
+from bson import ObjectId
 
 from fastapi import HTTPException
 
@@ -16,19 +18,14 @@ from docx import Document
 
 from pypdf import PdfReader
 
-from server.api.v1.crud.download_quiz import (
-
-    download_quiz,
-
-    generate_csv,
-
-    generate_docx,
-
-    generate_pdf,
-
-    generate_txt
-
-    )
+from server.api.v1.crud.download.download_quiz import (
+    download_mock_quiz,
+    download_quiz_by_id,
+)
+from server.api.v1.crud.generate_csv import generate_csv
+from server.api.v1.crud.generate_docx import generate_docx
+from server.api.v1.crud.generate_pdf import generate_pdf
+from server.api.v1.crud.generate_txt import generate_txt
 
 
 client = TestClient(app)
@@ -53,15 +50,15 @@ def mock_generate_file(data):
 
 ])
 
-@patch("server.api.v1.crud.download_quiz.quiz_data_multiple_choice", new=[{"q": "A"}] * 10)
+@patch("server.api.v1.crud.download.download_quiz.quiz_data_multiple_choice", new=[{"q": "A"}] * 10)
 
-@patch("server.api.v1.crud.download_quiz.generate_txt", side_effect=mock_generate_file)
+@patch("server.api.v1.crud.download.download_quiz.generate_txt", side_effect=mock_generate_file)
 
-@patch("server.api.v1.crud.download_quiz.generate_csv", side_effect=mock_generate_file)
+@patch("server.api.v1.crud.download.download_quiz.generate_csv", side_effect=mock_generate_file)
 
-@patch("server.api.v1.crud.download_quiz.generate_pdf", side_effect=mock_generate_file)
+@patch("server.api.v1.crud.download.download_quiz.generate_pdf", side_effect=mock_generate_file)
 
-@patch("server.api.v1.crud.download_quiz.generate_docx", side_effect=mock_generate_file)
+@patch("server.api.v1.crud.download.download_quiz.generate_docx", side_effect=mock_generate_file)
 
 def test_download_quiz_valid_formats(
 
@@ -71,7 +68,7 @@ def test_download_quiz_valid_formats(
 
     """Test if download_quiz correctly returns a StreamingResponse with valid formats."""
 
-    response = download_quiz(format=format, question_type="multichoice", num_question=5)
+    response = download_mock_quiz(format=format, question_type="multichoice", num_question=5)
 
 
     assert isinstance(response, StreamingResponse)
@@ -89,7 +86,7 @@ def test_download_quiz_invalid_question_type(question_type):
 
     with pytest.raises(HTTPException) as exc:
 
-        download_quiz(format="txt", question_type=question_type, num_question=5)
+        download_mock_quiz(format="txt", question_type=question_type, num_question=5)
 
     assert exc.value.status_code == 400
 
@@ -104,7 +101,7 @@ def test_download_quiz_invalid_format(format):
 
     with pytest.raises(HTTPException) as exc:
 
-        download_quiz(format=format, question_type="multichoice", num_question=5)
+        download_mock_quiz(format=format, question_type="multichoice", num_question=5)
 
     assert exc.value.status_code == 400
 
@@ -356,4 +353,46 @@ def test_generate_pdf(sample_quiz_data):
     assert "Answer: Photosynthesis is the process" in content
 
 
+@pytest.mark.asyncio
+async def test_download_quiz_by_id_reads_canonical_v2_quiz_and_normalizes_answers():
+    v2_collection = AsyncMock()
+    legacy_ai_collection = AsyncMock()
+    legacy_manual_collection = AsyncMock()
 
+    v2_collection.find_one.return_value = {
+        "_id": ObjectId("69e78f93594339fd166131ea"),
+        "questions": [
+            {
+                "question": "What is the main goal of AI automation?",
+                "options": [
+                    "A) To replace all human jobs",
+                    "B) To perform tasks without human intervention",
+                ],
+                "correct_answer": "B) To perform tasks without human intervention",
+            }
+        ],
+    }
+    legacy_ai_collection.find_one.return_value = None
+    legacy_manual_collection.find_one.return_value = None
+
+    with patch(
+        "server.api.v1.crud.download.download_quiz.get_quizzes_v2_collection",
+        return_value=v2_collection,
+    ), patch(
+        "server.api.v1.crud.download.download_quiz.get_ai_generated_quizzes_collection",
+        return_value=legacy_ai_collection,
+    ), patch(
+        "server.api.v1.crud.download.download_quiz.get_quizzes_collection",
+        return_value=legacy_manual_collection,
+    ), patch(
+        "server.api.v1.crud.download.download_quiz.generate_txt",
+        side_effect=generate_txt,
+    ):
+        response = await download_quiz_by_id(
+            quiz_id="69e78f93594339fd166131ea",
+            file_format="txt",
+            user_id="defaultUserId",
+        )
+
+    assert isinstance(response, StreamingResponse)
+    assert response.media_type == "text/plain"

--- a/server/tests/v2_database_tests/backfill_tests/__init__.py
+++ b/server/tests/v2_database_tests/backfill_tests/__init__.py
@@ -1,0 +1,1 @@
+"""Stage 3 backfill tests."""

--- a/server/tests/v2_database_tests/backfill_tests/conftest.py
+++ b/server/tests/v2_database_tests/backfill_tests/conftest.py
@@ -1,0 +1,49 @@
+import os
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+os.environ.setdefault("email_sender", "test@example.com")
+os.environ.setdefault("email_password", "password")
+os.environ.setdefault("email_host", "localhost")
+os.environ.setdefault("email_port", "1025")
+os.environ.setdefault("share_url", "http://localhost")
+os.environ.setdefault("db_name", "test_db")
+os.environ.setdefault("mongo_url", "mongodb://localhost:27017")
+
+from ....app.db.v2.migration.backfill_engine import build_migration_context
+from ....app.db.v2.migration.config import BackfillConfig
+from ....app.db.v2.setup import ensure_v2_collections_and_validators, ensure_v2_indexes
+
+
+@pytest_asyncio.fixture(scope="function")
+async def backfill_db(test_db):
+    await ensure_v2_collections_and_validators(test_db)
+    await ensure_v2_indexes(
+        test_db["quizzes_v2"],
+        test_db["folders_v2"],
+        test_db["folder_items_v2"],
+        test_db["saved_quizzes_v2"],
+        test_db["quiz_history_v2"],
+    )
+    return test_db
+
+
+@pytest.fixture(scope="function")
+def backfill_context_factory(backfill_db, tmp_path):
+    def factory(*, dry_run=False, collections=None, run_id="stage3-test"):
+        config = BackfillConfig.from_settings(
+            dry_run=dry_run,
+            collections=collections or ["quizzes", "saved", "history", "folders"],
+            run_id=run_id,
+            batch_size=50,
+        )
+        return build_migration_context(
+            config=config,
+            database=backfill_db,
+            report_dir=Path(tmp_path),
+        )
+
+    return factory

--- a/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
+++ b/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
@@ -1,0 +1,306 @@
+import pytest
+from bson import ObjectId
+
+from ....app.db.v2.migration.backfill_engine import (
+    backfill_folders,
+    backfill_quiz_history,
+    backfill_quizzes,
+    backfill_saved_quizzes,
+    run_backfill,
+    run_parity_checks,
+)
+
+
+@pytest.mark.asyncio
+async def test_stage3_backfill_reuses_ai_origin_for_saved_history_and_folder(
+    backfill_db,
+    backfill_context_factory,
+):
+    ai_id = ObjectId()
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Geography",
+            "question_type": "multichoice",
+            "difficulty_level": "easy",
+            "audience_type": "students",
+            "questions": [
+                {
+                    "question": "Capital of Kenya?",
+                    "options": ["Nairobi", "Mombasa"],
+                    "answer": "Nairobi",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    saved_id = ObjectId()
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-1",
+            "quiz_id": str(ai_id),
+            "title": "Geography",
+            "question_type": "multichoice",
+            "questions": [
+                {"question": "Capital of Kenya?", "options": ["Nairobi", "Mombasa"], "question_type": "multichoice"}
+            ],
+        }
+    )
+    history_id = ObjectId()
+    await backfill_db["quiz_history"].insert_one(
+        {
+            "_id": history_id,
+            "user_id": "user-1",
+            "quiz_id": str(ai_id),
+            "profession": "Geography",
+            "question_type": "multichoice",
+            "difficulty_level": "easy",
+            "audience_type": "students",
+            "questions": [
+                {
+                    "question": "Capital of Kenya?",
+                    "options": ["Nairobi", "Mombasa"],
+                    "answer": "Nairobi",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    folder_id = ObjectId()
+    await backfill_db["folders"].insert_one(
+        {
+            "_id": folder_id,
+            "user_id": "user-1",
+            "name": "Trips",
+            "quizzes": [
+                {
+                    "_id": "folder-item-1",
+                    "original_quiz_id": str(saved_id),
+                    "quiz_id": str(ai_id),
+                    "questions": [
+                        {"question": "Capital of Kenya?", "options": ["Nairobi", "Mombasa"], "question_type": "multichoice"}
+                    ],
+                    "question_type": "multichoice",
+                    "title": "Geography",
+                }
+            ],
+        }
+    )
+    context = backfill_context_factory()
+    await backfill_quizzes(context)
+    await backfill_saved_quizzes(context)
+    await backfill_quiz_history(context)
+    await backfill_folders(context)
+
+    canonical = await backfill_db["quizzes_v2"].find_one(
+        {"legacy_source_collection": "ai_generated_quizzes", "legacy_quiz_id": str(ai_id)}
+    )
+    saved_v2 = await backfill_db["saved_quizzes_v2"].find_one({"user_id": "user-1"})
+    history_v2 = await backfill_db["quiz_history_v2"].find_one({"legacy_history_id": str(history_id)})
+    folder_item_v2 = await backfill_db["folder_items_v2"].find_one({"legacy_folder_item_id": "folder-item-1"})
+
+    assert canonical is not None
+    assert saved_v2["quiz_id"] == str(canonical["_id"])
+    assert history_v2["quiz_id"] == str(canonical["_id"])
+    assert history_v2["metadata"]["source"] == "ai"
+    assert history_v2["metadata"]["topic"] == "Geography"
+    assert folder_item_v2["quiz_id"] == str(canonical["_id"])
+
+
+@pytest.mark.asyncio
+async def test_stage3_backfill_is_idempotent(backfill_db, backfill_context_factory):
+    ai_id = ObjectId()
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Networks",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is DNS?",
+                    "options": ["Name system", "Firewall"],
+                    "answer": "Name system",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    context = backfill_context_factory(collections=["quizzes"], run_id="idem-1")
+    await backfill_quizzes(context)
+    await backfill_quizzes(context)
+    assert await backfill_db["quizzes_v2"].count_documents({}) == 1
+
+
+@pytest.mark.asyncio
+async def test_stage3_history_rerun_counts_noop_records_as_skipped(backfill_db, backfill_context_factory):
+    ai_id = ObjectId()
+    history_id = ObjectId()
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Systems Design",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is caching?",
+                    "options": ["Storage", "Queue"],
+                    "answer": "Storage",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    await backfill_db["quiz_history"].insert_one(
+        {
+            "_id": history_id,
+            "user_id": "user-1",
+            "quiz_id": str(ai_id),
+            "profession": "Systems Design",
+            "question_type": "multichoice",
+            "difficulty_level": "easy",
+            "audience_type": "students",
+            "questions": [
+                {
+                    "question": "What is caching?",
+                    "options": ["Storage", "Queue"],
+                    "answer": "Storage",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["quizzes", "history"], run_id="history-rerun")
+    await backfill_quizzes(context)
+    first_summary = await backfill_quiz_history(context)
+    second_summary = await backfill_quiz_history(context)
+
+    assert first_summary.inserted == 1
+    assert second_summary.inserted == 0
+    assert second_summary.updated == 0
+    assert second_summary.skipped == 1
+
+
+@pytest.mark.asyncio
+async def test_stage3_backfill_dry_run_does_not_write(backfill_db, backfill_context_factory):
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ObjectId(),
+            "profession": "History",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "Who built the pyramids?",
+                    "options": ["Egyptians", "Romans"],
+                    "answer": "Egyptians",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    context = backfill_context_factory(dry_run=True, collections=["quizzes"], run_id="dry-run")
+    summary = await backfill_quizzes(context)
+    assert summary.inserted == 1
+    assert await backfill_db["quizzes_v2"].count_documents({}) == 0
+
+
+@pytest.mark.asyncio
+async def test_stage3_parity_reports_orphaned_references(backfill_db, backfill_context_factory):
+    await backfill_db["saved_quizzes_v2"].insert_one(
+        {"user_id": "user-1", "quiz_id": "missing-quiz", "saved_at": __import__("datetime").datetime.utcnow()}
+    )
+    context = backfill_context_factory(run_id="parity-1")
+    report = await run_parity_checks(context)
+    assert report.sections["saved"]["orphaned_quiz_refs"] == 1
+
+
+@pytest.mark.asyncio
+async def test_stage3_run_backfill_returns_collection_reports(backfill_db, backfill_context_factory):
+    ai_id = ObjectId()
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Biology",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is DNA?",
+                    "options": ["Acid", "Cell"],
+                    "answer": "Acid",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    context = backfill_context_factory(collections=["quizzes"], run_id="full-run")
+    report = await run_backfill(context)
+    assert "quizzes" in report.collections
+    assert report.collections["quizzes"].inserted == 1
+
+
+@pytest.mark.asyncio
+async def test_stage3_folder_backfill_with_structure_only_payload_does_not_crash(
+    backfill_db,
+    backfill_context_factory,
+):
+    ai_id = ObjectId()
+    saved_id = ObjectId()
+    folder_id = ObjectId()
+
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Geography",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "Capital of Kenya?",
+                    "options": ["Nairobi", "Mombasa"],
+                    "answer": "Nairobi",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-1",
+            "title": "Geography",
+            "question_type": "multichoice",
+            "questions": [
+                {"question": "Capital of Kenya?", "options": ["Nairobi", "Mombasa"], "question_type": "multichoice"}
+            ],
+        }
+    )
+    await backfill_db["folders"].insert_one(
+        {
+            "_id": folder_id,
+            "user_id": "user-1",
+            "name": "Trips",
+            "quizzes": [
+                {
+                    "_id": "folder-item-1",
+                    "original_quiz_id": str(saved_id),
+                    "questions": [
+                        {
+                            "question": "Capital of Kenya?",
+                            "options": ["Nairobi", "Mombasa"],
+                            "question_type": "multichoice",
+                        }
+                    ],
+                    "question_type": "multichoice",
+                    "title": "Geography",
+                }
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["quizzes", "folders"], run_id="folder-structure-only")
+    await backfill_quizzes(context)
+    summary = await backfill_folders(context)
+
+    assert summary.malformed == 0
+    assert summary.unresolved == 0
+    assert summary.inserted == 2

--- a/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
+++ b/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
@@ -304,3 +304,122 @@ async def test_stage3_folder_backfill_with_structure_only_payload_does_not_crash
     assert summary.malformed == 0
     assert summary.unresolved == 0
     assert summary.inserted == 2
+
+
+@pytest.mark.asyncio
+async def test_stage3_backfill_saved_quiz_without_answers_matches_legacy_ai_source(
+    backfill_db,
+    backfill_context_factory,
+):
+    ai_id = ObjectId()
+    saved_id = ObjectId()
+
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Entropy",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is entropy a measure of in a system?",
+                    "options": ["Energy", "Disorder", "Temperature", "Volume"],
+                    "answer": "Disorder",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-entropy",
+            "title": "Entropy Quiz",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is entropy a measure of in a system?",
+                    "options": ["Energy", "Disorder", "Temperature", "Volume"],
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["saved"], run_id="saved-legacy-structure")
+    summary = await backfill_saved_quizzes(context)
+
+    assert summary.unresolved == 0
+    assert summary.conflicts == 0
+    assert summary.inserted == 1
+
+    saved_v2 = await backfill_db["saved_quizzes_v2"].find_one({"legacy_saved_quiz_id": str(saved_id)})
+    canonical = await backfill_db["quizzes_v2"].find_one(
+        {"legacy_source_collection": "ai_generated_quizzes", "legacy_quiz_id": str(ai_id)}
+    )
+
+    assert saved_v2 is not None
+    assert canonical is not None
+    assert saved_v2["quiz_id"] == str(canonical["_id"])
+
+
+@pytest.mark.asyncio
+async def test_stage3_backfill_saved_quiz_reports_conflict_for_multiple_legacy_matches(
+    backfill_db,
+    backfill_context_factory,
+):
+    await backfill_db["ai_generated_quizzes"].insert_many(
+        [
+            {
+                "_id": ObjectId(),
+                "profession": "Entropy",
+                "question_type": "multichoice",
+                "questions": [
+                    {
+                        "question": "What is entropy?",
+                        "options": ["Order", "Disorder"],
+                        "answer": "Disorder",
+                        "question_type": "multichoice",
+                    }
+                ],
+            },
+            {
+                "_id": ObjectId(),
+                "profession": "Entropy",
+                "question_type": "multichoice",
+                "questions": [
+                    {
+                        "question": "What is entropy?",
+                        "options": ["Order", "Disorder"],
+                        "answer": "Disorder",
+                        "question_type": "multichoice",
+                    }
+                ],
+            },
+        ]
+    )
+    saved_id = ObjectId()
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-entropy",
+            "title": "Entropy Quiz",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is entropy?",
+                    "options": ["Order", "Disorder"],
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["saved"], run_id="saved-conflict")
+    summary = await backfill_saved_quizzes(context)
+
+    assert summary.inserted == 0
+    assert summary.conflicts == 1
+    assert summary.unresolved == 0
+    assert summary.conflict_examples[0]["record_id"] == str(saved_id)
+    assert len(summary.conflict_examples[0]["candidate_ids"]) == 2
+    assert await backfill_db["saved_quizzes_v2"].count_documents({}) == 0

--- a/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
+++ b/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
@@ -103,10 +103,13 @@ async def test_stage3_backfill_reuses_ai_origin_for_saved_history_and_folder(
 
     assert canonical is not None
     assert saved_v2["quiz_id"] == str(canonical["_id"])
+    assert saved_v2["display_title"] == "Geography"
     assert history_v2["quiz_id"] == str(canonical["_id"])
     assert history_v2["metadata"]["source"] == "ai"
     assert history_v2["metadata"]["topic"] == "Geography"
     assert folder_item_v2["quiz_id"] == str(canonical["_id"])
+    assert folder_item_v2["display_title"] == "Geography"
+    assert folder_item_v2["position"] == 0
 
 
 @pytest.mark.asyncio
@@ -377,6 +380,7 @@ async def test_stage3_folder_backfill_merges_duplicate_items_for_same_canonical_
     assert summary.conflicts == 0
     assert len(folder_items) == 1
     assert folder_items[0]["legacy_folder_item_id"] == "folder-item-1"
+    assert folder_items[0]["position"] == 0
 
 
 @pytest.mark.asyncio

--- a/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
+++ b/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
@@ -1,5 +1,6 @@
 import pytest
 from bson import ObjectId
+from datetime import datetime
 
 from ....app.db.v2.migration.backfill_engine import (
     backfill_folders,
@@ -423,3 +424,319 @@ async def test_stage3_backfill_saved_quiz_reports_conflict_for_multiple_legacy_m
     assert summary.conflict_examples[0]["record_id"] == str(saved_id)
     assert len(summary.conflict_examples[0]["candidate_ids"]) == 2
     assert await backfill_db["saved_quizzes_v2"].count_documents({}) == 0
+
+
+@pytest.mark.asyncio
+async def test_stage3_backfill_saved_quiz_reuses_existing_v2_question_only_match(
+    backfill_db,
+    backfill_context_factory,
+):
+    existing_quiz_id = ObjectId()
+    saved_id = ObjectId()
+    await backfill_db["quizzes_v2"].insert_one(
+        {
+            "_id": existing_quiz_id,
+            "title": "multichoice Quiz",
+            "quiz_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "correct_answer": "B) Moscow",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                },
+                {
+                    "question": "Russia is the largest country in the world by what measure?",
+                    "correct_answer": "B) Land area",
+                    "options": ["A) Population", "B) Land area", "C) Military size", "D) Number of cities"],
+                },
+            ],
+            "description": "Geopolitical power",
+            "owner_user_id": None,
+            "visibility": "private",
+            "status": "active",
+            "source": "legacy",
+            "tags": [],
+            "legacy_source_collection": None,
+            "legacy_quiz_id": None,
+            "content_fingerprint": "test-content",
+            "structure_fingerprint": "test-structure",
+            "schema_version": 1,
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow(),
+        }
+    )
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-russia",
+            "title": "Russia",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "question_type": "multichoice",
+                },
+                {
+                    "question": "Russia is the largest country in the world by what measure?",
+                    "options": ["A) Population", "B) Land area", "C) Military size", "D) Number of cities"],
+                    "question_type": "multichoice",
+                },
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["saved"], run_id="saved-v2-question-only")
+    summary = await backfill_saved_quizzes(context)
+    saved_v2 = await backfill_db["saved_quizzes_v2"].find_one({"legacy_saved_quiz_id": str(saved_id)})
+
+    assert summary.unresolved == 0
+    assert summary.conflicts == 0
+    assert summary.inserted == 1
+    assert saved_v2 is not None
+    assert saved_v2["quiz_id"] == str(existing_quiz_id)
+
+
+@pytest.mark.asyncio
+async def test_stage3_history_prefers_profession_over_generic_quiz_name_when_creating_canonical(
+    backfill_db,
+    backfill_context_factory,
+):
+    history_id = ObjectId()
+    await backfill_db["quiz_history"].insert_one(
+        {
+            "_id": history_id,
+            "user_id": "user-russia",
+            "quiz_name": "multichoice Quiz",
+            "profession": "Russia",
+            "question_type": "multichoice",
+            "difficulty_level": "easy",
+            "audience_type": "students",
+            "custom_instruction": "Geopolitical power",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "answer": "B) Moscow",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["history"], run_id="history-generic-title")
+    summary = await backfill_quiz_history(context)
+    history_v2 = await backfill_db["quiz_history_v2"].find_one({"legacy_history_id": str(history_id)})
+    canonical = await backfill_db["quizzes_v2"].find_one({"_id": ObjectId(history_v2["quiz_id"])})
+
+    assert summary.inserted == 1
+    assert history_v2 is not None
+    assert canonical["title"] == "Russia"
+
+
+@pytest.mark.asyncio
+async def test_stage3_saved_backfill_updates_existing_legacy_reference_in_place_when_canonical_changes(
+    backfill_db,
+    backfill_context_factory,
+):
+    old_quiz_id = ObjectId()
+    new_quiz_id = ObjectId()
+    saved_id = ObjectId()
+    now = datetime.utcnow()
+
+    await backfill_db["quizzes_v2"].insert_many(
+        [
+            {
+                "_id": old_quiz_id,
+                "title": "multichoice Quiz",
+                "quiz_type": "multichoice",
+                "questions": [
+                    {
+                        "question": "What is the capital of Russia?",
+                        "correct_answer": "B) Moscow",
+                        "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    }
+                ],
+                "description": "Geopolitical power",
+                "owner_user_id": None,
+                "visibility": "private",
+                "status": "active",
+                "source": "legacy",
+                "tags": [],
+                "legacy_source_collection": None,
+                "legacy_quiz_id": None,
+                "content_fingerprint": "old-content",
+                "structure_fingerprint": "old-structure",
+                "schema_version": 1,
+                "created_at": now,
+                "updated_at": now,
+            },
+            {
+                "_id": new_quiz_id,
+                "title": "Russia",
+                "quiz_type": "multichoice",
+                "questions": [
+                    {
+                        "question": "What is the capital of Russia?",
+                        "correct_answer": "B) Moscow",
+                        "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    }
+                ],
+                "description": "Geopolitical power",
+                "owner_user_id": None,
+                "visibility": "private",
+                "status": "active",
+                "source": "legacy",
+                "tags": [],
+                "legacy_source_collection": None,
+                "legacy_quiz_id": None,
+                "content_fingerprint": "new-content",
+                "structure_fingerprint": "new-structure",
+                "schema_version": 1,
+                "created_at": now,
+                "updated_at": now,
+            },
+        ]
+    )
+
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-russia",
+            "title": "Russia",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    await backfill_db["saved_quizzes_v2"].insert_one(
+        {
+            "_id": ObjectId(),
+            "user_id": "user-russia",
+            "quiz_id": str(old_quiz_id),
+            "legacy_saved_quiz_id": str(saved_id),
+            "saved_at": now,
+        }
+    )
+
+    context = backfill_context_factory(collections=["saved"], run_id="saved-legacy-id-upsert")
+    summary = await backfill_saved_quizzes(context)
+    rows = await backfill_db["saved_quizzes_v2"].find({"legacy_saved_quiz_id": str(saved_id)}).to_list(length=10)
+
+    assert summary.inserted == 0
+    assert summary.updated == 1
+    assert len(rows) == 1
+    assert rows[0]["quiz_id"] == str(new_quiz_id)
+
+
+@pytest.mark.asyncio
+async def test_stage3_saved_backfill_merges_existing_duplicate_saved_rows(
+    backfill_db,
+    backfill_context_factory,
+):
+    old_quiz_id = ObjectId()
+    new_quiz_id = ObjectId()
+    saved_id = ObjectId()
+    now = datetime.utcnow()
+
+    await backfill_db["quizzes_v2"].insert_many(
+        [
+            {
+                "_id": old_quiz_id,
+                "title": "multichoice Quiz",
+                "quiz_type": "multichoice",
+                "questions": [
+                    {
+                        "question": "What is the capital of Russia?",
+                        "correct_answer": "B) Moscow",
+                        "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    }
+                ],
+                "description": "Geopolitical power",
+                "owner_user_id": None,
+                "visibility": "private",
+                "status": "active",
+                "source": "legacy",
+                "tags": [],
+                "legacy_source_collection": None,
+                "legacy_quiz_id": None,
+                "content_fingerprint": "merge-old-content",
+                "structure_fingerprint": "merge-old-structure",
+                "schema_version": 1,
+                "created_at": now,
+                "updated_at": now,
+            },
+            {
+                "_id": new_quiz_id,
+                "title": "Russia",
+                "quiz_type": "multichoice",
+                "questions": [
+                    {
+                        "question": "What is the capital of Russia?",
+                        "correct_answer": "B) Moscow",
+                        "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    }
+                ],
+                "description": "Geopolitical power",
+                "owner_user_id": None,
+                "visibility": "private",
+                "status": "active",
+                "source": "legacy",
+                "tags": [],
+                "legacy_source_collection": None,
+                "legacy_quiz_id": None,
+                "content_fingerprint": "merge-new-content",
+                "structure_fingerprint": "merge-new-structure",
+                "schema_version": 1,
+                "created_at": now,
+                "updated_at": now,
+            },
+        ]
+    )
+    await backfill_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-russia",
+            "title": "Russia",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    await backfill_db["saved_quizzes_v2"].insert_many(
+        [
+            {
+                "_id": ObjectId(),
+                "user_id": "user-russia",
+                "quiz_id": str(old_quiz_id),
+                "legacy_saved_quiz_id": str(saved_id),
+                "saved_at": now,
+            },
+            {
+                "_id": ObjectId(),
+                "user_id": "user-russia",
+                "quiz_id": str(new_quiz_id),
+                "legacy_saved_quiz_id": str(saved_id),
+                "saved_at": now,
+            },
+        ]
+    )
+
+    context = backfill_context_factory(collections=["saved"], run_id="saved-merge-duplicates")
+    summary = await backfill_saved_quizzes(context)
+    rows = await backfill_db["saved_quizzes_v2"].find({"legacy_saved_quiz_id": str(saved_id)}).to_list(length=10)
+
+    assert summary.inserted == 0
+    assert summary.updated == 1
+    assert len(rows) == 1
+    assert rows[0]["quiz_id"] == str(new_quiz_id)

--- a/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
+++ b/server/tests/v2_database_tests/backfill_tests/test_stage3_backfill.py
@@ -308,6 +308,78 @@ async def test_stage3_folder_backfill_with_structure_only_payload_does_not_crash
 
 
 @pytest.mark.asyncio
+async def test_stage3_folder_backfill_merges_duplicate_items_for_same_canonical_quiz(
+    backfill_db,
+    backfill_context_factory,
+):
+    ai_id = ObjectId()
+    folder_id = ObjectId()
+
+    await backfill_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "profession": "Geography",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "answer": "B) Moscow",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+    await backfill_db["folders"].insert_one(
+        {
+            "_id": folder_id,
+            "user_id": "user-russia",
+            "name": "Geopolitics",
+            "quizzes": [
+                {
+                    "_id": "folder-item-1",
+                    "quiz_id": str(ai_id),
+                    "title": "Russia",
+                    "question_type": "multichoice",
+                    "questions": [
+                        {
+                            "question": "What is the capital of Russia?",
+                            "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                            "question_type": "multichoice",
+                        }
+                    ],
+                },
+                {
+                    "_id": "folder-item-2",
+                    "quiz_id": str(ai_id),
+                    "title": "Russia duplicate",
+                    "question_type": "multichoice",
+                    "questions": [
+                        {
+                            "question": "What is the capital of Russia?",
+                            "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                            "question_type": "multichoice",
+                        }
+                    ],
+                },
+            ],
+        }
+    )
+
+    context = backfill_context_factory(collections=["quizzes", "folders"], run_id="folder-duplicate-items")
+    await backfill_quizzes(context)
+    summary = await backfill_folders(context)
+    folder_v2 = await backfill_db["folders_v2"].find_one({"legacy_folder_id": str(folder_id)})
+    folder_items = await backfill_db["folder_items_v2"].find({"folder_id": str(folder_v2["_id"])}).to_list(length=10)
+
+    assert summary.malformed == 0
+    assert summary.unresolved == 0
+    assert summary.conflicts == 0
+    assert len(folder_items) == 1
+    assert folder_items[0]["legacy_folder_item_id"] == "folder-item-1"
+
+
+@pytest.mark.asyncio
 async def test_stage3_backfill_saved_quiz_without_answers_matches_legacy_ai_source(
     backfill_db,
     backfill_context_factory,

--- a/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
+++ b/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
@@ -314,6 +314,76 @@ async def test_dual_writes_migration_folder_create_and_add_dual_write(
 
 
 @pytest.mark.asyncio
+async def test_dual_writes_migration_folder_add_merges_duplicate_items_for_same_quiz(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(saved_quiz_crud, "collection", dual_write_db["saved_quizzes"])
+    monkeypatch.setattr(saved_quiz_crud, "dual_write_service", service)
+    monkeypatch.setattr(folder_crud, "folders_collection", dual_write_db["folders"])
+    monkeypatch.setattr(folder_crud, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "dual_write")
+
+    await service.mirror_ai_generated_quiz(
+        "legacy-ai-quiz-dup-folder",
+        {
+            "_id": "legacy-ai-quiz-dup-folder",
+            "user_id": "user-folder",
+            "profession": "Russia",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "answer": "B) Moscow",
+                    "question_type": "multichoice",
+                }
+            ],
+        },
+    )
+
+    legacy_saved_id = await saved_quiz_crud.save_quiz(
+        user_id="user-folder",
+        title="Russia",
+        question_type="multichoice",
+        quiz_id="legacy-ai-quiz-dup-folder",
+        questions=[
+            {
+                "question": "What is the capital of Russia?",
+                "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                "question_type": "multichoice",
+            }
+        ],
+    )
+    saved_doc = await dual_write_db["saved_quizzes"].find_one({"_id": ObjectId(legacy_saved_id)})
+    folder = await folder_crud.create_folder({"user_id": "user-folder", "name": "Geopolitics"})
+
+    item_payload = {
+        "original_quiz_id": legacy_saved_id,
+        "quiz_id": saved_doc["quiz_id"],
+        "canonical_quiz_id": saved_doc["canonical_quiz_id"],
+        "title": saved_doc["title"],
+        "question_type": saved_doc["question_type"],
+        "questions": saved_doc["questions"],
+        "created_at": saved_doc["created_at"],
+        "quiz_data": saved_doc,
+    }
+
+    await folder_crud.add_quiz_to_folder(folder["_id"], {"_id": "legacy-folder-item-1", **item_payload})
+    await folder_crud.add_quiz_to_folder(folder["_id"], {"_id": "legacy-folder-item-2", **item_payload})
+
+    folder_v2 = await dual_write_db["folders_v2"].find_one({"legacy_folder_id": folder["_id"]})
+    folder_items = await dual_write_db["folder_items_v2"].find({"folder_id": str(folder_v2["_id"])}).to_list(length=10)
+
+    assert folder_v2 is not None
+    assert len(folder_items) == 1
+    assert folder_items[0]["legacy_folder_item_id"] == "legacy-folder-item-1"
+    assert folder_items[0]["quiz_id"] == saved_doc["canonical_quiz_id"]
+
+
+@pytest.mark.asyncio
 async def test_dual_writes_migration_saved_quiz_without_quiz_id_reuses_legacy_ai_source(
     dual_write_db,
     dual_write_service_factory,

--- a/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
+++ b/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
@@ -602,6 +602,75 @@ async def test_stage5_saved_quiz_v2_only_writes_only_v2_records(
 
 
 @pytest.mark.asyncio
+async def test_stage5_saved_quiz_delete_soft_deletes_and_live_save_revives(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(saved_quiz_crud, "collection", dual_write_db["saved_quizzes"])
+    monkeypatch.setattr(saved_quiz_crud, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "v2_only")
+
+    await dual_write_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ObjectId("690000000000000000000003"),
+            "user_id": "user-soft-save",
+            "profession": "Operating Systems",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What does CPU stand for?",
+                    "options": ["Central Processing Unit", "Core Process Utility"],
+                    "answer": "Central Processing Unit",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    saved_reference = await saved_quiz_crud.save_quiz(
+        user_id="user-soft-save",
+        title="Operating Systems",
+        question_type="multichoice",
+        quiz_id="690000000000000000000003",
+        questions=[
+            {
+                "question": "What does CPU stand for?",
+                "options": ["Central Processing Unit", "Core Process Utility"],
+                "question_type": "multichoice",
+            }
+        ],
+    )
+
+    deleted = await saved_quiz_crud.delete_saved_quiz(str(saved_reference.id), "user-soft-save")
+    assert deleted is True
+
+    stored_deleted = await dual_write_db["saved_quizzes_v2"].find_one({"_id": saved_reference.id})
+    assert stored_deleted is not None
+    assert stored_deleted["deleted_at"] is not None
+
+    revived = await saved_quiz_crud.save_quiz(
+        user_id="user-soft-save",
+        title="Operating Systems Restored",
+        question_type="multichoice",
+        quiz_id="690000000000000000000003",
+        questions=[
+            {
+                "question": "What does CPU stand for?",
+                "options": ["Central Processing Unit", "Core Process Utility"],
+                "question_type": "multichoice",
+            }
+        ],
+    )
+
+    assert str(revived.id) == str(saved_reference.id)
+    stored_revived = await dual_write_db["saved_quizzes_v2"].find_one({"_id": saved_reference.id})
+    assert stored_revived["deleted_at"] is None
+    assert stored_revived["display_title"] == "Operating Systems Restored"
+
+
+@pytest.mark.asyncio
 async def test_stage5_quiz_history_v2_only_writes_only_v2_records(
     dual_write_db,
     dual_write_service_factory,
@@ -716,8 +785,34 @@ async def test_stage5_folder_v2_only_mutations_operate_without_legacy_rows(
         user_id="user-folder-v2",
     )
     assert removed is True
-    assert await dual_write_db["folder_items_v2"].count_documents({}) == 0
+    deleted_item = await dual_write_db["folder_items_v2"].find_one({"_id": folder_item.id})
+    assert deleted_item is not None
+    assert deleted_item["deleted_at"] is not None
     assert await dual_write_db["folders"].count_documents({}) == 0
+
+
+@pytest.mark.asyncio
+async def test_stage5_folder_delete_soft_deletes_and_recreate_revives(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "v2_only")
+
+    folder = await service.create_folder_v2(user_id="user-folder-soft", name="Networking")
+    deleted = await service.delete_folder_v2(folder_id=str(folder.id), user_id="user-folder-soft")
+
+    assert deleted is True
+    stored_folder = await dual_write_db["folders_v2"].find_one({"_id": folder.id})
+    assert stored_folder is not None
+    assert stored_folder["deleted_at"] is not None
+
+    revived = await service.create_folder_v2(user_id="user-folder-soft", name="Networking")
+
+    assert str(revived.id) == str(folder.id)
+    revived_folder = await dual_write_db["folders_v2"].find_one({"_id": folder.id})
+    assert revived_folder["deleted_at"] is None
 
 
 @pytest.mark.asyncio

--- a/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
+++ b/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
@@ -1,5 +1,6 @@
 import pytest
 from bson import ObjectId
+from datetime import datetime
 
 from ....app.db.core.config import settings
 from ....app.db.crud import folder_crud, quiz_crud, saved_quiz_crud, update_quiz_history
@@ -365,3 +366,113 @@ async def test_dual_writes_migration_saved_quiz_without_quiz_id_reuses_legacy_ai
     assert canonical is not None
     assert legacy_doc["canonical_quiz_id"] == str(canonical["_id"])
     assert saved_reference["quiz_id"] == str(canonical["_id"])
+
+
+@pytest.mark.asyncio
+async def test_dual_writes_migration_saved_quiz_without_quiz_id_reuses_existing_v2_question_match(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(saved_quiz_crud, "collection", dual_write_db["saved_quizzes"])
+    monkeypatch.setattr(saved_quiz_crud, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "dual_write")
+
+    existing_quiz_id = ObjectId()
+    await dual_write_db["quizzes_v2"].insert_one(
+        {
+            "_id": existing_quiz_id,
+            "title": "multichoice Quiz",
+            "quiz_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "correct_answer": "B) Moscow",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                },
+                {
+                    "question": "Russia is the largest country in the world by what measure?",
+                    "correct_answer": "B) Land area",
+                    "options": ["A) Population", "B) Land area", "C) Military size", "D) Number of cities"],
+                },
+            ],
+            "description": "Geopolitical power",
+            "owner_user_id": None,
+            "visibility": "private",
+            "status": "active",
+            "source": "legacy",
+            "tags": [],
+            "legacy_source_collection": None,
+            "legacy_quiz_id": None,
+            "content_fingerprint": "dual-write-content",
+            "structure_fingerprint": "dual-write-structure",
+            "schema_version": 1,
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow(),
+        }
+    )
+
+    legacy_id = await saved_quiz_crud.save_quiz(
+        user_id="user-russia",
+        title="Russia",
+        question_type="multichoice",
+        questions=[
+            {
+                "question": "What is the capital of Russia?",
+                "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                "question_type": "multichoice",
+            },
+            {
+                "question": "Russia is the largest country in the world by what measure?",
+                "options": ["A) Population", "B) Land area", "C) Military size", "D) Number of cities"],
+                "question_type": "multichoice",
+            },
+        ],
+    )
+
+    legacy_doc = await dual_write_db["saved_quizzes"].find_one({"_id": ObjectId(legacy_id)})
+    saved_reference = await dual_write_db["saved_quizzes_v2"].find_one({"legacy_saved_quiz_id": legacy_id})
+
+    assert legacy_doc is not None
+    assert saved_reference is not None
+    assert legacy_doc["canonical_quiz_id"] == str(existing_quiz_id)
+    assert saved_reference["quiz_id"] == str(existing_quiz_id)
+
+
+@pytest.mark.asyncio
+async def test_dual_writes_migration_history_prefers_profession_over_generic_quiz_name(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(update_quiz_history, "quiz_history_collection", dual_write_db["quiz_history"])
+    monkeypatch.setattr(update_quiz_history, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "dual_write")
+
+    legacy_id = await update_quiz_history.update_quiz_history(
+        {
+            "user_id": "user-russia",
+            "quiz_name": "multichoice Quiz",
+            "question_type": "multichoice",
+            "profession": "Russia",
+            "audience_type": "students",
+            "difficulty_level": "easy",
+            "custom_instruction": "Geopolitical power",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow", "C) St. Petersburg", "D) Minsk"],
+                    "answer": "B) Moscow",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    history_reference = await dual_write_db["quiz_history_v2"].find_one({"legacy_history_id": legacy_id})
+    canonical = await dual_write_db["quizzes_v2"].find_one({"_id": ObjectId(history_reference["quiz_id"])})
+
+    assert history_reference is not None
+    assert canonical["title"] == "Russia"

--- a/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
+++ b/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
@@ -310,3 +310,58 @@ async def test_dual_writes_migration_folder_create_and_add_dual_write(
     assert folder_item_v2 is not None
     assert folder_item_v2["quiz_id"] == str(canonical_quiz["_id"])
     assert folder_item_v2["quiz_id"] == saved_doc["canonical_quiz_id"]
+
+
+@pytest.mark.asyncio
+async def test_dual_writes_migration_saved_quiz_without_quiz_id_reuses_legacy_ai_source(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(saved_quiz_crud, "collection", dual_write_db["saved_quizzes"])
+    monkeypatch.setattr(saved_quiz_crud, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "dual_write")
+
+    ai_id = ObjectId()
+    await dual_write_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ai_id,
+            "user_id": "user-entropy",
+            "profession": "Entropy",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is entropy?",
+                    "options": ["Order", "Disorder"],
+                    "answer": "Disorder",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    legacy_id = await saved_quiz_crud.save_quiz(
+        user_id="user-entropy",
+        title="Entropy Quiz",
+        question_type="multichoice",
+        questions=[
+            {
+                "question": "What is entropy?",
+                "options": ["Order", "Disorder"],
+                "question_type": "multichoice",
+            }
+        ],
+    )
+
+    legacy_doc = await dual_write_db["saved_quizzes"].find_one({"_id": ObjectId(legacy_id)})
+    saved_reference = await dual_write_db["saved_quizzes_v2"].find_one({"legacy_saved_quiz_id": legacy_id})
+    canonical = await dual_write_db["quizzes_v2"].find_one(
+        {"legacy_source_collection": "ai_generated_quizzes", "legacy_quiz_id": str(ai_id)}
+    )
+
+    assert legacy_doc is not None
+    assert saved_reference is not None
+    assert canonical is not None
+    assert legacy_doc["canonical_quiz_id"] == str(canonical["_id"])
+    assert saved_reference["quiz_id"] == str(canonical["_id"])

--- a/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
+++ b/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
@@ -125,6 +125,7 @@ async def test_dual_writes_migration_saved_quiz_dual_write(
     assert legacy_doc["quiz_id"] == "legacy-ai-quiz-1"
     assert legacy_doc["is_deleted"] is False
     assert legacy_doc["canonical_quiz_id"] == saved_reference["quiz_id"]
+    assert saved_reference["display_title"] == "Saved quiz"
 
 
 @pytest.mark.asyncio
@@ -311,6 +312,8 @@ async def test_dual_writes_migration_folder_create_and_add_dual_write(
     assert folder_item_v2 is not None
     assert folder_item_v2["quiz_id"] == str(canonical_quiz["_id"])
     assert folder_item_v2["quiz_id"] == saved_doc["canonical_quiz_id"]
+    assert folder_item_v2["display_title"] == saved_doc["title"]
+    assert folder_item_v2["position"] == 0
 
 
 @pytest.mark.asyncio
@@ -381,6 +384,7 @@ async def test_dual_writes_migration_folder_add_merges_duplicate_items_for_same_
     assert len(folder_items) == 1
     assert folder_items[0]["legacy_folder_item_id"] == "legacy-folder-item-1"
     assert folder_items[0]["quiz_id"] == saved_doc["canonical_quiz_id"]
+    assert folder_items[0]["position"] == 0
 
 
 @pytest.mark.asyncio

--- a/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
+++ b/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
@@ -3,7 +3,7 @@ from bson import ObjectId
 from datetime import datetime
 
 from ....app.db.core.config import settings
-from ....app.db.crud import folder_crud, quiz_crud, saved_quiz_crud, update_quiz_history
+from ....app.db.crud import ai_generated_quiz_crud, folder_crud, quiz_crud, saved_quiz_crud, update_quiz_history
 from ....app.db.v2.models.quiz_models import QuizCreateV2
 from ....app.db.schemas.quiz_schemas import NewQuizSchema
 
@@ -550,3 +550,207 @@ async def test_dual_writes_migration_history_prefers_profession_over_generic_qui
 
     assert history_reference is not None
     assert canonical["title"] == "Russia"
+
+
+@pytest.mark.asyncio
+async def test_stage5_saved_quiz_v2_only_writes_only_v2_records(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(saved_quiz_crud, "collection", dual_write_db["saved_quizzes"])
+    monkeypatch.setattr(saved_quiz_crud, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "v2_only")
+
+    await dual_write_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ObjectId("690000000000000000000001"),
+            "user_id": "user-v2-only",
+            "profession": "Caching",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What does Redis store in memory?",
+                    "options": ["Data", "Templates"],
+                    "answer": "Data",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    saved_id = await saved_quiz_crud.save_quiz(
+        user_id="user-v2-only",
+        title="Caching Quiz",
+        question_type="multichoice",
+        questions=[
+            {
+                "question": "What does Redis store in memory?",
+                "options": ["Data", "Templates"],
+                "question_type": "multichoice",
+            }
+        ],
+    )
+
+    assert await dual_write_db["saved_quizzes"].count_documents({}) == 0
+
+    saved_reference = await dual_write_db["saved_quizzes_v2"].find_one({"_id": ObjectId(saved_id)})
+    assert saved_reference is not None
+    assert saved_reference["user_id"] == "user-v2-only"
+    assert saved_reference["display_title"] == "Caching Quiz"
+
+
+@pytest.mark.asyncio
+async def test_stage5_quiz_history_v2_only_writes_only_v2_records(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(update_quiz_history, "quiz_history_collection", dual_write_db["quiz_history"])
+    monkeypatch.setattr(update_quiz_history, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "v2_only")
+
+    history_id = await update_quiz_history.update_quiz_history(
+        {
+            "user_id": "user-history-v2",
+            "quiz_name": "Queueing",
+            "question_type": "open-ended",
+            "profession": "Queueing",
+            "questions": [
+                {
+                    "question": "Define a message queue.",
+                    "answer": "A buffer for asynchronous processing.",
+                    "question_type": "open-ended",
+                }
+            ],
+        }
+    )
+
+    assert await dual_write_db["quiz_history"].count_documents({}) == 0
+
+    history_reference = await dual_write_db["quiz_history_v2"].find_one({"_id": ObjectId(history_id)})
+    assert history_reference is not None
+    assert history_reference["user_id"] == "user-history-v2"
+
+    canonical = await dual_write_db["quizzes_v2"].find_one({"_id": ObjectId(history_reference["quiz_id"])})
+    assert canonical is not None
+    assert canonical["title"] == "Queueing"
+
+
+@pytest.mark.asyncio
+async def test_stage5_folder_v2_only_mutations_operate_without_legacy_rows(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(saved_quiz_crud, "collection", dual_write_db["saved_quizzes"])
+    monkeypatch.setattr(saved_quiz_crud, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "v2_only")
+
+    await dual_write_db["ai_generated_quizzes"].insert_one(
+        {
+            "_id": ObjectId("690000000000000000000002"),
+            "user_id": "user-folder-v2",
+            "profession": "Graphs",
+            "question_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What does BFS stand for?",
+                    "options": ["Breadth-first search", "Binary file system"],
+                    "answer": "Breadth-first search",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    saved_id = await saved_quiz_crud.save_quiz(
+        user_id="user-folder-v2",
+        title="Graphs",
+        question_type="multichoice",
+        quiz_id="690000000000000000000002",
+        questions=[
+            {
+                "question": "What does BFS stand for?",
+                "options": ["Breadth-first search", "Binary file system"],
+                "question_type": "multichoice",
+            }
+        ],
+    )
+
+    saved_reference = await dual_write_db["saved_quizzes_v2"].find_one({"_id": ObjectId(saved_id)})
+    assert saved_reference is not None
+
+    source_folder = await service.create_folder_v2(user_id="user-folder-v2", name="Algorithms")
+    target_folder = await service.create_folder_v2(user_id="user-folder-v2", name="Interview Prep")
+
+    _folder, folder_item = await service.add_saved_quiz_to_folder_v2(
+        folder_id=str(source_folder.id),
+        saved_quiz_id=saved_id,
+        user_id="user-folder-v2",
+    )
+
+    assert await dual_write_db["folders"].count_documents({}) == 0
+    assert await dual_write_db["folder_items_v2"].count_documents({}) == 1
+    stored_item = await dual_write_db["folder_items_v2"].find_one({"_id": folder_item.id})
+    assert stored_item["folder_id"] == str(source_folder.id)
+    assert stored_item["display_title"] == "Graphs"
+
+    moved = await service.move_folder_item_v2(
+        folder_item_id=str(folder_item.id),
+        source_folder_id=str(source_folder.id),
+        target_folder_id=str(target_folder.id),
+        user_id="user-folder-v2",
+    )
+    assert moved is True
+
+    moved_item = await dual_write_db["folder_items_v2"].find_one({"_id": folder_item.id})
+    assert moved_item["folder_id"] == str(target_folder.id)
+
+    removed = await service.remove_folder_item_v2(
+        folder_id=str(target_folder.id),
+        folder_item_id=str(folder_item.id),
+        user_id="user-folder-v2",
+    )
+    assert removed is True
+    assert await dual_write_db["folder_items_v2"].count_documents({}) == 0
+    assert await dual_write_db["folders"].count_documents({}) == 0
+
+
+@pytest.mark.asyncio
+async def test_stage5_ai_generated_quiz_v2_only_returns_canonical_id_and_skips_legacy_insert(
+    dual_write_db,
+    dual_write_service_factory,
+    monkeypatch,
+):
+    service = dual_write_service_factory()
+    monkeypatch.setattr(ai_generated_quiz_crud, "dual_write_service", service)
+    monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "v2_only")
+
+    result = await ai_generated_quiz_crud.save_ai_generated_quiz(
+        {
+            "user_id": "user-ai-v2",
+            "profession": "Distributed Systems",
+            "question_type": "multichoice",
+            "difficulty_level": "easy",
+            "num_questions": 1,
+            "audience_type": "students",
+            "custom_instruction": "",
+            "questions": [
+                {
+                    "question": "What does CAP stand for?",
+                    "options": ["Consistency, Availability, Partition tolerance", "Caching, Access, Persistence"],
+                    "answer": "Consistency, Availability, Partition tolerance",
+                    "question_type": "multichoice",
+                }
+            ],
+        }
+    )
+
+    assert await dual_write_db["ai_generated_quizzes"].count_documents({}) == 0
+    canonical = await dual_write_db["quizzes_v2"].find_one({"_id": ObjectId(result["quiz_id"])})
+    assert canonical is not None
+    assert canonical["title"] == "Distributed Systems"

--- a/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
+++ b/server/tests/v2_database_tests/dual_writes_migration_tests/test_dual_writes_migration.py
@@ -580,7 +580,7 @@ async def test_stage5_saved_quiz_v2_only_writes_only_v2_records(
         }
     )
 
-    saved_id = await saved_quiz_crud.save_quiz(
+    saved_reference_obj = await saved_quiz_crud.save_quiz(
         user_id="user-v2-only",
         title="Caching Quiz",
         question_type="multichoice",
@@ -595,7 +595,7 @@ async def test_stage5_saved_quiz_v2_only_writes_only_v2_records(
 
     assert await dual_write_db["saved_quizzes"].count_documents({}) == 0
 
-    saved_reference = await dual_write_db["saved_quizzes_v2"].find_one({"_id": ObjectId(saved_id)})
+    saved_reference = await dual_write_db["saved_quizzes_v2"].find_one({"_id": saved_reference_obj.id})
     assert saved_reference is not None
     assert saved_reference["user_id"] == "user-v2-only"
     assert saved_reference["display_title"] == "Caching Quiz"
@@ -612,7 +612,7 @@ async def test_stage5_quiz_history_v2_only_writes_only_v2_records(
     monkeypatch.setattr(update_quiz_history, "dual_write_service", service)
     monkeypatch.setattr(settings, "QUIZ_V2_WRITE_MODE", "v2_only")
 
-    history_id = await update_quiz_history.update_quiz_history(
+    history_reference_obj = await update_quiz_history.update_quiz_history(
         {
             "user_id": "user-history-v2",
             "quiz_name": "Queueing",
@@ -630,7 +630,7 @@ async def test_stage5_quiz_history_v2_only_writes_only_v2_records(
 
     assert await dual_write_db["quiz_history"].count_documents({}) == 0
 
-    history_reference = await dual_write_db["quiz_history_v2"].find_one({"_id": ObjectId(history_id)})
+    history_reference = await dual_write_db["quiz_history_v2"].find_one({"_id": history_reference_obj.id})
     assert history_reference is not None
     assert history_reference["user_id"] == "user-history-v2"
 
@@ -667,7 +667,7 @@ async def test_stage5_folder_v2_only_mutations_operate_without_legacy_rows(
         }
     )
 
-    saved_id = await saved_quiz_crud.save_quiz(
+    saved_reference_obj = await saved_quiz_crud.save_quiz(
         user_id="user-folder-v2",
         title="Graphs",
         question_type="multichoice",
@@ -681,7 +681,7 @@ async def test_stage5_folder_v2_only_mutations_operate_without_legacy_rows(
         ],
     )
 
-    saved_reference = await dual_write_db["saved_quizzes_v2"].find_one({"_id": ObjectId(saved_id)})
+    saved_reference = await dual_write_db["saved_quizzes_v2"].find_one({"_id": saved_reference_obj.id})
     assert saved_reference is not None
 
     source_folder = await service.create_folder_v2(user_id="user-folder-v2", name="Algorithms")
@@ -689,7 +689,7 @@ async def test_stage5_folder_v2_only_mutations_operate_without_legacy_rows(
 
     _folder, folder_item = await service.add_saved_quiz_to_folder_v2(
         folder_id=str(source_folder.id),
-        saved_quiz_id=saved_id,
+        saved_quiz_id=str(saved_reference_obj.id),
         user_id="user-folder-v2",
     )
 

--- a/server/tests/v2_database_tests/read_cutover_tests/conftest.py
+++ b/server/tests/v2_database_tests/read_cutover_tests/conftest.py
@@ -1,0 +1,79 @@
+import os
+
+import pytest
+import pytest_asyncio
+
+os.environ.setdefault("JWT_SECRET", "test-secret")
+os.environ.setdefault("email_sender", "test@example.com")
+os.environ.setdefault("email_password", "password")
+os.environ.setdefault("email_host", "localhost")
+os.environ.setdefault("email_port", "1025")
+os.environ.setdefault("share_url", "http://localhost")
+os.environ.setdefault("db_name", "test_db")
+os.environ.setdefault("mongo_url", "mongodb://localhost:27017")
+
+from server.app.db.core.config import settings
+from server.app.db.services.quiz_user_library_read_service import QuizUserLibraryReadService
+from server.app.db.services.shared_quiz_read_service import SharedQuizReadService
+from server.app.db.v2.repositories.quiz_repository import QuizV2Repository
+from server.app.db.v2.repositories.reference_repository import ReferenceV2Repository
+from server.app.db.v2.setup import ensure_v2_collections_and_validators, ensure_v2_indexes
+
+
+@pytest_asyncio.fixture(scope="function")
+async def read_cutover_db(test_db):
+    await ensure_v2_collections_and_validators(test_db)
+    await ensure_v2_indexes(
+        test_db["quizzes_v2"],
+        test_db["folders_v2"],
+        test_db["folder_items_v2"],
+        test_db["saved_quizzes_v2"],
+        test_db["quiz_history_v2"],
+    )
+    return test_db
+
+
+@pytest.fixture(scope="function")
+def read_service_factory(read_cutover_db):
+    def factory():
+        return QuizUserLibraryReadService(
+            saved_quizzes_collection=read_cutover_db["saved_quizzes"],
+            quiz_history_collection=read_cutover_db["quiz_history"],
+            folders_collection=read_cutover_db["folders"],
+            quiz_repository=QuizV2Repository(read_cutover_db["quizzes_v2"]),
+            reference_repository=ReferenceV2Repository(
+                read_cutover_db["folders_v2"],
+                read_cutover_db["folder_items_v2"],
+                read_cutover_db["saved_quizzes_v2"],
+                read_cutover_db["quiz_history_v2"],
+            ),
+        )
+
+    return factory
+
+
+@pytest.fixture(scope="function")
+def shared_read_service_factory(read_cutover_db):
+    def factory():
+        return SharedQuizReadService(
+            quizzes_collection=read_cutover_db["quizzes"],
+            ai_generated_quizzes_collection=read_cutover_db["ai_generated_quizzes"],
+            saved_quizzes_collection=read_cutover_db["saved_quizzes"],
+            quiz_repository=QuizV2Repository(read_cutover_db["quizzes_v2"]),
+            reference_repository=ReferenceV2Repository(
+                read_cutover_db["folders_v2"],
+                read_cutover_db["folder_items_v2"],
+                read_cutover_db["saved_quizzes_v2"],
+                read_cutover_db["quiz_history_v2"],
+            ),
+        )
+
+    return factory
+
+
+@pytest.fixture(scope="function", autouse=True)
+def reset_read_modes(monkeypatch):
+    monkeypatch.setattr(settings, "QUIZ_V2_SAVED_READ_MODE", "legacy_only")
+    monkeypatch.setattr(settings, "QUIZ_V2_HISTORY_READ_MODE", "legacy_only")
+    monkeypatch.setattr(settings, "QUIZ_V2_FOLDER_READ_MODE", "legacy_only")
+    monkeypatch.setattr(settings, "QUIZ_V2_SHARE_READ_MODE", "legacy_only")

--- a/server/tests/v2_database_tests/read_cutover_tests/conftest.py
+++ b/server/tests/v2_database_tests/read_cutover_tests/conftest.py
@@ -12,7 +12,6 @@ os.environ.setdefault("share_url", "http://localhost")
 os.environ.setdefault("db_name", "test_db")
 os.environ.setdefault("mongo_url", "mongodb://localhost:27017")
 
-from server.app.db.core.config import settings
 from server.app.db.services.quiz_user_library_read_service import QuizUserLibraryReadService
 from server.app.db.services.shared_quiz_read_service import SharedQuizReadService
 from server.app.db.v2.repositories.quiz_repository import QuizV2Repository
@@ -69,11 +68,3 @@ def shared_read_service_factory(read_cutover_db):
         )
 
     return factory
-
-
-@pytest.fixture(scope="function", autouse=True)
-def reset_read_modes(monkeypatch):
-    monkeypatch.setattr(settings, "QUIZ_V2_SAVED_READ_MODE", "legacy_only")
-    monkeypatch.setattr(settings, "QUIZ_V2_HISTORY_READ_MODE", "legacy_only")
-    monkeypatch.setattr(settings, "QUIZ_V2_FOLDER_READ_MODE", "legacy_only")
-    monkeypatch.setattr(settings, "QUIZ_V2_SHARE_READ_MODE", "legacy_only")

--- a/server/tests/v2_database_tests/read_cutover_tests/test_stage4_read_cutover.py
+++ b/server/tests/v2_database_tests/read_cutover_tests/test_stage4_read_cutover.py
@@ -3,17 +3,12 @@ from datetime import datetime
 import pytest
 from bson import ObjectId
 
-from server.app.db.core.config import settings
-
-
 @pytest.mark.asyncio
-async def test_stage4_history_v2_only_reads_legacy_compatible_payload(
+async def test_stage4_history_reads_v2_payload(
     read_cutover_db,
     read_service_factory,
-    monkeypatch,
 ):
     service = read_service_factory()
-    monkeypatch.setattr(settings, "QUIZ_V2_HISTORY_READ_MODE", "v2_only")
 
     quiz_id = ObjectId()
     history_id = ObjectId()
@@ -60,38 +55,23 @@ async def test_stage4_history_v2_only_reads_legacy_compatible_payload(
 
     assert len(payload) == 1
     assert payload[0]["id"] is not None
-    assert payload[0]["legacy_id"] == str(history_id)
-    assert payload[0]["_id"] == str(history_id)
     assert payload[0]["quiz_id"] == str(quiz_id)
-    assert payload[0]["legacy_quiz_id"] == "legacy-ai-1"
+    assert payload[0]["quiz_name"] == "Caching"
     assert payload[0]["question_type"] == "multichoice"
     assert payload[0]["questions"][0]["answer"] == "Keys"
     assert payload[0]["questions"][0]["question_type"] == "multichoice"
 
 
 @pytest.mark.asyncio
-async def test_stage4_saved_compare_mode_returns_legacy_contract(
+async def test_stage4_saved_reads_v2_payload(
     read_cutover_db,
     read_service_factory,
-    monkeypatch,
 ):
     service = read_service_factory()
-    monkeypatch.setattr(settings, "QUIZ_V2_SAVED_READ_MODE", "compare")
 
     saved_id = ObjectId()
     quiz_id = ObjectId()
     created_at = datetime.utcnow()
-    await read_cutover_db["saved_quizzes"].insert_one(
-        {
-            "_id": saved_id,
-            "user_id": "user-1",
-            "quiz_id": "legacy-ai-1",
-            "title": "Legacy Saved Quiz",
-            "question_type": "multichoice",
-            "questions": [{"question": "Legacy question", "options": ["A", "B"], "question_type": "multichoice"}],
-            "created_at": created_at,
-        }
-    )
     await read_cutover_db["quizzes_v2"].insert_one(
         {
             "_id": quiz_id,
@@ -132,20 +112,18 @@ async def test_stage4_saved_compare_mode_returns_legacy_contract(
     payload = await service.get_saved_quizzes_for_user("user-1")
 
     assert len(payload) == 1
-    assert payload[0]["_id"] == str(saved_id)
+    assert payload[0]["id"] is not None
     assert payload[0]["title"] == "Legacy Saved Quiz"
     assert payload[0]["questions"][0]["question"] == "Legacy question"
-    assert "correct_answer" not in payload[0]["questions"][0]
+    assert payload[0]["questions"][0]["correct_answer"] == "A"
 
 
 @pytest.mark.asyncio
-async def test_stage4_saved_v2_only_preserves_legacy_saved_id_and_restores_answers(
+async def test_stage4_saved_detail_reads_v2_payload(
     read_cutover_db,
     read_service_factory,
-    monkeypatch,
 ):
     service = read_service_factory()
-    monkeypatch.setattr(settings, "QUIZ_V2_SAVED_READ_MODE", "v2_only")
 
     saved_id = ObjectId()
     quiz_id = ObjectId()
@@ -192,23 +170,17 @@ async def test_stage4_saved_v2_only_preserves_legacy_saved_id_and_restores_answe
 
     assert payload is not None
     assert payload["id"] is not None
-    assert payload["legacy_id"] == str(saved_id)
-    assert payload["_id"] == str(saved_id)
     assert payload["title"] == "Russia"
     assert payload["quiz_id"] == str(quiz_id)
-    assert payload["legacy_quiz_id"] == "legacy-russia"
-    assert payload["canonical_quiz_id"] == str(quiz_id)
     assert payload["questions"][0]["correct_answer"] == "B) Moscow"
 
 
 @pytest.mark.asyncio
-async def test_stage4_folder_v2_only_preserves_folder_and_item_legacy_ids_and_position(
+async def test_stage4_folder_reads_v2_payload_and_preserves_position(
     read_cutover_db,
     read_service_factory,
-    monkeypatch,
 ):
     service = read_service_factory()
-    monkeypatch.setattr(settings, "QUIZ_V2_FOLDER_READ_MODE", "v2_only")
 
     folder_v2_id = ObjectId()
     quiz_one_id = ObjectId()
@@ -295,24 +267,18 @@ async def test_stage4_folder_v2_only_preserves_folder_and_item_legacy_ids_and_po
 
     assert payload is not None
     assert payload["id"] == str(folder_v2_id)
-    assert payload["legacy_id"] == "legacy-folder-1"
-    assert payload["_id"] == "legacy-folder-1"
-    assert [item["_id"] for item in payload["quizzes"]] == ["item-1", "item-2"]
     assert all(item.get("id") for item in payload["quizzes"])
     assert payload["quizzes"][0]["quiz_id"] == str(quiz_two_id)
-    assert payload["quizzes"][0]["legacy_quiz_id"] == "legacy-quiz-1"
     assert payload["quizzes"][0]["title"] == "Russia"
     assert payload["quizzes"][1]["title"] == "USA Military"
 
 
 @pytest.mark.asyncio
-async def test_stage4_shared_v2_only_resolves_saved_quiz_legacy_id(
+async def test_stage4_shared_reads_v2_payload_and_can_resolve_saved_legacy_id(
     read_cutover_db,
     shared_read_service_factory,
-    monkeypatch,
 ):
     service = shared_read_service_factory()
-    monkeypatch.setattr(settings, "QUIZ_V2_SHARE_READ_MODE", "v2_only")
 
     saved_id = ObjectId()
     quiz_id = ObjectId()
@@ -352,6 +318,5 @@ async def test_stage4_shared_v2_only_resolves_saved_quiz_legacy_id(
 
     assert payload is not None
     assert payload["id"] == str(quiz_id)
-    assert payload["legacy_quiz_id"] == "legacy-shared-ai"
     assert payload["title"] == "Shared Quiz"
     assert payload["questions"][0]["correct_answer"] == "B"

--- a/server/tests/v2_database_tests/read_cutover_tests/test_stage4_read_cutover.py
+++ b/server/tests/v2_database_tests/read_cutover_tests/test_stage4_read_cutover.py
@@ -1,0 +1,343 @@
+from datetime import datetime
+
+import pytest
+from bson import ObjectId
+
+from server.app.db.core.config import settings
+
+
+@pytest.mark.asyncio
+async def test_stage4_history_v2_only_reads_legacy_compatible_payload(
+    read_cutover_db,
+    read_service_factory,
+    monkeypatch,
+):
+    service = read_service_factory()
+    monkeypatch.setattr(settings, "QUIZ_V2_HISTORY_READ_MODE", "v2_only")
+
+    quiz_id = ObjectId()
+    history_id = ObjectId()
+    await read_cutover_db["quizzes_v2"].insert_one(
+        {
+            "_id": quiz_id,
+            "title": "Caching",
+            "quiz_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What does Redis store?",
+                    "options": ["Rows", "Keys"],
+                    "correct_answer": "Keys",
+                }
+            ],
+            "description": "Infra topic",
+            "owner_user_id": None,
+            "visibility": "private",
+            "status": "active",
+            "source": "legacy",
+            "tags": [],
+            "legacy_source_collection": "ai_generated_quizzes",
+            "legacy_quiz_id": "legacy-ai-1",
+            "content_fingerprint": "history-content",
+            "structure_fingerprint": "history-structure",
+            "schema_version": 1,
+            "created_at": datetime.utcnow(),
+            "updated_at": datetime.utcnow(),
+            "deleted_at": None,
+        }
+    )
+    await read_cutover_db["quiz_history_v2"].insert_one(
+        {
+            "user_id": "user-1",
+            "quiz_id": str(quiz_id),
+            "action": "generated",
+            "metadata": {"topic": "Caching", "difficulty_level": "easy"},
+            "legacy_history_id": str(history_id),
+            "created_at": datetime.utcnow(),
+        }
+    )
+
+    payload = await service.get_quiz_history_for_user("user-1")
+
+    assert len(payload) == 1
+    assert payload[0]["_id"] == str(history_id)
+    assert payload[0]["question_type"] == "multichoice"
+    assert payload[0]["questions"][0]["answer"] == "Keys"
+    assert payload[0]["questions"][0]["question_type"] == "multichoice"
+
+
+@pytest.mark.asyncio
+async def test_stage4_saved_compare_mode_returns_legacy_contract(
+    read_cutover_db,
+    read_service_factory,
+    monkeypatch,
+):
+    service = read_service_factory()
+    monkeypatch.setattr(settings, "QUIZ_V2_SAVED_READ_MODE", "compare")
+
+    saved_id = ObjectId()
+    quiz_id = ObjectId()
+    created_at = datetime.utcnow()
+    await read_cutover_db["saved_quizzes"].insert_one(
+        {
+            "_id": saved_id,
+            "user_id": "user-1",
+            "quiz_id": "legacy-ai-1",
+            "title": "Legacy Saved Quiz",
+            "question_type": "multichoice",
+            "questions": [{"question": "Legacy question", "options": ["A", "B"], "question_type": "multichoice"}],
+            "created_at": created_at,
+        }
+    )
+    await read_cutover_db["quizzes_v2"].insert_one(
+        {
+            "_id": quiz_id,
+            "title": "Legacy Saved Quiz",
+            "quiz_type": "multichoice",
+            "questions": [
+                {
+                    "question": "Legacy question",
+                    "options": ["A", "B"],
+                    "correct_answer": "A",
+                }
+            ],
+            "description": None,
+            "owner_user_id": None,
+            "visibility": "private",
+            "status": "active",
+            "source": "legacy",
+            "tags": [],
+            "legacy_source_collection": "ai_generated_quizzes",
+            "legacy_quiz_id": "legacy-ai-1",
+            "content_fingerprint": "saved-content",
+            "structure_fingerprint": "saved-structure",
+            "schema_version": 1,
+            "created_at": created_at,
+            "updated_at": created_at,
+            "deleted_at": None,
+        }
+    )
+    await read_cutover_db["saved_quizzes_v2"].insert_one(
+        {
+            "user_id": "user-1",
+            "quiz_id": str(quiz_id),
+            "legacy_saved_quiz_id": str(saved_id),
+            "saved_at": created_at,
+        }
+    )
+
+    payload = await service.get_saved_quizzes_for_user("user-1")
+
+    assert len(payload) == 1
+    assert payload[0]["_id"] == str(saved_id)
+    assert payload[0]["title"] == "Legacy Saved Quiz"
+    assert payload[0]["questions"][0]["question"] == "Legacy question"
+    assert "correct_answer" not in payload[0]["questions"][0]
+
+
+@pytest.mark.asyncio
+async def test_stage4_saved_v2_only_preserves_legacy_saved_id_and_restores_answers(
+    read_cutover_db,
+    read_service_factory,
+    monkeypatch,
+):
+    service = read_service_factory()
+    monkeypatch.setattr(settings, "QUIZ_V2_SAVED_READ_MODE", "v2_only")
+
+    saved_id = ObjectId()
+    quiz_id = ObjectId()
+    created_at = datetime.utcnow()
+    await read_cutover_db["quizzes_v2"].insert_one(
+        {
+            "_id": quiz_id,
+            "title": "Russian Federation",
+            "quiz_type": "multichoice",
+            "questions": [
+                {
+                    "question": "What is the capital of Russia?",
+                    "options": ["A) Kyiv", "B) Moscow"],
+                    "correct_answer": "B) Moscow",
+                }
+            ],
+            "description": "Geopolitics",
+            "owner_user_id": None,
+            "visibility": "private",
+            "status": "active",
+            "source": "legacy",
+            "tags": [],
+            "legacy_source_collection": "ai_generated_quizzes",
+            "legacy_quiz_id": "legacy-russia",
+            "content_fingerprint": "saved-content-v2",
+            "structure_fingerprint": "saved-structure-v2",
+            "schema_version": 1,
+            "created_at": created_at,
+            "updated_at": created_at,
+            "deleted_at": None,
+        }
+    )
+    await read_cutover_db["saved_quizzes_v2"].insert_one(
+        {
+            "user_id": "user-2",
+            "quiz_id": str(quiz_id),
+            "display_title": "Russia",
+            "legacy_saved_quiz_id": str(saved_id),
+            "saved_at": created_at,
+        }
+    )
+
+    payload = await service.get_saved_quiz_by_id(str(saved_id), "user-2")
+
+    assert payload is not None
+    assert payload["_id"] == str(saved_id)
+    assert payload["title"] == "Russia"
+    assert payload["canonical_quiz_id"] == str(quiz_id)
+    assert payload["questions"][0]["correct_answer"] == "B) Moscow"
+
+
+@pytest.mark.asyncio
+async def test_stage4_folder_v2_only_preserves_folder_and_item_legacy_ids_and_position(
+    read_cutover_db,
+    read_service_factory,
+    monkeypatch,
+):
+    service = read_service_factory()
+    monkeypatch.setattr(settings, "QUIZ_V2_FOLDER_READ_MODE", "v2_only")
+
+    folder_v2_id = ObjectId()
+    quiz_one_id = ObjectId()
+    quiz_two_id = ObjectId()
+    created_at = datetime.utcnow()
+    await read_cutover_db["folders_v2"].insert_one(
+        {
+            "_id": folder_v2_id,
+            "user_id": "user-folder",
+            "name": "Research",
+            "legacy_folder_id": "legacy-folder-1",
+            "created_at": created_at,
+            "updated_at": created_at,
+        }
+    )
+    await read_cutover_db["quizzes_v2"].insert_many(
+        [
+            {
+                "_id": quiz_one_id,
+                "title": "United States Military",
+                "quiz_type": "multichoice",
+                "questions": [{"question": "Q2", "options": ["A", "B"], "correct_answer": "A"}],
+                "description": None,
+                "owner_user_id": None,
+                "visibility": "private",
+                "status": "active",
+                "source": "legacy",
+                "tags": [],
+                "legacy_source_collection": "ai_generated_quizzes",
+                "legacy_quiz_id": "legacy-quiz-2",
+                "content_fingerprint": "folder-content-2",
+                "structure_fingerprint": "folder-structure-2",
+                "schema_version": 1,
+                "created_at": created_at,
+                "updated_at": created_at,
+                "deleted_at": None,
+            },
+            {
+                "_id": quiz_two_id,
+                "title": "Russian Federation",
+                "quiz_type": "multichoice",
+                "questions": [{"question": "Q1", "options": ["A", "B"], "correct_answer": "B"}],
+                "description": None,
+                "owner_user_id": None,
+                "visibility": "private",
+                "status": "active",
+                "source": "legacy",
+                "tags": [],
+                "legacy_source_collection": "ai_generated_quizzes",
+                "legacy_quiz_id": "legacy-quiz-1",
+                "content_fingerprint": "folder-content-1",
+                "structure_fingerprint": "folder-structure-1",
+                "schema_version": 1,
+                "created_at": created_at,
+                "updated_at": created_at,
+                "deleted_at": None,
+            },
+        ]
+    )
+    await read_cutover_db["folder_items_v2"].insert_many(
+        [
+            {
+                "folder_id": str(folder_v2_id),
+                "quiz_id": str(quiz_one_id),
+                "added_by": "user-folder",
+                "position": 1,
+                "display_title": "USA Military",
+                "legacy_folder_item_id": "item-2",
+                "created_at": created_at,
+            },
+            {
+                "folder_id": str(folder_v2_id),
+                "quiz_id": str(quiz_two_id),
+                "added_by": "user-folder",
+                "position": 0,
+                "display_title": "Russia",
+                "legacy_folder_item_id": "item-1",
+                "created_at": created_at,
+            },
+        ]
+    )
+
+    payload = await service.get_folder_by_id("legacy-folder-1", "user-folder")
+
+    assert payload is not None
+    assert payload["_id"] == "legacy-folder-1"
+    assert [item["_id"] for item in payload["quizzes"]] == ["item-1", "item-2"]
+    assert payload["quizzes"][0]["title"] == "Russia"
+    assert payload["quizzes"][1]["title"] == "USA Military"
+
+
+@pytest.mark.asyncio
+async def test_stage4_shared_v2_only_resolves_saved_quiz_legacy_id(
+    read_cutover_db,
+    shared_read_service_factory,
+    monkeypatch,
+):
+    service = shared_read_service_factory()
+    monkeypatch.setattr(settings, "QUIZ_V2_SHARE_READ_MODE", "v2_only")
+
+    saved_id = ObjectId()
+    quiz_id = ObjectId()
+    created_at = datetime.utcnow()
+    await read_cutover_db["quizzes_v2"].insert_one(
+        {
+            "_id": quiz_id,
+            "title": "Shared Quiz",
+            "quiz_type": "multichoice",
+            "questions": [{"question": "Q1", "options": ["A", "B"], "correct_answer": "B"}],
+            "description": "Shared description",
+            "owner_user_id": None,
+            "visibility": "private",
+            "status": "active",
+            "source": "legacy",
+            "tags": [],
+            "legacy_source_collection": "ai_generated_quizzes",
+            "legacy_quiz_id": "legacy-shared-ai",
+            "content_fingerprint": "shared-content",
+            "structure_fingerprint": "shared-structure",
+            "schema_version": 1,
+            "created_at": created_at,
+            "updated_at": created_at,
+            "deleted_at": None,
+        }
+    )
+    await read_cutover_db["saved_quizzes_v2"].insert_one(
+        {
+            "user_id": "user-1",
+            "quiz_id": str(quiz_id),
+            "legacy_saved_quiz_id": str(saved_id),
+            "saved_at": created_at,
+        }
+    )
+
+    payload = await service.resolve_shared_quiz(str(saved_id))
+
+    assert payload is not None
+    assert payload["id"] == str(saved_id)
+    assert payload["title"] == "Shared Quiz"
+    assert payload["questions"][0]["correct_answer"] == "B"

--- a/server/tests/v2_database_tests/read_cutover_tests/test_stage4_read_cutover.py
+++ b/server/tests/v2_database_tests/read_cutover_tests/test_stage4_read_cutover.py
@@ -59,7 +59,11 @@ async def test_stage4_history_v2_only_reads_legacy_compatible_payload(
     payload = await service.get_quiz_history_for_user("user-1")
 
     assert len(payload) == 1
+    assert payload[0]["id"] is not None
+    assert payload[0]["legacy_id"] == str(history_id)
     assert payload[0]["_id"] == str(history_id)
+    assert payload[0]["quiz_id"] == str(quiz_id)
+    assert payload[0]["legacy_quiz_id"] == "legacy-ai-1"
     assert payload[0]["question_type"] == "multichoice"
     assert payload[0]["questions"][0]["answer"] == "Keys"
     assert payload[0]["questions"][0]["question_type"] == "multichoice"
@@ -187,8 +191,12 @@ async def test_stage4_saved_v2_only_preserves_legacy_saved_id_and_restores_answe
     payload = await service.get_saved_quiz_by_id(str(saved_id), "user-2")
 
     assert payload is not None
+    assert payload["id"] is not None
+    assert payload["legacy_id"] == str(saved_id)
     assert payload["_id"] == str(saved_id)
     assert payload["title"] == "Russia"
+    assert payload["quiz_id"] == str(quiz_id)
+    assert payload["legacy_quiz_id"] == "legacy-russia"
     assert payload["canonical_quiz_id"] == str(quiz_id)
     assert payload["questions"][0]["correct_answer"] == "B) Moscow"
 
@@ -286,8 +294,13 @@ async def test_stage4_folder_v2_only_preserves_folder_and_item_legacy_ids_and_po
     payload = await service.get_folder_by_id("legacy-folder-1", "user-folder")
 
     assert payload is not None
+    assert payload["id"] == str(folder_v2_id)
+    assert payload["legacy_id"] == "legacy-folder-1"
     assert payload["_id"] == "legacy-folder-1"
     assert [item["_id"] for item in payload["quizzes"]] == ["item-1", "item-2"]
+    assert all(item.get("id") for item in payload["quizzes"])
+    assert payload["quizzes"][0]["quiz_id"] == str(quiz_two_id)
+    assert payload["quizzes"][0]["legacy_quiz_id"] == "legacy-quiz-1"
     assert payload["quizzes"][0]["title"] == "Russia"
     assert payload["quizzes"][1]["title"] == "USA Military"
 
@@ -338,6 +351,7 @@ async def test_stage4_shared_v2_only_resolves_saved_quiz_legacy_id(
     payload = await service.resolve_shared_quiz(str(saved_id))
 
     assert payload is not None
-    assert payload["id"] == str(saved_id)
+    assert payload["id"] == str(quiz_id)
+    assert payload["legacy_quiz_id"] == "legacy-shared-ai"
     assert payload["title"] == "Shared Quiz"
     assert payload["questions"][0]["correct_answer"] == "B"

--- a/server/tests/v2_database_tests/test_v2_repositories.py
+++ b/server/tests/v2_database_tests/test_v2_repositories.py
@@ -1,7 +1,14 @@
 import pytest
 
 from ...app.db.v2.models.quiz_models import QuizDocumentV2, QuizMetadataUpdateV2
+from ...app.db.v2.models.reference_models import (
+    FolderDocumentV2,
+    FolderItemDocumentV2,
+    QuizHistoryDocumentV2,
+    SavedQuizDocumentV2,
+)
 from ...app.db.v2.repositories.quiz_repository import QuizV2Repository
+from ...app.db.v2.repositories.reference_repository import ReferenceV2Repository
 
 
 @pytest.mark.asyncio
@@ -77,3 +84,192 @@ async def test_quiz_v2_repository_soft_delete(test_db):
     assert deleted is not None
     assert deleted.status == "deleted"
     assert deleted.deleted_at is not None
+
+
+@pytest.mark.asyncio
+async def test_reference_repository_saved_quiz_soft_delete_and_revive(test_db):
+    repository = ReferenceV2Repository(
+        test_db["folders_v2"],
+        test_db["folder_items_v2"],
+        test_db["saved_quizzes_v2"],
+        test_db["quiz_history_v2"],
+    )
+
+    saved = await repository.upsert_saved_quiz(
+        SavedQuizDocumentV2(
+            user_id="user-1",
+            quiz_id="quiz-1",
+            display_title="Saved quiz",
+        ),
+        revive_deleted=True,
+    )
+
+    deleted_count = await repository.delete_saved_quiz_by_id(str(saved.id), user_id="user-1")
+    assert deleted_count == 1
+    assert await repository.get_saved_quiz_by_id(str(saved.id), user_id="user-1") is None
+    assert await repository.list_saved_quizzes_for_user("user-1") == []
+
+    revived = await repository.upsert_saved_quiz(
+        SavedQuizDocumentV2(
+            user_id="user-1",
+            quiz_id="quiz-1",
+            display_title="Saved quiz revived",
+        ),
+        revive_deleted=True,
+    )
+
+    assert str(revived.id) == str(saved.id)
+    assert revived.deleted_at is None
+    assert revived.display_title == "Saved quiz revived"
+
+
+@pytest.mark.asyncio
+async def test_reference_repository_saved_quiz_legacy_upsert_preserves_deleted_state(test_db):
+    repository = ReferenceV2Repository(
+        test_db["folders_v2"],
+        test_db["folder_items_v2"],
+        test_db["saved_quizzes_v2"],
+        test_db["quiz_history_v2"],
+    )
+
+    saved = await repository.upsert_saved_quiz(
+        SavedQuizDocumentV2(
+            user_id="user-legacy",
+            quiz_id="quiz-legacy",
+            display_title="Legacy saved",
+            legacy_saved_quiz_id="legacy-saved-1",
+        ),
+        revive_deleted=True,
+    )
+    await repository.delete_saved_quiz_by_id(str(saved.id), user_id="user-legacy")
+
+    preserved = await repository.upsert_saved_quiz(
+        SavedQuizDocumentV2(
+            user_id="user-legacy",
+            quiz_id="quiz-legacy",
+            display_title="Legacy saved updated",
+            legacy_saved_quiz_id="legacy-saved-1",
+        ),
+    )
+
+    assert str(preserved.id) == str(saved.id)
+    assert preserved.deleted_at is not None
+    assert await repository.get_saved_quiz_by_legacy_id("legacy-saved-1", user_id="user-legacy") is None
+
+
+@pytest.mark.asyncio
+async def test_reference_repository_folder_soft_delete_cascades_to_items_and_revives(test_db):
+    repository = ReferenceV2Repository(
+        test_db["folders_v2"],
+        test_db["folder_items_v2"],
+        test_db["saved_quizzes_v2"],
+        test_db["quiz_history_v2"],
+    )
+
+    folder = await repository.insert_folder(
+        FolderDocumentV2(
+            user_id="user-folder",
+            name="Backend",
+        )
+    )
+    item = await repository.upsert_folder_item_by_legacy_id(
+        FolderItemDocumentV2(
+            folder_id=str(folder.id),
+            quiz_id="quiz-1",
+            display_title="Quiz one",
+            position=0,
+        ),
+        revive_deleted=True,
+    )
+
+    await repository.delete_folder_by_id(str(folder.id))
+
+    assert await repository.get_folder_by_id(str(folder.id)) is None
+    assert await repository.list_folders_for_user("user-folder") == []
+    assert await repository.get_folder_item_by_id(str(item.id)) is None
+    assert await repository.list_folder_items_for_folder(str(folder.id)) == []
+
+    revived_folder = await repository.insert_folder(
+        FolderDocumentV2(
+            user_id="user-folder",
+            name="Backend",
+        )
+    )
+    assert str(revived_folder.id) == str(folder.id)
+    assert revived_folder.deleted_at is None
+
+
+@pytest.mark.asyncio
+async def test_reference_repository_folder_item_soft_delete_and_revive(test_db):
+    repository = ReferenceV2Repository(
+        test_db["folders_v2"],
+        test_db["folder_items_v2"],
+        test_db["saved_quizzes_v2"],
+        test_db["quiz_history_v2"],
+    )
+
+    folder = await repository.insert_folder(FolderDocumentV2(user_id="user-folder", name="Systems"))
+    item = await repository.upsert_folder_item_by_legacy_id(
+        FolderItemDocumentV2(
+            folder_id=str(folder.id),
+            quiz_id="quiz-2",
+            display_title="Quiz two",
+            position=0,
+        ),
+        revive_deleted=True,
+    )
+
+    await repository.delete_folder_item_by_id(str(item.id))
+    assert await repository.get_folder_item_by_id(str(item.id)) is None
+
+    revived = await repository.upsert_folder_item_by_legacy_id(
+        FolderItemDocumentV2(
+            folder_id=str(folder.id),
+            quiz_id="quiz-2",
+            display_title="Quiz two revived",
+            position=0,
+        ),
+        revive_deleted=True,
+    )
+
+    assert str(revived.id) == str(item.id)
+    assert revived.deleted_at is None
+    assert revived.display_title == "Quiz two revived"
+
+
+@pytest.mark.asyncio
+async def test_reference_repository_quiz_history_soft_delete_and_preserve_legacy_state(test_db):
+    repository = ReferenceV2Repository(
+        test_db["folders_v2"],
+        test_db["folder_items_v2"],
+        test_db["saved_quizzes_v2"],
+        test_db["quiz_history_v2"],
+    )
+
+    history = await repository.insert_quiz_history(
+        QuizHistoryDocumentV2(
+            user_id="user-history",
+            quiz_id="quiz-hist",
+            action="generated",
+            metadata={"topic": "Caching"},
+            legacy_history_id="legacy-history-1",
+        )
+    )
+
+    deleted_count = await repository.soft_delete_quiz_history_by_id(str(history.id), user_id="user-history")
+    assert deleted_count == 1
+    assert await repository.list_quiz_history_for_user("user-history") == []
+
+    preserved = await repository.upsert_quiz_history(
+        QuizHistoryDocumentV2(
+            user_id="user-history",
+            quiz_id="quiz-hist",
+            action="generated",
+            metadata={"topic": "Caching updated"},
+            legacy_history_id="legacy-history-1",
+        )
+    )
+
+    assert str(preserved.id) == str(history.id)
+    assert preserved.deleted_at is not None
+    assert await repository.list_quiz_history_for_user("user-history") == []


### PR DESCRIPTION
## Summary

This PR introduces soft delete support for the V2 reference layer so saved quizzes, folders, folder items, and quiz history can be deleted without hard removal from the database.

The goal is to make current delete flows safer and to lay the foundation for future restore/trash features without changing the user-facing behavior of existing delete endpoints.

## What Changed

### Soft delete model for V2 reference collections
Added `deleted_at` support to V2 reference documents for:
- `saved_quizzes_v2`
- `folders_v2`
- `folder_items_v2`
- `quiz_history_v2`

This keeps the reference layer aligned with the existing soft-delete pattern already used by canonical quiz documents.

### Validator updates
Updated V2 validators so the reference collections accept:
- `deleted_at: null | date`

### Index updates
Updated active uniqueness rules so soft-deleted rows no longer block recreate/re-add flows.

This applies to:
- folder uniqueness by `(user_id, name)`
- folder item uniqueness by `(folder_id, quiz_id)`
- saved quiz uniqueness by `(user_id, quiz_id)`

Also added index reconciliation logic so environments with pre-soft-delete indexes can upgrade cleanly without crashing on startup.

### Repository behavior
Updated the V2 reference repository so:
- reads exclude soft-deleted rows by default
- delete operations set `deleted_at` instead of hard deleting
- folder delete cascades soft delete to folder items
- live user actions can revive soft-deleted saved/folder references
- legacy/backfill upserts preserve deleted state instead of restoring it

### Service behavior
Updated the active V2 write service so:
- saved quiz delete now soft deletes
- folder delete now soft deletes
- folder item remove now soft deletes
- live re-save / re-add operations revive the soft-deleted reference instead of creating logical drift
- history soft-delete support now exists in the service layer for future delete routes/features

## Important behavior decisions

### Deleted state is preserved during migration/backfill-style upserts
If a legacy/backfill path encounters a previously soft-deleted saved/folder/history reference, it does **not** restore it automatically.

This keeps user deletion intent authoritative.

### Live user actions can revive soft-deleted refs
If a user:
- saves the same quiz again
- recreates a deleted folder with the same name
- re-adds the same quiz to a folder

the corresponding V2 reference is revived instead of duplicating records.

## Why this matters

This PR improves deletion safety immediately while keeping the app behavior stable.

It also gives us the correct storage foundation for future features such as:
- restore from trash
- undo delete
- history hide/restore
- more robust auditability for user library actions

## How to Test

### 1. Backend regression suites

```bash
cd /quiz-generator/server
pipenv run pytest tests/v2_database_tests/test_v2_repositories.py -q
pipenv run pytest tests/v2_database_tests/dual_writes_migration_tests -k "stage5 or soft_delete" -q
pipenv run pytest tests/v2_database_tests/read_cutover_tests -q
```

### 2. Manual App verification

Spin up the app in Docker and verify these flows:
- create a folder
- add a quiz to the folder
- remove the quiz from the folder
- re-add the quiz and confirm it works
- delete a folder
- recreate a folder with the same name and confirm it works
- confirm deleted saved/folder data no longer appears in normal reads

## Notes

This PR does **not** add restore endpoints yet.

It focuses on:
- storage semantics
- current delete behavior
- safe future extensibility

History soft delete is implemented in the data/service layer now, even though there is not yet a user-facing delete route for history.

## Migration / startup note

This PR includes index reconciliation for existing environments.

If a DB already has the pre-soft-delete unique indexes, startup will now:
- detect the outdated index definition
- replace it with the soft-delete-aware version
