### PR TITLE
feat: implement mini-navigation header and consolidate mobile drawer …

### DIFF
--- a/client/src/features/quiz/components/NavBar.tsx
+++ b/client/src/features/quiz/components/NavBar.tsx
@@ -1,15 +1,13 @@
 "use client";
 
 import React, { useState } from "react";
+import { useRouter } from "next/router";
 import Link from "next/link";
 import { Menu, X } from "lucide-react";
 import SignInButton from "./SignInButton";
 import SignUpButton from "./SignUpButton";
 import SignUpModal from "@features/auth/components/SignUpModal";
 import SignInModal from "@features/auth/components/SignInModal";
-import QuizDropdown from "./QuizDropdown";
-import PricingLink from "./PricingLink";
-import HowItWorksLink from "./HowItWorksLink";
 import NavGenerateQuizButton from "./NavGenerateQuizButton";
 import Sidebar from "./Sidebar";
 import BrowseModal from "./modals/BrowseModal";
@@ -24,6 +22,8 @@ const NavBar: React.FC = () => {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
   const { user, isAuthenticated, logout, isLoading } = useAuth();
 
+  const router = useRouter();
+
   const switchToSignIn = () => {
     setIsSignUpOpen(false);
     setIsLoginOpen(true);
@@ -36,23 +36,27 @@ const NavBar: React.FC = () => {
 
   return (
     <>
-      <button
-        onClick={() => setIsSidebarOpen(!isSidebarOpen)}
-        className="fixed top-4 left-4 z-[100] text-[#0F2654] text-2xl focus:outline-none bg-[#E0E2E5] p-2 rounded-full shadow-md"
-      >
-        {isSidebarOpen ? <X /> : <Menu />}
-      </button>
+      {!isLoading && isAuthenticated && (
+        <>
+          <button
+            onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+            className="hidden md:flex fixed top-4 left-4 z-[100] text-[#0F2654] text-2xl focus:outline-none bg-[#E0E2E5] p-2 rounded-full shadow-md"
+          >
+            {isSidebarOpen ? <X /> : <Menu />}
+          </button>
 
-      <div
-        className={`
-          fixed top-0 left-0 h-full bg-[#F5F5F5] shadow-md z-50
-          transition-all duration-300
-          ${isSidebarOpen ? "w-64" : "w-0 overflow-hidden"}
-        `}
-        style={{ paddingTop: "64px" }}
-      >
-        <Sidebar onBrowseClick={() => setIsBrowseModalOpen(true)} />
-      </div>
+          <div
+            className={`
+              fixed top-0 left-0 h-full bg-[#F5F5F5] shadow-md z-50
+              transition-all duration-300
+              ${isSidebarOpen ? "w-64" : "w-0 overflow-hidden"}
+            `}
+            style={{ paddingTop: "64px" }}
+          >
+            <Sidebar onBrowseClick={() => setIsBrowseModalOpen(true)} />
+          </div>
+        </>
+      )}
 
       <nav className="bg-[#E0E2E5] shadow-md fixed top-0 left-0 right-0 z-40 h-16 flex items-center">
         <div className="max-w-6xl w-full mx-auto px-4 sm:px-6 md:px-8 flex items-center justify-between">
@@ -64,9 +68,37 @@ const NavBar: React.FC = () => {
           </Link>
 
           <div className="hidden md:flex items-center space-x-8">
-            <QuizDropdown />
-            <PricingLink />
-            <HowItWorksLink />
+            <Link
+              href="/"
+              className={`text-sm font-medium transition-all ${router.pathname === "/" && !router.asPath.includes("#") ? "text-[#0F2654] font-semibold" : "text-gray-500 hover:text-[#0F2654]"
+                }`}
+            >
+              Home
+            </Link>
+
+            <Link
+              href="/generate"
+              className={`text-sm font-medium transition-all ${router.pathname === "/generate" ? "text-[#0F2654] font-semibold" : "text-gray-500 hover:text-[#0F2654]"
+                }`}
+            >
+              Generate Quiz
+            </Link>
+
+            <button
+              onClick={() => setIsBrowseModalOpen(true)}
+              className={`text-sm font-medium transition-all ${isBrowseModalOpen ? "text-[#0F2654] font-semibold" : "text-gray-500 hover:text-[#0F2654]"
+                }`}
+            >
+              Categories
+            </button>
+
+            <Link
+              href="/#pricing"
+              className={`text-sm font-medium transition-all ${router.asPath.endsWith("#pricing") ? "text-[#0F2654] font-semibold" : "text-gray-500 hover:text-[#0F2654]"
+                }`}
+            >
+              Pricing
+            </Link>
           </div>
 
           <div className="hidden md:flex items-center space-x-4">
@@ -111,14 +143,99 @@ const NavBar: React.FC = () => {
       <div
         className={`
           fixed top-16 left-0 w-full bg-white shadow-md z-30
-          md:hidden transition-transform duration-200
+          md:hidden transition-transform duration-200 overflow-y-auto max-h-[calc(100vh-64px)]
           ${isMobileNavOpen ? "translate-y-0" : "-translate-y-full"}
         `}
       >
         <div className="flex flex-col px-4 py-4 space-y-4">
-          <QuizDropdown />
-          <PricingLink />
-          <HowItWorksLink />
+          <Link
+            href="/"
+            onClick={() => setIsMobileNavOpen(false)}
+            className={`text-base font-medium px-3 py-2 rounded-md transition-all ${router.pathname === "/" && !router.asPath.includes("#") ? "bg-[#0F2654] text-white font-semibold shadow-sm" : "text-gray-600 hover:bg-gray-100"
+              }`}
+          >
+            Home
+          </Link>
+
+          <Link
+            href="/generate"
+            onClick={() => setIsMobileNavOpen(false)}
+            className={`text-base font-medium px-3 py-2 rounded-md transition-all ${router.pathname === "/generate" ? "bg-[#0F2654] text-white font-semibold shadow-sm" : "text-gray-600 hover:bg-gray-100"
+              }`}
+          >
+            Generate Quiz
+          </Link>
+
+          <button
+            onClick={() => {
+              setIsMobileNavOpen(false);
+              setIsBrowseModalOpen(true);
+            }}
+            className={`text-base font-medium px-3 py-2 rounded-md transition-all text-left ${isBrowseModalOpen ? "bg-[#0F2654] text-white font-semibold shadow-sm" : "text-gray-600 hover:bg-gray-100"
+              }`}
+          >
+            Categories
+          </button>
+
+          <Link
+            href="/#pricing"
+            onClick={() => setIsMobileNavOpen(false)}
+            className={`text-base font-medium px-3 py-2 rounded-md transition-all ${router.asPath.endsWith("#pricing") ? "bg-[#0F2654] text-white font-semibold shadow-sm" : "text-gray-600 hover:bg-gray-100"
+              }`}
+          >
+            Pricing
+          </Link>
+
+          {!isLoading && isAuthenticated && (
+            <>
+              <div className="border-t border-gray-200 my-2 pt-2">
+                <p className="px-3 text-xs font-bold uppercase tracking-wider text-gray-400 mb-1">
+                  Dashboard Menu
+                </p>
+              </div>
+
+              <Link
+                href="/profile"
+                onClick={() => setIsMobileNavOpen(false)}
+                className="text-base font-medium px-3 py-2 rounded-md text-gray-600 hover:bg-gray-100 transition-all flex items-center gap-2"
+              >
+                👤 My Profile
+              </Link>
+
+              <Link
+                href="/saved_quiz"
+                onClick={() => setIsMobileNavOpen(false)}
+                className="text-base font-medium px-3 py-2 rounded-md text-gray-600 hover:bg-gray-100 transition-all flex items-center gap-2"
+              >
+                💾 Saved Quizzes
+              </Link>
+
+              <Link
+                href="/popular"
+                onClick={() => setIsMobileNavOpen(false)}
+                className="text-base font-medium px-3 py-2 rounded-md text-gray-600 hover:bg-gray-100 transition-all flex items-center gap-2"
+              >
+                🌟 Popular Quizzes
+              </Link>
+
+              <Link
+                href="/folders"
+                onClick={() => setIsMobileNavOpen(false)}
+                className="text-base font-medium px-3 py-2 rounded-md text-gray-600 hover:bg-gray-100 transition-all flex items-center gap-2"
+              >
+                📁 Folders
+              </Link>
+
+              <Link
+                href="/quiz_history"
+                onClick={() => setIsMobileNavOpen(false)}
+                className="text-base font-medium px-3 py-2 rounded-md text-gray-600 hover:bg-gray-100 transition-all flex items-center gap-2"
+              >
+                🕘 Quiz History
+              </Link>
+            </>
+          )}
+
           <div className="border-t border-gray-200 my-2" />
           <NavGenerateQuizButton className="w-full text-center" />
           {!isLoading && (


### PR DESCRIPTION
## Description
This PR implements the **Mini-Navigation Feature**, exposing primary landing lanes (`Home`, `Generate Quiz`, `Categories`, and `Pricing`) directly in the header layout. It also introduces crucial UX layout refactors for guest users and mobile responsiveness.

### 📋 Key Changes
- **Core Navigation Layer:** Integrated Next.js `useRouter` inside `NavBar.tsx` to dynamically track and smoothly highlight active routes.
- **Auth-Guarded Sidebar:** Wrapped the dashboard sidebar trigger in an `isAuthenticated` check using `useAuth`, eliminating interface clutter for guest visitors.
- **Mobile Menu Consolidation:** Consolidated competing mobile layout elements into a single right-hand dropdown drawer menu, adding proper vertical overflow scroll limits.

### 🧠 Architectural Decisions & Component Strategy
- To prevent layout conflicts and style pollution inside the mobile dropdown drawer, I chose to isolate the drawer actions as context-specific `<Link>` structures rather than forcing the import of tightly coupled desktop sidebar button components. This maintains code isolation, prevents component bloat, and avoids breaking any underlying state shared across other branches.

## 🖼️ Full Documentation & Visual Proof
For a full breakdown of the UX adjustments, architectural trade-offs, and **"Before vs. After" screenshots**, please review the team documentation here:
👉 **[View the Slack Canvas Documentation Here](https://kingobi.slack.com/docs/T9NCVT484/F0B9RGCL5N3)**

## ✅ Testing Checklist
- [x] Verified routing and active states across all links locally.
- [x] Verified layout responsiveness on mobile, tablet, and desktop breakpoints.
- [x] Verified guest session vs. authenticated session states.