### PR TITLE
Fix issues from live quiz

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -11,6 +11,8 @@
 
 # next.js
 /.next/
+/.next-stale-owned-by-docker/
+/.next-stale-build-blocked-*/
 /out/
 
 # production

--- a/client/src/features/live-quiz/api/liveQuizService.ts
+++ b/client/src/features/live-quiz/api/liveQuizService.ts
@@ -97,6 +97,7 @@ export interface AccessCodeResponse {
   invited_emails: string[];
   invitations_created: number;
   invitations_delivered: number;
+  invitations_queued: number;
 }
 
 export interface LiveQuizSummary {
@@ -265,8 +266,12 @@ export const liveQuizService = {
     const socket = new WebSocket(
       `${wsBaseUrl}/api/v1/quizzes/${encodeURIComponent(
         quizId,
-      )}/live-sessions/ws?token=${encodeURIComponent(token)}`,
+      )}/live-sessions/ws`,
     );
+
+    socket.addEventListener("open", () => {
+      socket.send(JSON.stringify({ type: "authenticate", token }));
+    });
 
     socket.onmessage = (message) => {
       try {

--- a/client/src/features/live-quiz/components/LiveQuizAccessCodePanel.tsx
+++ b/client/src/features/live-quiz/components/LiveQuizAccessCodePanel.tsx
@@ -55,9 +55,13 @@ const LiveQuizAccessCodePanel: React.FC<LiveQuizAccessCodePanelProps> = ({
         send_email_invitations: sendEmailInvitations,
       });
       setAccessCode(response.access_code);
+      const sentCount =
+        response.invitations_queued || response.invitations_delivered;
       toast.success(
         response.invitations_created
-          ? `Live quiz ready. ${response.invitations_delivered} invitation email(s) delivered.`
+          ? `Live quiz ready. ${sentCount} invitation email(s) ${
+              response.invitations_queued ? "queued" : "delivered"
+            }.`
           : "Live quiz access code generated.",
       );
     } catch (error: any) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - NEXT_PUBLIC_API_BASE_URL=http://localhost:8000
       - NEXT_PUBLIC_SSR_API_BASE_URL=http://server:8000
       - SHARE_URL=${SHARE_URL}
+      - FRONTEND_BASE_URL=${FRONTEND_BASE_URL:-http://localhost:3000}
     command: ["pnpm", "run", "dev"]
     depends_on:
       - server
@@ -31,6 +32,7 @@ services:
     environment:
       - REDIS_URL=redis://redis:6379/0
       - MONGO_URI=mongodb://mongodb:27017/quizApp_db
+      - FRONTEND_BASE_URL=${FRONTEND_BASE_URL:-http://localhost:3000}
       - PYTHONPATH=/
     command: ["uvicorn", "server.main:app", "--host", "0.0.0.0", "--port", "${BACKEND_PORT:-8000}", "--reload"]
     depends_on:
@@ -51,6 +53,7 @@ services:
       - EMAIL_HOST=${EMAIL_HOST}
       - EMAIL_PORT=${EMAIL_PORT}
       - SHARE_URL=${SHARE_URL}
+      - FRONTEND_BASE_URL=${FRONTEND_BASE_URL:-http://localhost:3000}
       - MONGO_URI=mongodb://mongodb:27017/quizApp_db
       - REDIS_URL=redis://redis:6379/0
       - PYTHONPATH=/

--- a/server/app/core/config.py
+++ b/server/app/core/config.py
@@ -1,8 +1,9 @@
 import os
 from functools import lru_cache
 from typing import Literal, Optional
+from urllib.parse import urlparse, urlunparse
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 class Settings(BaseSettings):
@@ -84,6 +85,27 @@ class Settings(BaseSettings):
         extra="ignore",
         case_sensitive=False,
     )
+
+    @field_validator("FRONTEND_BASE_URL")
+    @classmethod
+    def validate_frontend_base_url(cls, value: str) -> str:
+        parsed = urlparse((value or "").strip())
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("FRONTEND_BASE_URL must be an absolute http(s) URL")
+        if parsed.username or parsed.password:
+            raise ValueError("FRONTEND_BASE_URL must not include credentials")
+        if parsed.query or parsed.fragment:
+            raise ValueError("FRONTEND_BASE_URL must not include query or fragment")
+        return urlunparse(
+            (
+                parsed.scheme,
+                parsed.netloc,
+                parsed.path.rstrip("/"),
+                "",
+                "",
+                "",
+            )
+        )
 
 @lru_cache()
 def get_settings():

--- a/server/app/quiz/models/quiz_models.py
+++ b/server/app/quiz/models/quiz_models.py
@@ -67,3 +67,4 @@ class QuizResponse(BaseModel):
     invited_emails: List[str] = Field(default_factory=list)
     invitations_created: int = 0
     invitations_delivered: int = 0
+    invitations_queued: int = 0

--- a/server/app/quiz/routes/generation.py
+++ b/server/app/quiz/routes/generation.py
@@ -5,6 +5,12 @@ from server.app.quiz.services.generation_policy import validate_generation_quest
 from server.app.quiz.utils.questions import get_questions
 from server.app.core.dependencies import get_current_user_optional
 from server.app.core.config import settings
+from server.app.db.core.connection import get_live_quiz_invitations_collection
+from server.app.email_platform.deps import get_email_service
+from server.app.email_platform.service import EmailService
+from server.app.quiz.repositories.v2.repositories.live_quiz_invitation_repository import (
+    LiveQuizInvitationRepository,
+)
 
 
 router = APIRouter()
@@ -17,6 +23,7 @@ async def get_quiz(
     request: QuizRequest,
 
     current_user=Depends(get_current_user_optional),
+    email_service: EmailService = Depends(get_email_service),
 
 ):
     if settings.QUIZ_GENERATION_REQUIRES_AUTH and current_user is None:
@@ -28,5 +35,13 @@ async def get_quiz(
     request.num_questions = validate_generation_question_count(request.num_questions)
 
     user_id = str(current_user.id) if current_user else None
+    invitation_repository = LiveQuizInvitationRepository(
+        get_live_quiz_invitations_collection()
+    )
 
-    return await get_questions(request, user_id=user_id)
+    return await get_questions(
+        request,
+        user_id=user_id,
+        invitation_repository=invitation_repository,
+        email_service=email_service,
+    )

--- a/server/app/quiz/routes/live_sessions.py
+++ b/server/app/quiz/routes/live_sessions.py
@@ -1,8 +1,9 @@
+import asyncio
 from typing import List, Optional
 
 import jwt
 from bson import ObjectId
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Depends, Header, HTTPException, WebSocket, WebSocketDisconnect
 from fastapi.encoders import jsonable_encoder
 from motor.motor_asyncio import AsyncIOMotorCollection
 from jwt.exceptions import DecodeError, ExpiredSignatureError, InvalidTokenError
@@ -47,6 +48,7 @@ from server.app.quiz.services.live_quiz_realtime import live_quiz_realtime_broad
 
 
 router = APIRouter()
+WEBSOCKET_AUTH_TIMEOUT_SECONDS = 10
 
 
 def get_live_quiz_service(
@@ -88,7 +90,6 @@ def get_participant_token(
 async def generate_quiz_access_code(
     quiz_id: str,
     payload: AccessCodeCreateRequest,
-    request: Request,
     current_user: UserOut = Depends(get_verified_user),
     service: LiveQuizSessionService = Depends(get_live_quiz_service),
     invitation_repository: LiveQuizInvitationRepository = Depends(
@@ -106,7 +107,6 @@ async def generate_quiz_access_code(
         send_email_invitations=payload.send_email_invitations,
         invitation_repository=invitation_repository,
         email_service=email_service,
-        frontend_origin=request.headers.get("origin"),
     )
 
 
@@ -289,15 +289,41 @@ async def _get_verified_user_from_websocket_token(
     return UserOut(**user_payload)
 
 
+async def _receive_websocket_auth_token(websocket: WebSocket) -> str | None:
+    try:
+        message = await asyncio.wait_for(
+            websocket.receive_json(),
+            timeout=WEBSOCKET_AUTH_TIMEOUT_SECONDS,
+        )
+    except (asyncio.TimeoutError, WebSocketDisconnect, ValueError):
+        return None
+
+    if not isinstance(message, dict) or message.get("type") != "authenticate":
+        return None
+
+    token = message.get("token")
+    if not isinstance(token, str):
+        return None
+
+    token = token.strip()
+    return token or None
+
+
 @router.websocket("/quizzes/{quiz_id}/live-sessions/ws")
 async def live_quiz_participants_ws(
     websocket: WebSocket,
     quiz_id: str,
-    token: str = Query(default=""),
     service: LiveQuizSessionService = Depends(get_live_quiz_service),
     users_collection: AsyncIOMotorCollection = Depends(get_users_collection),
     sessions_collection: AsyncIOMotorCollection = Depends(get_user_sessions_collection),
 ):
+    await websocket.accept()
+
+    token = await _receive_websocket_auth_token(websocket)
+    if not token:
+        await websocket.close(code=1008)
+        return
+
     try:
         current_user = await _get_verified_user_from_websocket_token(
             token,
@@ -309,7 +335,7 @@ async def live_quiz_participants_ws(
         await websocket.close(code=1008)
         return
 
-    await live_quiz_realtime_broadcaster.connect(quiz_id, websocket)
+    await live_quiz_realtime_broadcaster.connect(quiz_id, websocket, accepted=True)
     try:
         await websocket.send_json(
             jsonable_encoder({

--- a/server/app/quiz/schemas/quiz_schemas.py
+++ b/server/app/quiz/schemas/quiz_schemas.py
@@ -90,6 +90,7 @@ class AccessCodeResponse(BaseModel):
     invited_emails: List[str] = []
     invitations_created: int = 0
     invitations_delivered: int = 0
+    invitations_queued: int = 0
 
 
 class QuizAccessPreview(BaseModel):

--- a/server/app/quiz/services/live_quiz_realtime.py
+++ b/server/app/quiz/services/live_quiz_realtime.py
@@ -9,8 +9,15 @@ class LiveQuizRealtimeBroadcaster:
     def __init__(self):
         self._connections: dict[str, set[WebSocket]] = defaultdict(set)
 
-    async def connect(self, quiz_id: str, websocket: WebSocket) -> None:
-        await websocket.accept()
+    async def connect(
+        self,
+        quiz_id: str,
+        websocket: WebSocket,
+        *,
+        accepted: bool = False,
+    ) -> None:
+        if not accepted:
+            await websocket.accept()
         self._connections[quiz_id].add(websocket)
 
     def disconnect(self, quiz_id: str, websocket: WebSocket) -> None:

--- a/server/app/quiz/services/live_session_service.py
+++ b/server/app/quiz/services/live_session_service.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import HTTPException, status
 from pydantic import EmailStr, TypeAdapter, ValidationError
 
+from server.app.core.config import settings
 from server.app.quiz.utils.grading import grade_answers
 from server.app.quiz.repositories.live_session_repository import (
     LiveQuizSessionRepository,
@@ -52,7 +53,6 @@ class LiveQuizSessionService:
         send_email_invitations: bool = False,
         invitation_repository=None,
         email_service=None,
-        frontend_origin: Optional[str] = None,
     ) -> Dict[str, Any]:
         quiz = await self.repository.get_quiz_by_id(quiz_id)
         if not quiz:
@@ -84,6 +84,7 @@ class LiveQuizSessionService:
                 "invited_emails": invited,
                 "invitations_created": len(invited),
                 "invitations_delivered": 0,
+                "invitations_queued": 0,
             }
 
         if _as_utc(access_code_expires_at) <= _utc_now():
@@ -116,9 +117,10 @@ class LiveQuizSessionService:
 
         invitations_created = 0
         invitations_delivered = 0
+        invitations_queued = 0
         if invitation_repository and normalized_invited_emails:
             title = updated_quiz.get("title", "Live Quiz")
-            join_link = self._join_link(code, frontend_origin)
+            join_link = self._join_link(code)
             for email in normalized_invited_emails:
                 invitation_id = await invitation_repository.upsert_invitation(
                     {
@@ -136,7 +138,7 @@ class LiveQuizSessionService:
                 invitations_created += 1
                 if send_email_invitations and email_service:
                     try:
-                        await email_service.send_email(
+                        send_result = await email_service.send_email(
                             to=email,
                             template_id="custom",
                             template_vars={
@@ -153,13 +155,18 @@ class LiveQuizSessionService:
                             purpose="live_quiz_invitation",
                             priority="default",
                         )
+                        is_queued = send_result.adapter in {"background", "celery"}
+                        delivery_status = "queued" if is_queued else "delivered"
                         await invitation_repository.update_email_delivery(
                             invitation_id,
-                            email_sent=True,
-                            invitation_sent_status="delivered",
-                            status="delivered",
+                            email_sent=not is_queued,
+                            invitation_sent_status=delivery_status,
+                            status=delivery_status,
                         )
-                        invitations_delivered += 1
+                        if is_queued:
+                            invitations_queued += 1
+                        else:
+                            invitations_delivered += 1
                     except Exception as e:
                         logger.warning(f"Could not send live quiz invitation to {email}: {e}")
                         await invitation_repository.update_email_delivery(
@@ -167,6 +174,16 @@ class LiveQuizSessionService:
                             email_sent=False,
                             invitation_sent_status="failed",
                         )
+            logger.info(
+                "Created %s live quiz invitation(s) for quiz %s",
+                invitations_created,
+                updated_quiz["_id"],
+            )
+            logger.info(
+                "Queued %s live quiz invitation email(s) for quiz %s",
+                invitations_queued,
+                updated_quiz["_id"],
+            )
 
         return {
             "quiz_id": str(updated_quiz["_id"]),
@@ -178,6 +195,7 @@ class LiveQuizSessionService:
             "invited_emails": normalized_invited_emails,
             "invitations_created": invitations_created,
             "invitations_delivered": invitations_delivered,
+            "invitations_queued": invitations_queued,
         }
 
     async def validate_access_code(self, code: str) -> Dict[str, Any]:
@@ -773,11 +791,8 @@ class LiveQuizSessionService:
             )
         return normalized
 
-    def _join_link(self, access_code: str, frontend_origin: Optional[str]) -> str:
-        origin = (frontend_origin or "").rstrip("/")
-        if not origin:
-            return f"/quiz-access/{access_code}"
-        return f"{origin}/quiz-access/{access_code}"
+    def _join_link(self, access_code: str) -> str:
+        return f"{settings.FRONTEND_BASE_URL}/quiz-access/{access_code}"
 
     def _invitation_email_body(
         self,

--- a/server/app/quiz/utils/questions.py
+++ b/server/app/quiz/utils/questions.py
@@ -7,10 +7,14 @@ from server.app.quiz.utils.huggingface_utils import generate_quiz_with_huggingfa
 from server.app.quiz.utils.mock_quiz_generator import get_mock_questions_by_type
 from server.app.quiz.repositories.ai_generated_quiz_repository import save_ai_generated_quiz
 from server.app.db.core.connection import (
+    get_live_quiz_invitations_collection,
     get_live_quiz_sessions_collection,
     get_quizzes_v2_collection,
 )
 from server.app.quiz.repositories.live_session_repository import LiveQuizSessionRepository
+from server.app.quiz.repositories.v2.repositories.live_quiz_invitation_repository import (
+    LiveQuizInvitationRepository,
+)
 from server.app.quiz.services.live_session_service import LiveQuizSessionService
 
 
@@ -19,7 +23,6 @@ async def get_questions(
     user_id: str | None = None,
     invitation_repository=None,
     email_service=None,
-    frontend_origin: str | None = None,
 ) -> Dict:
 
     ai_down = False
@@ -42,6 +45,7 @@ async def get_questions(
     live_invited_emails = []
     live_invitations_created = 0
     live_invitations_delivered = 0
+    live_invitations_queued = 0
 
     base_quiz_payload = {
         "profession": request.profession,
@@ -170,6 +174,10 @@ async def get_questions(
                 get_live_quiz_sessions_collection(),
             )
         )
+        if invitation_repository is None:
+            invitation_repository = LiveQuizInvitationRepository(
+                get_live_quiz_invitations_collection()
+            )
         live_config = await live_service.generate_access_code(
             quiz_id=quiz_id,
             access_code_expires_at=request.access_code_expires_at,
@@ -180,7 +188,6 @@ async def get_questions(
             send_email_invitations=request.send_email_invitations,
             invitation_repository=invitation_repository,
             email_service=email_service,
-            frontend_origin=frontend_origin,
         )
         live_access_code = live_config["access_code"]
         live_access_code_expires_at = live_config["access_code_expires_at"]
@@ -189,6 +196,14 @@ async def get_questions(
         live_invited_emails = live_config["invited_emails"]
         live_invitations_created = live_config["invitations_created"]
         live_invitations_delivered = live_config["invitations_delivered"]
+        live_invitations_queued = live_config["invitations_queued"]
+        logging.info(
+            "Live quiz invitation workflow completed for quiz %s: created=%s queued=%s delivered=%s",
+            quiz_id,
+            live_invitations_created,
+            live_invitations_queued,
+            live_invitations_delivered,
+        )
 
     result = {
         "source": source,
@@ -205,6 +220,7 @@ async def get_questions(
         "invited_emails": live_invited_emails,
         "invitations_created": live_invitations_created,
         "invitations_delivered": live_invitations_delivered,
+        "invitations_queued": live_invitations_queued,
     }
 
     logging.warning(f"Final API Response: {result}")

--- a/server/tests/test_live_quiz_analytics.py
+++ b/server/tests/test_live_quiz_analytics.py
@@ -9,12 +9,19 @@ Tests cover:
 """
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
+import jwt
 import pytest
+from bson import ObjectId
 from fastapi import HTTPException
+from starlette.websockets import WebSocketDisconnect
 
 import server.app.quiz.services.live_session_service as live_quiz_session_service
+from server.app.core.config import settings
+from server.app.quiz.routes import live_sessions as live_sessions_routes
 from server.app.quiz.services.live_session_service import LiveQuizSessionService
+from server.app.users.models import UserOut
 
 
 class FakeAnalyticsRepository:
@@ -392,12 +399,18 @@ class FakeEmailService:
 
     async def send_email(self, **kwargs):
         self.sent.append(kwargs)
+        return SimpleNamespace(ok=True, adapter="background")
 
 
 @pytest.mark.asyncio
 async def test_generate_access_code_creates_and_sends_invitations(monkeypatch):
     fixed_now = datetime(2025, 6, 1, 10, 30, tzinfo=timezone.utc)
     monkeypatch.setattr(live_quiz_session_service, "_utc_now", lambda: fixed_now)
+    monkeypatch.setattr(
+        live_quiz_session_service.settings,
+        "FRONTEND_BASE_URL",
+        "https://quiz.example",
+    )
 
     invitation_repository = FakeInvitationRepository()
     email_service = FakeEmailService()
@@ -413,15 +426,160 @@ async def test_generate_access_code_creates_and_sends_invitations(monkeypatch):
         send_email_invitations=True,
         invitation_repository=invitation_repository,
         email_service=email_service,
-        frontend_origin="https://quiz.example",
     )
 
     assert response["invitations_created"] == 2
-    assert response["invitations_delivered"] == 2
+    assert response["invitations_queued"] == 2
+    assert response["invitations_delivered"] == 0
     assert response["invited_emails"] == ["ada@example.com", "grace@example.com"]
     assert invitation_repository.invitations[0]["status"] == "pending"
-    assert invitation_repository.deliveries[0]["status"] == "delivered"
+    assert invitation_repository.deliveries[0]["status"] == "queued"
     assert len(email_service.sent) == 2
+    assert "https://quiz.example/quiz-access/" in email_service.sent[0]["template_vars"]["body"]
+
+
+@pytest.mark.asyncio
+async def test_generate_access_code_route_uses_configured_frontend_url(monkeypatch):
+    fixed_now = datetime(2025, 6, 1, 10, 30, tzinfo=timezone.utc)
+    monkeypatch.setattr(live_quiz_session_service, "_utc_now", lambda: fixed_now)
+    monkeypatch.setattr(
+        live_quiz_session_service.settings,
+        "FRONTEND_BASE_URL",
+        "https://trusted.example",
+    )
+
+    invitation_repository = FakeInvitationRepository()
+    email_service = FakeEmailService()
+    service = LiveQuizSessionService(FakeAccessCodeRepository())
+    payload = live_sessions_routes.AccessCodeCreateRequest(
+        time_limit_minutes=15,
+        access_code_expires_at=fixed_now + timedelta(days=1),
+        participant_access_mode="restricted",
+        invited_emails=["ada@example.com"],
+        send_email_invitations=True,
+    )
+    current_user = UserOut(
+        id="creator-1",
+        username="creator",
+        email="creator@example.com",
+        is_verified=True,
+        status="active",
+    )
+
+    await live_sessions_routes.generate_quiz_access_code(
+        quiz_id="quiz-1",
+        payload=payload,
+        current_user=current_user,
+        service=service,
+        invitation_repository=invitation_repository,
+        email_service=email_service,
+    )
+
+    body = email_service.sent[0]["template_vars"]["body"]
+    assert "https://trusted.example/quiz-access/" in body
+    assert "https://attacker.example" not in body
+
+
+class FakeWebSocket:
+    def __init__(self, auth_message):
+        self.auth_message = auth_message
+        self.accepted = False
+        self.close_code = None
+        self.sent_json = []
+
+    async def accept(self):
+        self.accepted = True
+
+    async def receive_json(self):
+        return self.auth_message
+
+    async def close(self, code):
+        self.close_code = code
+
+    async def send_json(self, payload):
+        self.sent_json.append(payload)
+
+    async def receive_text(self):
+        raise WebSocketDisconnect()
+
+
+@pytest.mark.asyncio
+async def test_live_quiz_websocket_rejects_missing_auth_message():
+    websocket = FakeWebSocket({"type": "authenticate"})
+
+    await live_sessions_routes.live_quiz_participants_ws(
+        websocket,
+        "quiz-1",
+        service=object(),
+        users_collection=object(),
+        sessions_collection=object(),
+    )
+
+    assert websocket.accepted is True
+    assert websocket.close_code == 1008
+    assert websocket.sent_json == []
+
+
+@pytest.mark.asyncio
+async def test_live_quiz_websocket_authenticates_with_first_message():
+    user_id = ObjectId()
+    user = {
+        "_id": user_id,
+        "username": "creator",
+        "email": "creator@example.com",
+        "is_active": True,
+        "is_verified": True,
+        "status": "active",
+        "created_at": datetime(2025, 6, 1, tzinfo=timezone.utc),
+        "updated_at": datetime(2025, 6, 1, tzinfo=timezone.utc),
+    }
+    token = jwt.encode(
+        {
+            "sub": str(user_id),
+            "jti": "jti-1",
+            "sid": "session-1",
+            "type": "access",
+            "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+        },
+        settings.JWT_SECRET,
+        algorithm=settings.JWT_ALGORITHM,
+    )
+
+    class FakeCollection:
+        async def find_one(self, query):
+            if query.get("_id") == user_id:
+                return user
+            if query.get("session_id") == "session-1":
+                return {"session_id": "session-1", "user_id": str(user_id)}
+            return None
+
+        async def update_one(self, *_args, **_kwargs):
+            return None
+
+    class FakeLiveQuizService:
+        async def list_analytics(self, quiz_id, creator_id):
+            assert quiz_id == "quiz-1"
+            assert creator_id == str(user_id)
+            return []
+
+    websocket = FakeWebSocket({"type": "authenticate", "token": token})
+
+    await live_sessions_routes.live_quiz_participants_ws(
+        websocket,
+        "quiz-1",
+        service=FakeLiveQuizService(),
+        users_collection=FakeCollection(),
+        sessions_collection=FakeCollection(),
+    )
+
+    assert websocket.close_code is None
+    assert websocket.sent_json == [
+        {
+            "type": "participants_snapshot",
+            "quiz_id": "quiz-1",
+            "participants": [],
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_quiz_generation_persistence.py
+++ b/server/tests/test_quiz_generation_persistence.py
@@ -1,5 +1,8 @@
 import pytest
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 
+import server.app.quiz.services.live_session_service as live_quiz_session_service
 from server.app.quiz.models.quiz_models import QuizRequest
 from server.app.quiz.utils.questions import get_questions
 
@@ -40,3 +43,137 @@ async def test_authenticated_get_questions_persists_fallback_quiz(monkeypatch):
     assert saved_payloads
     assert saved_payloads[0]["user_id"] == "user-1"
     assert saved_payloads[0]["questions"]
+
+
+class FakeLiveQuizRepository:
+    def __init__(self):
+        self.quiz = {
+            "_id": "canonical-quiz-1",
+            "title": "Generated Live Quiz",
+            "owner_user_id": "user-1",
+            "questions": [{"question": "Q1", "answer": "A"}],
+        }
+
+    async def get_quiz_by_id(self, quiz_id):
+        return self.quiz
+
+    async def access_code_exists(self, access_code):
+        return False
+
+    async def enable_live_quiz(self, **kwargs):
+        self.quiz = {
+            **self.quiz,
+            "live_quiz_enabled": True,
+            "access_code": kwargs["access_code"],
+            "time_limit_minutes": kwargs["time_limit_minutes"],
+            "access_code_expires_at": kwargs["access_code_expires_at"],
+            "participant_access_mode": kwargs["participant_access_mode"],
+            "invited_participant_emails": kwargs["invited_participant_emails"],
+        }
+        return self.quiz
+
+
+class FakeInvitationRepository:
+    def __init__(self):
+        self.invitations = []
+        self.deliveries = []
+
+    async def upsert_invitation(self, invitation):
+        self.invitations.append(invitation)
+        return f"inv-{len(self.invitations)}"
+
+    async def update_email_delivery(self, invitation_id, **kwargs):
+        self.deliveries.append({"invitation_id": invitation_id, **kwargs})
+
+
+class FakeEmailService:
+    def __init__(self):
+        self.sent = []
+
+    async def send_email(self, **kwargs):
+        self.sent.append(kwargs)
+        return SimpleNamespace(ok=True, adapter="background")
+
+
+@pytest.mark.asyncio
+async def test_live_get_questions_creates_invitations_and_uses_frontend_base_url(monkeypatch):
+    fixed_now = datetime(2025, 6, 1, 10, 30, tzinfo=timezone.utc)
+    saved_payloads = []
+    live_repository = FakeLiveQuizRepository()
+    invitation_repository = FakeInvitationRepository()
+    email_service = FakeEmailService()
+
+    async def _generate(_payload):
+        return {
+            "questions": [
+                {
+                    "question": "Q1",
+                    "options": ["A", "B"],
+                    "answer": "A",
+                }
+            ]
+        }
+
+    async def _save(quiz_payload):
+        saved_payloads.append(quiz_payload)
+        return {"quiz_id": "canonical-quiz-1"}
+
+    monkeypatch.setattr(
+        "server.app.quiz.utils.questions.generate_quiz_with_huggingface",
+        _generate,
+    )
+    monkeypatch.setattr(
+        "server.app.quiz.utils.questions.save_ai_generated_quiz",
+        _save,
+    )
+    monkeypatch.setattr(
+        "server.app.quiz.utils.questions.get_quizzes_v2_collection",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        "server.app.quiz.utils.questions.get_live_quiz_sessions_collection",
+        lambda: object(),
+    )
+    monkeypatch.setattr(
+        "server.app.quiz.utils.questions.LiveQuizSessionRepository",
+        lambda *_args, **_kwargs: live_repository,
+    )
+    monkeypatch.setattr(
+        "server.app.quiz.services.live_session_service._utc_now",
+        lambda: fixed_now,
+    )
+    monkeypatch.setattr(
+        live_quiz_session_service.settings,
+        "FRONTEND_BASE_URL",
+        "https://trusted.example",
+    )
+
+    result = await get_questions(
+        QuizRequest(
+            profession="Engineer",
+            num_questions=1,
+            question_type="multichoice",
+            difficulty_level="medium",
+            audience_type="students",
+            live_quiz_enabled=True,
+            time_limit_minutes=15,
+            access_code_expires_at=fixed_now + timedelta(days=1),
+            participant_access_mode="restricted",
+            invited_emails=["ADA@example.com"],
+            send_email_invitations=True,
+        ),
+        user_id="user-1",
+        invitation_repository=invitation_repository,
+        email_service=email_service,
+    )
+
+    assert result["quiz_id"] == "canonical-quiz-1"
+    assert result["invited_emails"] == ["ada@example.com"]
+    assert result["invitations_created"] == 1
+    assert result["invitations_queued"] == 1
+    assert result["invitations_delivered"] == 0
+    assert invitation_repository.invitations[0]["email"] == "ada@example.com"
+    assert invitation_repository.deliveries[0]["status"] == "queued"
+    body = email_service.sent[0]["template_vars"]["body"]
+    assert "https://trusted.example/quiz-access/" in body
+    assert "https://attacker.example" not in body


### PR DESCRIPTION
## Summary

Fixes live quiz security and invitation handling regressions.

- Removes JWT access tokens from live quiz WebSocket URLs.
- Authenticates creator dashboard WebSockets via the first WebSocket message instead of query params.
- Rejects unauthenticated WebSocket connections with policy violation close code.
- Stops trusting `Origin` for invitation links.
- Uses validated `FRONTEND_BASE_URL` for live quiz invitation join links.
- Restores invitation creation/sending for live quiz generation through `/api/get-questions`.
- Adds `invitations_queued` so async email sends are not reported as delivered.
- Logs invitation creation and enqueue counts without logging credentials.
- Updates frontend toast/type handling for queued vs delivered invitation emails.

## Details

The `/get-questions` live quiz path was enabling the live quiz but not providing an invitation repository or email service to `LiveQuizSessionService.generate_access_code()`, so invited emails were returned but invitation records were never created.

This PR wires the invitation repository and email platform into that path, keeps join-link generation based only on configured `FRONTEND_BASE_URL`, and preserves the prior security fix that removed request-origin trust.

For email status reporting, Celery/background sends are now counted as queued, while direct/mailgun sends count as delivered.