### PR TITLE
fix: restore Next dev UI rendering

### DIFF
--- a/client/next.config.mjs
+++ b/client/next.config.mjs
@@ -1,13 +1,14 @@
 const apiBaseUrl =
   process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:8000";
 const apiWsUrl = apiBaseUrl.replace(/^http/i, "ws");
+const isDevelopment = process.env.NODE_ENV !== "production";
 
 // Next.js injects inline bootstrap scripts (__NEXT_DATA__), so script-src
 // needs 'unsafe-inline' until a nonce-based CSP is introduced. This still
 // blocks externally injected scripts, framing, and form exfiltration.
 const contentSecurityPolicy = [
   "default-src 'self'",
-  "script-src 'self' 'unsafe-inline'",
+  `script-src 'self' 'unsafe-inline'${isDevelopment ? " 'unsafe-eval'" : ""}`,
   "style-src 'self' 'unsafe-inline'",
   "img-src 'self' data: blob:",
   "font-src 'self' data:",

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -20,6 +20,25 @@ export default function MyApp({ Component, pageProps }: AppProps) {
 
   useEffect(() => {
     if (typeof window !== "undefined" && "serviceWorker" in navigator) {
+      if (process.env.NODE_ENV !== "production") {
+        navigator.serviceWorker
+          .getRegistrations()
+          .then((registrations) =>
+            Promise.all(
+              registrations.map((registration) => registration.unregister()),
+            ),
+          )
+          .catch((err) => console.error("SW cleanup failed:", err));
+
+        if ("caches" in window) {
+          caches
+            .keys()
+            .then((keys) => Promise.all(keys.map((key) => caches.delete(key))))
+            .catch((err) => console.error("Cache cleanup failed:", err));
+        }
+        return;
+      }
+
       window.addEventListener("load", () => {
         navigator.serviceWorker
           .register("/sw.js")


### PR DESCRIPTION
## Summary

This PR fixes the blank UI seen when running the app locally with Docker/Next dev.

## What Changed

- Allows `unsafe-eval` only in development CSP because Next dev uses eval-based source maps.
- Keeps production CSP strict by leaving `unsafe-eval` out when `NODE_ENV=production`.
- Disables service worker registration during development.
- Cleans existing local service worker registrations and Cache Storage entries in development to prevent stale cached pages/chunks after branch changes.

## Why

The app was returning valid HTML, but the browser could remain blank because Next dev JavaScript was blocked by CSP. A stale service worker/cache could also keep serving old assets after the project restructure.

## Validation

- `pnpm lint` passed.
- `pnpm exec tsc --noEmit --pretty false` passed.
- Verified local development response includes `script-src 'self' 'unsafe-inline' 'unsafe-eval'`.