### PR TITLE
feat(persona): complete onboarding carry-through and profile editing

### DIFF
--- a/client/__tests__/PersonaOnboardingGate.test.tsx
+++ b/client/__tests__/PersonaOnboardingGate.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import PersonaOnboardingGate from "@features/persona/components/PersonaOnboardingGate";
+
+const mockSetPersona = jest.fn();
+let mockAuthState: any;
+let mockPersonaState: any;
+let mockPathname = "/";
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ pathname: mockPathname }),
+}));
+
+jest.mock("@features/auth/context/authContext", () => ({
+  useAuth: () => mockAuthState,
+}));
+
+jest.mock("@features/persona/context/personaContext", () => ({
+  usePersona: () => mockPersonaState,
+}));
+
+describe("PersonaOnboardingGate", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    mockSetPersona.mockReset();
+    mockPathname = "/";
+    mockAuthState = {
+      user: {
+        id: "user-1",
+        persona_category: null,
+        persona_user_type: null,
+      },
+      isAuthenticated: true,
+      isLoading: false,
+    };
+    mockPersonaState = {
+      persona: null,
+      source: "none",
+      setPersona: mockSetPersona,
+    };
+  });
+
+  test("shows onboarding when an authenticated user has no persona", () => {
+    render(<PersonaOnboardingGate />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Pick your Quizwerk persona")).toBeInTheDocument();
+  });
+
+  test("does not show again after the user skips", () => {
+    render(<PersonaOnboardingGate />);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /i'll do this later/i }),
+    );
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  test("silently persists a carried persona as inferred", async () => {
+    mockSetPersona.mockResolvedValue(undefined);
+    mockPersonaState = {
+      persona: { category: "school", userType: "teacher" },
+      source: "storage",
+      setPersona: mockSetPersona,
+    };
+
+    render(<PersonaOnboardingGate />);
+
+    await waitFor(() => {
+      expect(mockSetPersona).toHaveBeenCalledWith(
+        { category: "school", userType: "teacher" },
+        { source: "inferred" },
+      );
+    });
+  });
+
+  test("does not show when the profile already has persona", () => {
+    mockAuthState.user.persona_category = "corporate";
+    mockAuthState.user.persona_user_type = "hr";
+
+    render(<PersonaOnboardingGate />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  test("does not suppress onboarding on dashboard", () => {
+    mockPathname = "/dashboard";
+
+    render(<PersonaOnboardingGate />);
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  test("suppresses onboarding on auth routes", () => {
+    mockPathname = "/auth/login";
+
+    render(<PersonaOnboardingGate />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});

--- a/client/__tests__/PersonaOnboardingGate.test.tsx
+++ b/client/__tests__/PersonaOnboardingGate.test.tsx
@@ -57,11 +57,11 @@ describe("PersonaOnboardingGate", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  test("silently persists a carried persona as inferred", async () => {
+  test("silently persists a query carried persona as inferred", async () => {
     mockSetPersona.mockResolvedValue(undefined);
     mockPersonaState = {
       persona: { category: "school", userType: "teacher" },
-      source: "storage",
+      source: "query",
       setPersona: mockSetPersona,
     };
 
@@ -73,6 +73,20 @@ describe("PersonaOnboardingGate", () => {
         { source: "inferred" },
       );
     });
+  });
+
+  test("does not silently persist a storage carried persona", () => {
+    mockPersonaState = {
+      persona: { category: "school", userType: "teacher" },
+      source: "storage",
+      setPersona: mockSetPersona,
+    };
+
+    render(<PersonaOnboardingGate />);
+
+    expect(mockSetPersona).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("Which describes you best?")).toBeInTheDocument();
   });
 
   test("does not show when the profile already has persona", () => {

--- a/client/__tests__/PersonaProvider.test.tsx
+++ b/client/__tests__/PersonaProvider.test.tsx
@@ -6,6 +6,22 @@ import {
 } from "@features/persona/context/personaContext";
 
 const mockRefreshUser = jest.fn();
+const guestAuthState = {
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  refreshUser: mockRefreshUser,
+};
+
+let mockAuthState: {
+  user: {
+    persona_category?: string | null;
+    persona_user_type?: string | null;
+  } | null;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  refreshUser: typeof mockRefreshUser;
+} = guestAuthState;
 
 let mockRouter: {
   asPath: string;
@@ -27,12 +43,7 @@ jest.mock("next/router", () => ({
 }));
 
 jest.mock("@features/auth/context/authContext", () => ({
-  useAuth: () => ({
-    user: null,
-    isAuthenticated: false,
-    isLoading: false,
-    refreshUser: mockRefreshUser,
-  }),
+  useAuth: () => mockAuthState,
 }));
 
 function PersonaProbe() {
@@ -53,6 +64,7 @@ describe("PersonaProvider", () => {
   beforeEach(() => {
     localStorage.clear();
     mockRefreshUser.mockReset();
+    mockAuthState = guestAuthState;
     mockRouter = {
       asPath:
         "/generate?persona=lecturer&category=school&topic=Introduction+to+microeconomics",
@@ -92,6 +104,44 @@ describe("PersonaProvider", () => {
     );
 
     setItemSpy.mockRestore();
+  });
+
+  test("does not leak authenticated profile persona after logout", async () => {
+    mockRouter = {
+      asPath: "/generate",
+      pathname: "/generate",
+      query: {},
+    };
+    mockAuthState = {
+      ...guestAuthState,
+      user: {
+        persona_category: "school",
+        persona_user_type: "teacher",
+      },
+      isAuthenticated: true,
+    };
+
+    const { rerender } = render(
+      <PersonaProvider>
+        <PersonaProbe />
+      </PersonaProvider>,
+    );
+
+    expect(screen.getByTestId("persona-state")).toHaveTextContent(
+      "school:teacher:profile",
+    );
+
+    mockAuthState = guestAuthState;
+    rerender(
+      <PersonaProvider>
+        <PersonaProbe />
+      </PersonaProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-state")).toHaveTextContent("none"),
+    );
+    expect(localStorage.getItem("quizwerk.persona")).toBeNull();
   });
 
   test("clearPersona clears local storage and cached stored persona state", async () => {

--- a/client/__tests__/PersonaProvider.test.tsx
+++ b/client/__tests__/PersonaProvider.test.tsx
@@ -72,6 +72,14 @@ function PersonaProbe() {
       >
         Infer persona
       </button>
+      <button
+        type="button"
+        onClick={() =>
+          void setPersona({ category: "corporate", userType: "hr" })
+        }
+      >
+        Set guest persona
+      </button>
       <button type="button" onClick={clearPersona}>
         Clear persona
       </button>
@@ -164,7 +172,45 @@ describe("PersonaProvider", () => {
     expect(localStorage.getItem("quizwerk.persona")).toBeNull();
   });
 
-  test("clears inferred authenticated override on logout before another user logs in", async () => {
+  test("does not let guest persona override a logged-in user's profile persona", async () => {
+    mockRouter = {
+      asPath: "/generate",
+      pathname: "/generate",
+      query: {},
+    };
+
+    const { rerender } = render(
+      <PersonaProvider>
+        <PersonaProbe />
+      </PersonaProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Set guest persona" }));
+
+    expect(screen.getByTestId("persona-state")).toHaveTextContent(
+      "corporate:hr:storage",
+    );
+
+    mockAuthState = {
+      ...guestAuthState,
+      user: {
+        persona_category: "school",
+        persona_user_type: "teacher",
+      },
+      isAuthenticated: true,
+    };
+    rerender(
+      <PersonaProvider>
+        <PersonaProbe />
+      </PersonaProvider>,
+    );
+
+    expect(screen.getByTestId("persona-state")).toHaveTextContent(
+      "school:teacher:profile",
+    );
+  });
+
+  test("clears inferred persona storage on logout before another user logs in", async () => {
     localStorage.setItem(
       "quizwerk.persona",
       JSON.stringify({
@@ -206,7 +252,7 @@ describe("PersonaProvider", () => {
     expect(screen.getByTestId("persona-state")).toHaveTextContent(
       "school:lecturer:profile",
     );
-    expect(localStorage.getItem("quizwerk.persona")).not.toBeNull();
+    expect(localStorage.getItem("quizwerk.persona")).toBeNull();
 
     mockAuthState = guestAuthState;
     rerender(
@@ -216,16 +262,14 @@ describe("PersonaProvider", () => {
     );
 
     await waitFor(() =>
-      expect(screen.getByTestId("persona-state")).toHaveTextContent(
-        "school:lecturer:storage",
-      ),
+      expect(screen.getByTestId("persona-state")).toHaveTextContent("none"),
     );
 
     mockAuthState = {
       ...guestAuthState,
       user: {
-        persona_category: "corporate",
-        persona_user_type: "hr",
+        persona_category: null,
+        persona_user_type: null,
       },
       isAuthenticated: true,
     };
@@ -235,9 +279,7 @@ describe("PersonaProvider", () => {
       </PersonaProvider>,
     );
 
-    expect(screen.getByTestId("persona-state")).toHaveTextContent(
-      "corporate:hr:profile",
-    );
+    expect(screen.getByTestId("persona-state")).toHaveTextContent("none");
   });
 
   test("clearPersona clears local storage and cached stored persona state", async () => {

--- a/client/__tests__/PersonaProvider.test.tsx
+++ b/client/__tests__/PersonaProvider.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import {
+  PersonaProvider,
+  usePersona,
+} from "@features/persona/context/personaContext";
+
+const mockRefreshUser = jest.fn();
+
+let mockRouter = {
+  asPath:
+    "/generate?persona=lecturer&category=school&topic=Introduction+to+microeconomics",
+  pathname: "/generate",
+  query: {
+    persona: "lecturer",
+    category: "school",
+    topic: "Introduction to microeconomics",
+  },
+};
+
+jest.mock("next/router", () => ({
+  useRouter: () => mockRouter,
+}));
+
+jest.mock("@features/auth/context/authContext", () => ({
+  useAuth: () => ({
+    user: null,
+    isAuthenticated: false,
+    isLoading: false,
+    refreshUser: mockRefreshUser,
+  }),
+}));
+
+function PersonaProbe() {
+  const { persona, source } = usePersona();
+  return (
+    <p data-testid="persona-state">
+      {persona ? `${persona.category}:${persona.userType}:${source}` : "none"}
+    </p>
+  );
+}
+
+describe("PersonaProvider", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockRefreshUser.mockReset();
+    mockRouter = {
+      asPath:
+        "/generate?persona=lecturer&category=school&topic=Introduction+to+microeconomics",
+      pathname: "/generate",
+      query: {
+        persona: "lecturer",
+        category: "school",
+        topic: "Introduction to microeconomics",
+      },
+    };
+  });
+
+  test("persists guest query persona idempotently", async () => {
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+
+    render(
+      <PersonaProvider>
+        <PersonaProbe />
+      </PersonaProvider>,
+    );
+
+    expect(screen.getByTestId("persona-state")).toHaveTextContent(
+      "school:lecturer:query",
+    );
+
+    await waitFor(() => expect(setItemSpy).toHaveBeenCalledTimes(1));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(setItemSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(localStorage.getItem("quizwerk.persona") || "{}")).toEqual(
+      {
+        category: "school",
+        userType: "lecturer",
+        topic: "Introduction to microeconomics",
+        v: 1,
+      },
+    );
+
+    setItemSpy.mockRestore();
+  });
+});

--- a/client/__tests__/PersonaProvider.test.tsx
+++ b/client/__tests__/PersonaProvider.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import {
   PersonaProvider,
   usePersona,
@@ -7,7 +7,11 @@ import {
 
 const mockRefreshUser = jest.fn();
 
-let mockRouter = {
+let mockRouter: {
+  asPath: string;
+  pathname: string;
+  query: Record<string, string>;
+} = {
   asPath:
     "/generate?persona=lecturer&category=school&topic=Introduction+to+microeconomics",
   pathname: "/generate",
@@ -32,11 +36,16 @@ jest.mock("@features/auth/context/authContext", () => ({
 }));
 
 function PersonaProbe() {
-  const { persona, source } = usePersona();
+  const { persona, source, clearPersona } = usePersona();
   return (
-    <p data-testid="persona-state">
-      {persona ? `${persona.category}:${persona.userType}:${source}` : "none"}
-    </p>
+    <>
+      <p data-testid="persona-state">
+        {persona ? `${persona.category}:${persona.userType}:${source}` : "none"}
+      </p>
+      <button type="button" onClick={clearPersona}>
+        Clear persona
+      </button>
+    </>
   );
 }
 
@@ -73,6 +82,90 @@ describe("PersonaProvider", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(setItemSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(localStorage.getItem("quizwerk.persona") || "{}")).toEqual(
+      {
+        category: "school",
+        userType: "lecturer",
+        topic: "Introduction to microeconomics",
+        v: 1,
+      },
+    );
+
+    setItemSpy.mockRestore();
+  });
+
+  test("clearPersona clears local storage and cached stored persona state", async () => {
+    localStorage.setItem(
+      "quizwerk.persona",
+      JSON.stringify({
+        category: "corporate",
+        userType: "hr",
+        topic: "Onboarding checklist",
+        v: 1,
+      }),
+    );
+    mockRouter = {
+      asPath: "/generate",
+      pathname: "/generate",
+      query: {},
+    };
+
+    render(
+      <PersonaProvider>
+        <PersonaProbe />
+      </PersonaProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-state")).toHaveTextContent(
+        "corporate:hr:storage",
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear persona" }));
+
+    expect(localStorage.getItem("quizwerk.persona")).toBeNull();
+    expect(screen.getByTestId("persona-state")).toHaveTextContent("none");
+  });
+
+  test("does not rewrite matching stored persona when query has no topic", async () => {
+    localStorage.setItem(
+      "quizwerk.persona",
+      JSON.stringify({
+        category: "school",
+        userType: "lecturer",
+        topic: "Introduction to microeconomics",
+        v: 1,
+      }),
+    );
+    mockRouter = {
+      asPath: "/generate?persona=lecturer&category=school",
+      pathname: "/generate",
+      query: {
+        persona: "lecturer",
+        category: "school",
+      },
+    };
+    const setItemSpy = jest.spyOn(Storage.prototype, "setItem");
+
+    render(
+      <PersonaProvider>
+        <PersonaProbe />
+      </PersonaProvider>,
+    );
+
+    expect(screen.getByTestId("persona-state")).toHaveTextContent(
+      "school:lecturer:query",
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-state")).toHaveTextContent(
+        "school:lecturer:query",
+      ),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(setItemSpy).not.toHaveBeenCalled();
     expect(JSON.parse(localStorage.getItem("quizwerk.persona") || "{}")).toEqual(
       {
         category: "school",

--- a/client/__tests__/PersonaProvider.test.tsx
+++ b/client/__tests__/PersonaProvider.test.tsx
@@ -6,6 +6,9 @@ import {
 } from "@features/persona/context/personaContext";
 
 const mockRefreshUser = jest.fn();
+const mockUpdatePersona = jest.fn(
+  async (_persona: unknown, _source?: unknown) => ({}),
+);
 const guestAuthState = {
   user: null,
   isAuthenticated: false,
@@ -46,13 +49,29 @@ jest.mock("@features/auth/context/authContext", () => ({
   useAuth: () => mockAuthState,
 }));
 
+jest.mock("@features/persona/api/personaApi", () => ({
+  updatePersona: (persona: unknown, source: unknown) =>
+    mockUpdatePersona(persona, source),
+}));
+
 function PersonaProbe() {
-  const { persona, source, clearPersona } = usePersona();
+  const { persona, source, setPersona, clearPersona } = usePersona();
   return (
     <>
       <p data-testid="persona-state">
         {persona ? `${persona.category}:${persona.userType}:${source}` : "none"}
       </p>
+      <button
+        type="button"
+        onClick={() =>
+          void setPersona(
+            { category: "school", userType: "lecturer" },
+            { source: "inferred" },
+          )
+        }
+      >
+        Infer persona
+      </button>
       <button type="button" onClick={clearPersona}>
         Clear persona
       </button>
@@ -64,6 +83,7 @@ describe("PersonaProvider", () => {
   beforeEach(() => {
     localStorage.clear();
     mockRefreshUser.mockReset();
+    mockUpdatePersona.mockClear();
     mockAuthState = guestAuthState;
     mockRouter = {
       asPath:
@@ -142,6 +162,82 @@ describe("PersonaProvider", () => {
       expect(screen.getByTestId("persona-state")).toHaveTextContent("none"),
     );
     expect(localStorage.getItem("quizwerk.persona")).toBeNull();
+  });
+
+  test("clears inferred authenticated override on logout before another user logs in", async () => {
+    localStorage.setItem(
+      "quizwerk.persona",
+      JSON.stringify({
+        category: "school",
+        userType: "lecturer",
+        topic: "Introduction to microeconomics",
+        v: 1,
+      }),
+    );
+    mockRouter = {
+      asPath: "/generate",
+      pathname: "/generate",
+      query: {},
+    };
+    mockAuthState = {
+      ...guestAuthState,
+      user: {
+        persona_category: null,
+        persona_user_type: null,
+      },
+      isAuthenticated: true,
+    };
+
+    const { rerender } = render(
+      <PersonaProvider>
+        <PersonaProbe />
+      </PersonaProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-state")).toHaveTextContent(
+        "school:lecturer:storage",
+      ),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Infer persona" }));
+
+    await waitFor(() => expect(mockUpdatePersona).toHaveBeenCalledTimes(1));
+    expect(screen.getByTestId("persona-state")).toHaveTextContent(
+      "school:lecturer:profile",
+    );
+    expect(localStorage.getItem("quizwerk.persona")).not.toBeNull();
+
+    mockAuthState = guestAuthState;
+    rerender(
+      <PersonaProvider>
+        <PersonaProbe />
+      </PersonaProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId("persona-state")).toHaveTextContent(
+        "school:lecturer:storage",
+      ),
+    );
+
+    mockAuthState = {
+      ...guestAuthState,
+      user: {
+        persona_category: "corporate",
+        persona_user_type: "hr",
+      },
+      isAuthenticated: true,
+    };
+    rerender(
+      <PersonaProvider>
+        <PersonaProbe />
+      </PersonaProvider>,
+    );
+
+    expect(screen.getByTestId("persona-state")).toHaveTextContent(
+      "corporate:hr:profile",
+    );
   });
 
   test("clearPersona clears local storage and cached stored persona state", async () => {

--- a/client/__tests__/resolvePersona.test.ts
+++ b/client/__tests__/resolvePersona.test.ts
@@ -1,5 +1,10 @@
 import { resolvePersona } from "@features/persona/lib/resolvePersona";
 import {
+  readStoredPersona,
+  readStoredPersonaTopic,
+  writeStoredPersona,
+} from "@features/persona/lib/personaStorage";
+import {
   categoryForUserType,
   parsePersona,
   personaGenerateHref,
@@ -7,6 +12,10 @@ import {
 } from "@shared/config/persona";
 
 const EMPTY_QUERY = { persona: null, category: null };
+
+afterEach(() => {
+  window.localStorage.clear();
+});
 
 describe("parsePersona", () => {
   test("accepts slugs", () => {
@@ -52,6 +61,32 @@ describe("parsePersona", () => {
       });
       expect(params.get("topic")).toBeTruthy();
     }
+  });
+});
+
+describe("persona storage", () => {
+  test("persists persona and its carried topic", () => {
+    const persona = { category: "school" as const, userType: "teacher" as const };
+
+    writeStoredPersona(persona, {
+      topic: "Photosynthesis — Grade 8 biology",
+    });
+
+    expect(readStoredPersona()).toEqual(persona);
+    expect(readStoredPersonaTopic(persona)).toBe(
+      "Photosynthesis — Grade 8 biology",
+    );
+  });
+
+  test("does not apply a stored topic to a different persona", () => {
+    writeStoredPersona(
+      { category: "school", userType: "teacher" },
+      { topic: "Photosynthesis" },
+    );
+
+    expect(
+      readStoredPersonaTopic({ category: "corporate", userType: "hr" }),
+    ).toBeNull();
   });
 });
 

--- a/client/__tests__/resolvePersona.test.ts
+++ b/client/__tests__/resolvePersona.test.ts
@@ -88,6 +88,31 @@ describe("persona storage", () => {
       readStoredPersonaTopic({ category: "corporate", userType: "hr" }),
     ).toBeNull();
   });
+
+  test("preserves topic when rewriting the same stored persona without topic", () => {
+    const persona = { category: "school" as const, userType: "teacher" as const };
+
+    writeStoredPersona(persona, { topic: "Photosynthesis" });
+    writeStoredPersona(persona);
+
+    expect(readStoredPersonaTopic(persona)).toBe("Photosynthesis");
+  });
+
+  test("clears old topic when storing a different persona without topic", () => {
+    writeStoredPersona(
+      { category: "school", userType: "teacher" },
+      { topic: "Photosynthesis" },
+    );
+
+    const nextPersona = {
+      category: "corporate" as const,
+      userType: "hr" as const,
+    };
+    writeStoredPersona(nextPersona);
+
+    expect(readStoredPersona()).toEqual(nextPersona);
+    expect(readStoredPersonaTopic(nextPersona)).toBeNull();
+  });
 });
 
 describe("resolvePersona precedence", () => {

--- a/client/__tests__/resolvePersona.test.ts
+++ b/client/__tests__/resolvePersona.test.ts
@@ -89,6 +89,16 @@ describe("persona storage", () => {
     ).toBeNull();
   });
 
+  test("does not return a stored topic without a matching persona", () => {
+    writeStoredPersona(
+      { category: "corporate", userType: "hr" },
+      { topic: "Onboarding checklist" },
+    );
+
+    expect(readStoredPersonaTopic(null)).toBeNull();
+    expect(readStoredPersonaTopic()).toBeNull();
+  });
+
   test("preserves topic when rewriting the same stored persona without topic", () => {
     const persona = { category: "school" as const, userType: "teacher" as const };
 

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "react-hot-toast";
 import SplashScreen from "@app/components/SplashScreen";
 import { AuthProvider } from "@features/auth/context/authContext";
 import { PersonaProvider } from "@features/persona/context/personaContext";
+import PersonaOnboardingGate from "@features/persona/components/PersonaOnboardingGate";
 import SignInModal from "@features/auth/components/SignInModal";
 import AssistantLauncher from "@features/assistant/components/AssistantLauncher";
 import { ROUTES } from "@shared/config/patterns/routes";
@@ -53,6 +54,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       <PersonaProvider>
         <SplashScreen />
         <EmailVerificationBanner />
+        <PersonaOnboardingGate />
 
         <Component {...pageProps} openLoginModal={openSignInModal} />
         <AssistantLauncher />

--- a/client/src/features/persona/api/personaApi.ts
+++ b/client/src/features/persona/api/personaApi.ts
@@ -1,11 +1,16 @@
 import { api } from "@shared/api/http";
 import type { Persona } from "@shared/config/persona";
+import type { PersonaWriteSource } from "@features/persona/types/persona";
 
-/** Persists persona onto the user profile (rides PUT /auth/profile). */
-export async function updatePersona(persona: Persona) {
-  const response = await api.put("/auth/profile", {
+/** Persists persona onto the user profile without unlocking full profile edits. */
+export async function updatePersona(
+  persona: Persona,
+  source: PersonaWriteSource = "profile",
+) {
+  const response = await api.put("/auth/profile/persona", {
     persona_category: persona.category,
     persona_user_type: persona.userType,
+    source,
   });
   return response.data;
 }

--- a/client/src/features/persona/components/PersonaOnboardingGate.tsx
+++ b/client/src/features/persona/components/PersonaOnboardingGate.tsx
@@ -57,7 +57,7 @@ export default function PersonaOnboardingGate() {
       !user ||
       profilePersona ||
       !persona ||
-      (source !== "query" && source !== "storage") ||
+      source !== "query" ||
       !autoSaveKey ||
       pendingAutoSaveKey.current === autoSaveKey ||
       failedAutoSaveKeys.current.has(autoSaveKey)

--- a/client/src/features/persona/components/PersonaOnboardingGate.tsx
+++ b/client/src/features/persona/components/PersonaOnboardingGate.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/router";
+import { useAuth } from "@features/auth/context/authContext";
+import PersonaPicker from "@features/persona/components/PersonaPicker";
+import { usePersona } from "@features/persona/context/personaContext";
+import {
+  readPersonaOnboardingSkipped,
+  writePersonaOnboardingSkipped,
+} from "@features/persona/lib/personaOnboardingStorage";
+import { parsePersona } from "@shared/config/persona";
+import { BTN_GHOST, CONTAINER } from "@shared/ui/quizwerk";
+
+const SUPPRESSED_ROUTES = ["/auth"];
+
+export default function PersonaOnboardingGate() {
+  const router = useRouter();
+  const { user, isAuthenticated, isLoading } = useAuth();
+  const { persona, source, setPersona } = usePersona();
+  const [skipState, setSkipState] = useState<{
+    userId: string;
+    skipped: boolean;
+  } | null>(null);
+  const [isAutoSaving, setIsAutoSaving] = useState(false);
+  const failedAutoSaveKeys = useRef<Set<string>>(new Set());
+  const pendingAutoSaveKey = useRef<string | null>(null);
+
+  const profilePersona = useMemo(
+    () =>
+      user
+        ? parsePersona(user.persona_category, user.persona_user_type)
+        : null,
+    [user],
+  );
+
+  useEffect(() => {
+    if (!user?.id) {
+      setSkipState(null);
+      return;
+    }
+
+    setSkipState({
+      userId: user.id,
+      skipped: readPersonaOnboardingSkipped(user.id),
+    });
+  }, [user?.id]);
+
+  const autoSaveKey = persona
+    ? `${user?.id ?? "anonymous"}:${source}:${persona.category}:${persona.userType}`
+    : null;
+
+  useEffect(() => {
+    if (
+      isLoading ||
+      !isAuthenticated ||
+      !user ||
+      profilePersona ||
+      !persona ||
+      (source !== "query" && source !== "storage") ||
+      !autoSaveKey ||
+      pendingAutoSaveKey.current === autoSaveKey ||
+      failedAutoSaveKeys.current.has(autoSaveKey)
+    ) {
+      return;
+    }
+
+    pendingAutoSaveKey.current = autoSaveKey;
+    setIsAutoSaving(true);
+
+    void setPersona(persona, { source: "inferred" })
+      .catch((error) => {
+        failedAutoSaveKeys.current.add(autoSaveKey);
+        console.warn("Failed to persist carried persona", error);
+      })
+      .finally(() => {
+        if (pendingAutoSaveKey.current === autoSaveKey) {
+          pendingAutoSaveKey.current = null;
+        }
+        setIsAutoSaving(false);
+      });
+  }, [
+    autoSaveKey,
+    isAuthenticated,
+    isLoading,
+    persona,
+    profilePersona,
+    setPersona,
+    source,
+    user,
+  ]);
+
+  if (isLoading || !isAuthenticated || !user || profilePersona || isAutoSaving) {
+    return null;
+  }
+
+  const skipReady = skipState?.userId === user.id;
+  if (!skipReady || skipState.skipped) return null;
+
+  const isSuppressedRoute = SUPPRESSED_ROUTES.some((route) =>
+    router.pathname.startsWith(route),
+  );
+  if (isSuppressedRoute) return null;
+
+  const onSkip = () => {
+    writePersonaOnboardingSkipped(user.id);
+    setSkipState({ userId: user.id, skipped: true });
+  };
+
+  return (
+    <div
+      aria-modal="true"
+      role="dialog"
+      className="fixed inset-0 z-[130] overflow-y-auto bg-ink/70 px-4 py-8"
+    >
+      <div
+        className={`${CONTAINER} flex min-h-full items-center justify-center`}
+      >
+        <section className="w-full max-w-[760px] border-2 border-ink bg-paper p-[clamp(24px,4vw,44px)] text-ink shadow-[12px_12px_0_rgba(20,62,111,0.22)]">
+          <div className="mb-[28px] flex items-start justify-between gap-4">
+            <div>
+              <p className="text-[13px] font-extrabold uppercase tracking-[0.16em] text-brand">
+                First-time setup
+              </p>
+              <p className="mt-[8px] max-w-[56ch] text-[15px] leading-[24px] text-ink/72">
+                Choose the seat you are sitting in so Quizwerk can tune your
+                dashboard, language, and starting points.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={onSkip}
+              className="text-[14px] font-extrabold text-ink/70 underline-offset-4 hover:text-ink hover:underline"
+            >
+              Skip
+            </button>
+          </div>
+
+          <PersonaPicker
+            heading="Pick your Quizwerk persona"
+            initialCategory={persona?.category ?? null}
+            source="onboarding"
+            onPicked={onSkip}
+          />
+
+          <div className="mt-[28px] border-t-2 border-divider pt-[18px]">
+            <button type="button" onClick={onSkip} className={BTN_GHOST}>
+              I&apos;ll do this later
+            </button>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/client/src/features/persona/components/PersonaPicker.tsx
+++ b/client/src/features/persona/components/PersonaPicker.tsx
@@ -9,6 +9,7 @@ import {
 } from "@shared/config/persona";
 import { BTN_GHOST, BTN_PRIMARY, Kicker } from "@shared/ui/quizwerk";
 import { usePersona } from "@features/persona/context/personaContext";
+import type { PersonaWriteSource } from "@features/persona/types/persona";
 
 /**
  * Two-step category -> user-type picker, styled to the Quizwerk system.
@@ -19,18 +20,24 @@ import { usePersona } from "@features/persona/context/personaContext";
 export default function PersonaPicker({
   onPicked,
   heading = "Who are you setting up for?",
+  initialCategory = null,
+  source = "profile",
 }: {
   onPicked?: (persona: Persona) => void;
   heading?: string;
+  initialCategory?: PersonaCategory | null;
+  source?: PersonaWriteSource;
 }) {
   const { setPersona } = usePersona();
-  const [category, setCategory] = useState<PersonaCategory | null>(null);
+  const [category, setCategory] = useState<PersonaCategory | null>(
+    initialCategory,
+  );
   const [isSaving, setIsSaving] = useState(false);
 
   const choose = async (persona: Persona) => {
     setIsSaving(true);
     try {
-      await setPersona(persona);
+      await setPersona(persona, { source });
       onPicked?.(persona);
     } catch {
       toast.error("Could not save your choice. Please try again.");

--- a/client/src/features/persona/context/personaContext.tsx
+++ b/client/src/features/persona/context/personaContext.tsx
@@ -19,6 +19,7 @@ import { updatePersona } from "@features/persona/api/personaApi";
 import {
   clearStoredPersona,
   readStoredPersona,
+  readStoredPersonaTopic,
   writeStoredPersona,
 } from "@features/persona/lib/personaStorage";
 import { resolvePersona } from "@features/persona/lib/resolvePersona";
@@ -40,6 +41,9 @@ const EMPTY_STATE: PersonaState = {
 };
 
 const PersonaContext = createContext<PersonaState>(EMPTY_STATE);
+
+const samePersona = (first: Persona | null, second: Persona | null) =>
+  first?.category === second?.category && first?.userType === second?.userType;
 
 export function PersonaProvider({ children }: { children: React.ReactNode }) {
   const { user, isAuthenticated, isLoading, refreshUser } = useAuth();
@@ -80,14 +84,31 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
   }, [override, storedPersona, user, router.query]);
 
   useEffect(() => {
-    if (resolved.source === "query" && resolved.persona) {
-      const topic = Array.isArray(router.query?.topic)
-        ? router.query.topic[0]
-        : router.query?.topic;
+    if (resolved.source !== "query" || !resolved.persona) {
+      return;
+    }
+
+    const topic = Array.isArray(router.query?.topic)
+      ? router.query.topic[0]
+      : router.query?.topic;
+
+    const normalizedTopic =
+      typeof topic === "string" ? topic.trim().slice(0, 300) : "";
+    const storedTopic = readStoredPersonaTopic(resolved.persona) || "";
+    const isStoredPersonaCurrent = samePersona(storedPersona, resolved.persona);
+
+    if (!isStoredPersonaCurrent || storedTopic !== normalizedTopic) {
       writeStoredPersona(resolved.persona, { topic });
+    }
+    if (!isStoredPersonaCurrent) {
       setStoredPersona(resolved.persona);
     }
-  }, [resolved.persona, resolved.source, router.query]);
+  }, [
+    resolved.persona,
+    resolved.source,
+    router.query?.topic,
+    storedPersona,
+  ]);
 
   const setPersona = useCallback(
     async (

--- a/client/src/features/persona/context/personaContext.tsx
+++ b/client/src/features/persona/context/personaContext.tsx
@@ -92,15 +92,20 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
       ? router.query.topic[0]
       : router.query?.topic;
 
-    const normalizedTopic =
-      typeof topic === "string" ? topic.trim().slice(0, 300) : "";
+    const hasTopicParam = typeof topic === "string";
+    const normalizedTopic = hasTopicParam ? topic.trim().slice(0, 300) : "";
     const storedTopic = readStoredPersonaTopic(resolved.persona) || "";
-    const isStoredPersonaCurrent = samePersona(storedPersona, resolved.persona);
+    const storagePersona = storedPersona ?? readStoredPersona();
+    const isStoredPersonaCurrent = samePersona(storagePersona, resolved.persona);
+    const targetTopic = hasTopicParam ? normalizedTopic : storedTopic;
 
-    if (!isStoredPersonaCurrent || storedTopic !== normalizedTopic) {
-      writeStoredPersona(resolved.persona, { topic });
+    if (!isStoredPersonaCurrent || storedTopic !== targetTopic) {
+      writeStoredPersona(
+        resolved.persona,
+        hasTopicParam ? { topic } : undefined,
+      );
     }
-    if (!isStoredPersonaCurrent) {
+    if (!samePersona(storedPersona, resolved.persona)) {
       setStoredPersona(resolved.persona);
     }
   }, [
@@ -140,6 +145,7 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
 
   const clearPersona = useCallback(() => {
     setOverride(null);
+    setStoredPersona(null);
     clearStoredPersona();
   }, []);
 

--- a/client/src/features/persona/context/personaContext.tsx
+++ b/client/src/features/persona/context/personaContext.tsx
@@ -4,6 +4,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -21,7 +22,10 @@ import {
   writeStoredPersona,
 } from "@features/persona/lib/personaStorage";
 import { resolvePersona } from "@features/persona/lib/resolvePersona";
-import type { PersonaState } from "@features/persona/types/persona";
+import type {
+  PersonaState,
+  PersonaWriteSource,
+} from "@features/persona/types/persona";
 
 const EMPTY_STATE: PersonaState = {
   persona: null,
@@ -44,6 +48,17 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
   // Local override so a fresh pick renders immediately, before the profile
   // round-trip completes.
   const [override, setOverride] = useState<Persona | null>(null);
+  const [storedPersona, setStoredPersona] = useState<Persona | null>(null);
+
+  useEffect(() => {
+    setStoredPersona(readStoredPersona());
+  }, []);
+
+  useEffect(() => {
+    if (!isAuthenticated && override && !storedPersona) {
+      setOverride(null);
+    }
+  }, [isAuthenticated, override, storedPersona]);
 
   const resolved = useMemo(() => {
     if (override) {
@@ -60,19 +75,44 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
         persona: (router.query?.persona as string) ?? null,
         category: (router.query?.category as string) ?? null,
       },
-      stored: readStoredPersona(),
+      stored: storedPersona,
     });
-  }, [override, user, router.query]);
+  }, [override, storedPersona, user, router.query]);
+
+  useEffect(() => {
+    if (resolved.source === "query" && resolved.persona) {
+      const topic = Array.isArray(router.query?.topic)
+        ? router.query.topic[0]
+        : router.query?.topic;
+      writeStoredPersona(resolved.persona, { topic });
+      setStoredPersona(resolved.persona);
+    }
+  }, [resolved.persona, resolved.source, router.query]);
 
   const setPersona = useCallback(
-    async (persona: Persona) => {
-      setOverride(persona);
-      writeStoredPersona(persona);
-
+    async (
+      persona: Persona,
+      options: { source?: PersonaWriteSource } = {},
+    ) => {
       if (isAuthenticated) {
-        await updatePersona(persona);
-        await refreshUser();
+        setOverride(persona);
+        try {
+          await updatePersona(persona, options.source ?? "profile");
+          await refreshUser();
+          if ((options.source ?? "profile") !== "inferred") {
+            clearStoredPersona();
+            setStoredPersona(null);
+          }
+        } catch (error) {
+          setOverride(null);
+          throw error;
+        }
+        return;
       }
+
+      writeStoredPersona(persona);
+      setStoredPersona(persona);
+      setOverride(persona);
     },
     [isAuthenticated, refreshUser],
   );

--- a/client/src/features/persona/context/personaContext.tsx
+++ b/client/src/features/persona/context/personaContext.tsx
@@ -6,6 +6,7 @@ import React, {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useRouter } from "next/router";
@@ -53,16 +54,18 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
   // round-trip completes.
   const [override, setOverride] = useState<Persona | null>(null);
   const [storedPersona, setStoredPersona] = useState<Persona | null>(null);
+  const wasAuthenticatedRef = useRef(isAuthenticated);
 
   useEffect(() => {
     setStoredPersona(readStoredPersona());
   }, []);
 
   useEffect(() => {
-    if (!isAuthenticated && override && !storedPersona) {
+    if (wasAuthenticatedRef.current && !isAuthenticated) {
       setOverride(null);
     }
-  }, [isAuthenticated, override, storedPersona]);
+    wasAuthenticatedRef.current = isAuthenticated;
+  }, [isAuthenticated]);
 
   const resolved = useMemo(() => {
     if (override) {

--- a/client/src/features/persona/context/personaContext.tsx
+++ b/client/src/features/persona/context/personaContext.tsx
@@ -63,6 +63,10 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (wasAuthenticatedRef.current && !isAuthenticated) {
       setOverride(null);
+      setStoredPersona(null);
+      clearStoredPersona();
+    } else if (!wasAuthenticatedRef.current && isAuthenticated) {
+      setOverride(null);
     }
     wasAuthenticatedRef.current = isAuthenticated;
   }, [isAuthenticated]);
@@ -128,10 +132,8 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
         try {
           await updatePersona(persona, options.source ?? "profile");
           await refreshUser();
-          if ((options.source ?? "profile") !== "inferred") {
-            clearStoredPersona();
-            setStoredPersona(null);
-          }
+          clearStoredPersona();
+          setStoredPersona(null);
         } catch (error) {
           setOverride(null);
           throw error;
@@ -141,7 +143,6 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
 
       writeStoredPersona(persona);
       setStoredPersona(persona);
-      setOverride(persona);
     },
     [isAuthenticated, refreshUser],
   );

--- a/client/src/features/persona/lib/personaOnboardingStorage.ts
+++ b/client/src/features/persona/lib/personaOnboardingStorage.ts
@@ -1,0 +1,25 @@
+const SKIP_PREFIX = "quizwerk.personaOnboarding.skipped";
+
+function keyFor(userId: string): string {
+  return `${SKIP_PREFIX}.${userId}`;
+}
+
+export function readPersonaOnboardingSkipped(userId: string): boolean {
+  if (typeof window === "undefined") return false;
+
+  try {
+    return window.localStorage.getItem(keyFor(userId)) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function writePersonaOnboardingSkipped(userId: string): void {
+  if (typeof window === "undefined") return;
+
+  try {
+    window.localStorage.setItem(keyFor(userId), "true");
+  } catch {
+    // Losing this preference only means the user may see onboarding again.
+  }
+}

--- a/client/src/features/persona/lib/personaStorage.ts
+++ b/client/src/features/persona/lib/personaStorage.ts
@@ -35,7 +35,7 @@ export function readStoredPersona(): Persona | null {
 }
 
 export function readStoredPersonaTopic(persona?: Persona | null): string | null {
-  if (typeof window === "undefined") return null;
+  if (typeof window === "undefined" || !persona) return null;
 
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
@@ -53,10 +53,9 @@ export function readStoredPersonaTopic(persona?: Persona | null): string | null 
 
     const storedPersona = parsePersona(parsed.category, parsed.userType);
     if (
-      persona &&
-      (!storedPersona ||
-        storedPersona.category !== persona.category ||
-        storedPersona.userType !== persona.userType)
+      !storedPersona ||
+      storedPersona.category !== persona.category ||
+      storedPersona.userType !== persona.userType
     ) {
       return null;
     }

--- a/client/src/features/persona/lib/personaStorage.ts
+++ b/client/src/features/persona/lib/personaStorage.ts
@@ -75,10 +75,15 @@ export function writeStoredPersona(
   if (typeof window === "undefined") return;
 
   try {
+    const existingPersona = readStoredPersona();
+    const existingTopic = readStoredPersonaTopic(persona);
     const topic =
       typeof context.topic === "string"
         ? context.topic.trim().slice(0, MAX_STORED_TOPIC_LENGTH)
-        : "";
+        : existingPersona?.category === persona.category &&
+            existingPersona?.userType === persona.userType
+          ? existingTopic || ""
+          : "";
     window.localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({

--- a/client/src/features/persona/lib/personaStorage.ts
+++ b/client/src/features/persona/lib/personaStorage.ts
@@ -10,6 +10,7 @@ import { parsePersona, type Persona } from "@shared/config/persona";
  */
 const STORAGE_KEY = "quizwerk.persona";
 const STORAGE_VERSION = 1;
+const MAX_STORED_TOPIC_LENGTH = 300;
 
 export function readStoredPersona(): Persona | null {
   if (typeof window === "undefined") return null;
@@ -21,6 +22,7 @@ export function readStoredPersona(): Persona | null {
     const parsed = JSON.parse(raw) as {
       category?: string;
       userType?: string;
+      topic?: string;
       v?: number;
     };
     if (parsed?.v !== STORAGE_VERSION) return null;
@@ -32,13 +34,58 @@ export function readStoredPersona(): Persona | null {
   }
 }
 
-export function writeStoredPersona(persona: Persona): void {
+export function readStoredPersonaTopic(persona?: Persona | null): string | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+
+    const parsed = JSON.parse(raw) as {
+      category?: string;
+      userType?: string;
+      topic?: string;
+      v?: number;
+    };
+    if (parsed?.v !== STORAGE_VERSION || typeof parsed.topic !== "string") {
+      return null;
+    }
+
+    const storedPersona = parsePersona(parsed.category, parsed.userType);
+    if (
+      persona &&
+      (!storedPersona ||
+        storedPersona.category !== persona.category ||
+        storedPersona.userType !== persona.userType)
+    ) {
+      return null;
+    }
+
+    const topic = parsed.topic.trim();
+    return topic ? topic : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeStoredPersona(
+  persona: Persona,
+  context: { topic?: string | null } = {},
+): void {
   if (typeof window === "undefined") return;
 
   try {
+    const topic =
+      typeof context.topic === "string"
+        ? context.topic.trim().slice(0, MAX_STORED_TOPIC_LENGTH)
+        : "";
     window.localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ ...persona, v: STORAGE_VERSION }),
+      JSON.stringify({
+        ...persona,
+        ...(topic ? { topic } : {}),
+        v: STORAGE_VERSION,
+      }),
     );
   } catch {
     // Private browsing / quota — a lost preference is acceptable.

--- a/client/src/features/persona/types/persona.ts
+++ b/client/src/features/persona/types/persona.ts
@@ -10,6 +10,7 @@ export type { Persona, PersonaCategory, PersonaUserType };
 
 /** Where the active persona came from, most trusted first. */
 export type PersonaSource = "profile" | "query" | "storage" | "none";
+export type PersonaWriteSource = "onboarding" | "profile" | "inferred";
 
 export interface PersonaState {
   persona: Persona | null;
@@ -20,6 +21,9 @@ export interface PersonaState {
   source: PersonaSource;
   isLoading: boolean;
   /** Persists to the profile when signed in, otherwise to local storage. */
-  setPersona: (persona: Persona) => Promise<void>;
+  setPersona: (
+    persona: Persona,
+    options?: { source?: PersonaWriteSource },
+  ) => Promise<void>;
   clearPersona: () => void;
 }

--- a/client/src/features/profile/pages/ProfilePage.tsx
+++ b/client/src/features/profile/pages/ProfilePage.tsx
@@ -331,7 +331,7 @@ export default function ProfilePage() {
       ? "bg-green-100 text-green-800"
       : billingStatus === "past_due"
         ? "bg-amber-100 text-amber-800"
-      : "bg-gray-100 text-gray-700";
+        : "bg-gray-100 text-gray-700";
   const personaLabel =
     categoryDefinition && definition
       ? `${categoryDefinition.label} · ${definition.label}`

--- a/client/src/features/profile/pages/ProfilePage.tsx
+++ b/client/src/features/profile/pages/ProfilePage.tsx
@@ -18,9 +18,12 @@ import {
 import NavBar from "@features/quiz/components/NavBar";
 import Footer from "@features/quiz/components/Footer";
 import RequireAuth from "@features/auth/components/RequireAuth";
+import PersonaPicker from "@features/persona/components/PersonaPicker";
+import { usePersona } from "@features/persona/context/personaContext";
 
 export default function ProfilePage() {
   const { user, isLoading, logout, refreshUser } = useAuth();
+  const { persona, definition, categoryDefinition } = usePersona();
   const router = useRouter();
   const [isLoggingOut, setIsLoggingOut] = useState(false);
   const [showLogoutConfirm, setShowLogoutConfirm] = useState(false);
@@ -35,7 +38,7 @@ export default function ProfilePage() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [publicProfile, setPublicProfile] = useState(false);
   const [activeSettingSection, setActiveSettingSection] = useState<
-    "account" | "billing" | "profile" | null
+    "account" | "billing" | "profile" | "persona" | null
   >(null);
   const [paymentNotice, setPaymentNotice] = useState<{
     type: "cancelled" | "success";
@@ -328,7 +331,11 @@ export default function ProfilePage() {
       ? "bg-green-100 text-green-800"
       : billingStatus === "past_due"
         ? "bg-amber-100 text-amber-800"
-        : "bg-gray-100 text-gray-700";
+      : "bg-gray-100 text-gray-700";
+  const personaLabel =
+    categoryDefinition && definition
+      ? `${categoryDefinition.label} · ${definition.label}`
+      : "Not set";
 
   if (isLoading) {
     return (
@@ -615,6 +622,12 @@ export default function ProfilePage() {
                     {user?.email || "N/A"}
                   </span>
                 </div>
+                <div className="flex justify-between items-center gap-4 py-3 border-t">
+                  <span className="text-gray-600">Persona</span>
+                  <span className="text-right font-medium text-gray-900">
+                    {personaLabel}
+                  </span>
+                </div>
                 <div className="flex justify-between items-center py-3 border-t">
                   <span className="text-gray-600">Account Status</span>
                   <span className="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-800">
@@ -798,6 +811,42 @@ export default function ProfilePage() {
                           </p>
                         </button>
                       </div>
+                    </div>
+                  )}
+                </div>
+
+                <div className="border border-[#143E6F]/20 rounded-xl">
+                  <button
+                    onClick={() =>
+                      setActiveSettingSection((prev) =>
+                        prev === "persona" ? null : "persona",
+                      )
+                    }
+                    className="w-full px-5 py-4 flex items-center justify-between text-left"
+                  >
+                    <div>
+                      <h4 className="text-lg font-semibold text-[#143E6F]">
+                        Persona
+                      </h4>
+                      <p className="mt-1 text-sm text-gray-500">
+                        Current selection: {personaLabel}
+                      </p>
+                    </div>
+                    <span className="text-[#143E6F]">
+                      {activeSettingSection === "persona" ? "-" : "+"}
+                    </span>
+                  </button>
+                  {activeSettingSection === "persona" && (
+                    <div className="border-t border-[#143E6F]/10 p-5">
+                      <PersonaPicker
+                        heading="Change your Quizwerk persona"
+                        initialCategory={persona?.category ?? null}
+                        source="profile"
+                        onPicked={() => {
+                          toast.success("Persona updated successfully.");
+                          setActiveSettingSection(null);
+                        }}
+                      />
                     </div>
                   )}
                 </div>

--- a/client/src/features/quiz/components/QuizForm.tsx
+++ b/client/src/features/quiz/components/QuizForm.tsx
@@ -15,7 +15,8 @@ import { api } from "@shared/api/http";
 import publicApi from "@shared/api/publicHttp";
 import { saveQuizToHistory } from "@features/quiz-history/api/saveQuizToHistoryApi";
 import PersonaBadge from "@features/persona/components/PersonaBadge";
-import { parsePersona } from "@shared/config/persona";
+import { usePersona } from "@features/persona/context/personaContext";
+import { readStoredPersonaTopic } from "@features/persona/lib/personaStorage";
 
 type ApiErrorLike = {
   response?: {
@@ -122,22 +123,19 @@ export default function QuizForm() {
     );
   };
 
-  // Persona entry points land here as ?persona=&category=&topic=.
-  // parsePersona also accepts the pre-slug labels that shipped in earlier
-  // links (e.g. ?persona=HR%20personnel), so old bookmarks keep working.
+  // PersonaProvider resolves profile > URL query > localStorage, so persona
+  // entry points and post-auth carry-through use the same app-wide rule.
   const searchParams = useSearchParams();
-  const persona = parsePersona(
-    searchParams?.get("category"),
-    searchParams?.get("persona"),
-  );
+  const { persona } = usePersona();
 
   useEffect(() => {
-    const personaTopic = searchParams?.get("topic");
+    const personaTopic =
+      searchParams?.get("topic") || readStoredPersonaTopic(persona);
     if (personaTopic) {
       setGenerationMode("topic");
       setProfession((current) => current || personaTopic);
     }
-  }, [searchParams]);
+  }, [persona, searchParams]);
 
   useEffect(() => {
     if (user === undefined) return;

--- a/server/app/users/models.py
+++ b/server/app/users/models.py
@@ -210,6 +210,21 @@ class UpdateProfileRequest(BaseModel):
         return v
 
 
+class UpdatePersonaRequest(BaseModel):
+    persona_category: str
+    persona_user_type: str
+    source: Literal["onboarding", "profile", "inferred"] = "profile"
+
+    @model_validator(mode="after")
+    def validate_persona(self):
+        if not persona_pair_is_valid(self.persona_category, self.persona_user_type):
+            raise ValueError(
+                "persona_user_type must belong to persona_category, "
+                "and both must be provided together"
+            )
+        return self
+
+
 class UpdateProfileResponse(BaseModel):
     message: str
     user: UserOut

--- a/server/app/users/models.py
+++ b/server/app/users/models.py
@@ -217,6 +217,10 @@ class UpdatePersonaRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_persona(self):
+        if not self.persona_category.strip() or not self.persona_user_type.strip():
+            raise ValueError(
+                "persona_category and persona_user_type must be non-empty strings"
+            )
         if not persona_pair_is_valid(self.persona_category, self.persona_user_type):
             raise ValueError(
                 "persona_user_type must belong to persona_category, "

--- a/server/app/users/routes.py
+++ b/server/app/users/routes.py
@@ -5,7 +5,12 @@ from server.app.core.dependencies import get_current_user, get_verified_user
 from server.app.core.rate_limiter import RateLimits, limiter
 from server.app.email_platform.deps import get_email_service
 from server.app.email_platform.service import EmailService
-from server.app.users.models import UpdateProfileRequest, UpdateProfileResponse, UserOut
+from server.app.users.models import (
+    UpdatePersonaRequest,
+    UpdateProfileRequest,
+    UpdateProfileResponse,
+    UserOut,
+)
 from server.app.users.schemas import (
     EmailChangeRequest,
     EmailChangeVerifyRequest,
@@ -14,6 +19,7 @@ from server.app.users.schemas import (
 from server.app.users.services import (
     delete_account_service,
     get_user_profile_service,
+    update_user_persona_service,
     request_email_change_service,
     update_user_profile_service,
     verify_email_change_service,
@@ -62,6 +68,21 @@ async def update_profile(
 ):
     return await update_user_profile_service(
         profile_data,
+        current_user,
+        request.app.state.users_collection,
+    )
+
+
+@router.put("/auth/profile/persona", response_model=UpdateProfileResponse)
+@limiter.limit(RateLimits.API_WRITE)
+async def update_persona(
+    request: Request,
+    response: Response,
+    persona_data: UpdatePersonaRequest,
+    current_user: UserOut = Depends(get_current_user),
+):
+    return await update_user_persona_service(
+        persona_data,
         current_user,
         request.app.state.users_collection,
     )

--- a/server/app/users/services.py
+++ b/server/app/users/services.py
@@ -10,7 +10,12 @@ from server.app.db.core.connection import get_auth_events_collection, get_user_s
 from server.app.db.core.redis import get_redis_client
 from server.app.email_platform.service import EmailService
 from server.app.users.identity import normalize_email, now_utc
-from server.app.users.models import UpdateProfileRequest, UpdateProfileResponse, UserOut
+from server.app.users.models import (
+    UpdatePersonaRequest,
+    UpdateProfileRequest,
+    UpdateProfileResponse,
+    UserOut,
+)
 from server.app.users.persona import persona_update_fields
 from server.app.users.repository import (
     build_user_out_payload,
@@ -106,6 +111,64 @@ async def update_user_profile_service(
 
     return UpdateProfileResponse(
         message="Profile updated successfully",
+        user=UserOut(
+            **{
+                **build_user_out_payload(updated_user),
+                "created_at": created_at,
+                "updated_at": updated_at_value,
+            }
+        ),
+    )
+
+
+async def update_user_persona_service(
+    persona_data: UpdatePersonaRequest,
+    current_user: UserOut,
+    users_collection: AsyncIOMotorCollection,
+) -> UpdateProfileResponse:
+    update_data = persona_update_fields(
+        persona_data.persona_category,
+        persona_data.persona_user_type,
+        source=persona_data.source,
+    )
+    update_data["updated_at"] = now_utc()
+
+    try:
+        user_object_id = ObjectId(current_user.id)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid user ID format: {str(exc)}",
+        ) from exc
+
+    result = await users_collection.update_one(
+        {"_id": user_object_id, "status": {"$ne": "deleted"}},
+        {"$set": update_data},
+    )
+    if result.modified_count == 0:
+        user_exists = await users_collection.find_one(
+            {"_id": user_object_id, "status": {"$ne": "deleted"}}
+        )
+        if not user_exists:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    updated_user = await users_collection.find_one({"_id": user_object_id})
+    if not updated_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found after update",
+        )
+
+    created_at = updated_user.get("created_at")
+    if isinstance(created_at, datetime):
+        created_at = created_at.isoformat()
+
+    updated_at_value = updated_user.get("updated_at")
+    if isinstance(updated_at_value, datetime):
+        updated_at_value = updated_at_value.isoformat()
+
+    return UpdateProfileResponse(
+        message="Persona updated successfully",
         user=UserOut(
             **{
                 **build_user_out_payload(updated_user),

--- a/server/app/users/services.py
+++ b/server/app/users/services.py
@@ -94,7 +94,9 @@ async def update_user_profile_service(
         if not user_exists:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    updated_user = await users_collection.find_one({"_id": user_object_id})
+    updated_user = await users_collection.find_one(
+        {"_id": user_object_id, "status": {"$ne": "deleted"}}
+    )
     if not updated_user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -152,7 +154,9 @@ async def update_user_persona_service(
         if not user_exists:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    updated_user = await users_collection.find_one({"_id": user_object_id})
+    updated_user = await users_collection.find_one(
+        {"_id": user_object_id, "status": {"$ne": "deleted"}}
+    )
     if not updated_user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/server/tests/test_progressive_email_verification.py
+++ b/server/tests/test_progressive_email_verification.py
@@ -10,7 +10,7 @@ from server.app.auth import routes as auth_routes
 from server.app.auth.services import login_service
 from server.app.users import routes as user_routes
 from server.app.users.models import UserOut
-from server.app.core.dependencies import get_verified_user
+from server.app.core.dependencies import get_current_user, get_verified_user
 from server.app.quiz.models.quiz_models import QuizRequest
 from server.app.quiz.routes.generation import get_quiz
 from server.app.quiz.routes.downloads import download_quiz_handler, limiter
@@ -132,6 +132,14 @@ def test_sensitive_auth_routes_require_verified_user():
     _assert_uses_verified_dependency(user_routes.update_profile)
     _assert_uses_verified_dependency(user_routes.request_email_change)
     _assert_uses_verified_dependency(user_routes.verify_email_change)
+
+
+def test_persona_update_requires_authentication_but_not_verification():
+    dependency = inspect.signature(user_routes.update_persona).parameters[
+        "current_user"
+    ].default
+    assert isinstance(dependency, Depends)
+    assert dependency.dependency is get_current_user
 
 
 def test_login_password_reset_and_verification_routes_do_not_require_verified_user():

--- a/server/tests/test_progressive_email_verification.py
+++ b/server/tests/test_progressive_email_verification.py
@@ -9,7 +9,7 @@ from fastapi.params import Depends
 from server.app.auth import routes as auth_routes
 from server.app.auth.services import login_service
 from server.app.users import routes as user_routes
-from server.app.users.models import UserOut
+from server.app.users.models import UpdatePersonaRequest, UserOut
 from server.app.core.dependencies import get_current_user, get_verified_user
 from server.app.quiz.models.quiz_models import QuizRequest
 from server.app.quiz.routes.generation import get_quiz
@@ -42,6 +42,20 @@ def _assert_uses_verified_dependency(endpoint, parameter_name: str = "current_us
     dependency = inspect.signature(endpoint).parameters[parameter_name].default
     assert isinstance(dependency, Depends)
     assert dependency.dependency is get_verified_user
+
+
+def _request_with_users_collection(users_collection):
+    return type(
+        "Request",
+        (),
+        {
+            "app": type(
+                "App",
+                (),
+                {"state": type("State", (), {"users_collection": users_collection})()},
+            )()
+        },
+    )()
 
 
 @pytest.mark.asyncio
@@ -140,6 +154,98 @@ def test_persona_update_requires_authentication_but_not_verification():
     ].default
     assert isinstance(dependency, Depends)
     assert dependency.dependency is get_current_user
+
+
+@pytest.mark.asyncio
+async def test_persona_update_route_allows_unverified_authenticated_user():
+    user_id = ObjectId()
+    users_collection = AsyncMock()
+    users_collection.update_one.return_value = AsyncMock(modified_count=1)
+    users_collection.find_one.return_value = {
+        "_id": user_id,
+        "username": "unverified",
+        "email": "unverified@example.com",
+        "is_verified": False,
+        "is_active": True,
+        "status": "pending_verification",
+        "profile": {
+            "persona": {
+                "category": "school",
+                "user_type": "teacher",
+                "source": "onboarding",
+            }
+        },
+    }
+
+    result = await user_routes.update_persona(
+        _request_with_users_collection(users_collection),
+        Response(),
+        UpdatePersonaRequest(
+            persona_category="school",
+            persona_user_type="teacher",
+            source="onboarding",
+        ),
+        current_user=UserOut(
+            id=str(user_id),
+            username="unverified",
+            email="unverified@example.com",
+            is_verified=False,
+            is_active=True,
+            status="pending_verification",
+        ),
+    )
+
+    assert result.message == "Persona updated successfully"
+    assert result.user.persona_category == "school"
+    assert result.user.persona_user_type == "teacher"
+    users_collection.update_one.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_persona_update_route_returns_400_for_invalid_current_user_id():
+    users_collection = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await user_routes.update_persona(
+            _request_with_users_collection(users_collection),
+            Response(),
+            UpdatePersonaRequest(
+                persona_category="school",
+                persona_user_type="teacher",
+            ),
+            current_user=UserOut(
+                id="not-an-object-id",
+                username="user",
+                email="user@example.com",
+            ),
+        )
+
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_persona_update_route_returns_404_for_deleted_or_missing_user():
+    user_id = ObjectId()
+    users_collection = AsyncMock()
+    users_collection.update_one.return_value = AsyncMock(modified_count=0)
+    users_collection.find_one.return_value = None
+
+    with pytest.raises(HTTPException) as exc:
+        await user_routes.update_persona(
+            _request_with_users_collection(users_collection),
+            Response(),
+            UpdatePersonaRequest(
+                persona_category="school",
+                persona_user_type="teacher",
+            ),
+            current_user=UserOut(
+                id=str(user_id),
+                username="user",
+                email="user@example.com",
+            ),
+        )
+
+    assert exc.value.status_code == 404
 
 
 def test_login_password_reset_and_verification_routes_do_not_require_verified_user():

--- a/server/tests/test_user_persona.py
+++ b/server/tests/test_user_persona.py
@@ -5,7 +5,7 @@ import pytest
 from bson import ObjectId
 from pydantic import ValidationError
 
-from server.app.users.models import UpdateProfileRequest, UserPersona
+from server.app.users.models import UpdatePersonaRequest, UpdateProfileRequest, UserPersona
 from server.app.users.persona import (
     PERSONA_CATEGORIES,
     PERSONA_USER_TYPES,
@@ -18,7 +18,10 @@ from server.app.users.persona import (
     persona_update_fields,
 )
 from server.app.users.repository import build_user_out_payload
-from server.app.users.services import update_user_profile_service
+from server.app.users.services import (
+    update_user_persona_service,
+    update_user_profile_service,
+)
 
 
 def _user_doc(**overrides):
@@ -146,6 +149,34 @@ class TestUpdateProfileRequest:
             UpdateProfileRequest(persona_user_type="teacher")
 
 
+class TestUpdatePersonaRequest:
+    def test_accepts_valid_pair_and_source(self):
+        request = UpdatePersonaRequest(
+            persona_category="school",
+            persona_user_type="teacher",
+            source="onboarding",
+        )
+
+        assert request.persona_category == "school"
+        assert request.persona_user_type == "teacher"
+        assert request.source == "onboarding"
+
+    def test_rejects_mismatched_pair(self):
+        with pytest.raises(ValidationError):
+            UpdatePersonaRequest(
+                persona_category="corporate",
+                persona_user_type="teacher",
+            )
+
+    def test_rejects_unknown_source(self):
+        with pytest.raises(ValidationError):
+            UpdatePersonaRequest(
+                persona_category="school",
+                persona_user_type="teacher",
+                source="signup",
+            )
+
+
 class TestUserPersonaModel:
     def test_rejects_user_type_outside_category(self):
         with pytest.raises(ValidationError):
@@ -210,3 +241,46 @@ class TestUpdateProfileService:
         update_doc = collection.update_one.await_args.args[1]["$set"]
         assert not any(key.startswith("profile.persona") for key in update_doc)
         assert update_doc["profile.full_name"] == "Ada"
+
+
+class TestUpdatePersonaService:
+    @pytest.mark.asyncio
+    async def test_persists_only_persona_fields_for_authenticated_user(self):
+        user_id = ObjectId()
+        stored = _user_doc(
+            _id=user_id,
+            profile={
+                "persona": {
+                    "category": "corporate",
+                    "user_type": "employee",
+                }
+            },
+        )
+        collection = AsyncMock()
+        collection.update_one.return_value = AsyncMock(modified_count=1)
+        collection.find_one.return_value = stored
+
+        current_user = type("CurrentUser", (), {"id": str(user_id)})()
+
+        await update_user_persona_service(
+            UpdatePersonaRequest(
+                persona_category="corporate",
+                persona_user_type="employee",
+                source="inferred",
+            ),
+            current_user,
+            collection,
+        )
+
+        update_doc = collection.update_one.await_args.args[1]["$set"]
+        assert set(update_doc) == {
+            "profile.persona.category",
+            "profile.persona.user_type",
+            "profile.persona.source",
+            "profile.persona.set_at",
+            "updated_at",
+        }
+        assert update_doc["profile.persona.category"] == "corporate"
+        assert update_doc["profile.persona.user_type"] == "employee"
+        assert update_doc["profile.persona.source"] == "inferred"
+        assert isinstance(update_doc["profile.persona.set_at"], datetime)

--- a/server/tests/test_user_persona.py
+++ b/server/tests/test_user_persona.py
@@ -224,6 +224,10 @@ class TestUpdateProfileService:
         assert update_doc["profile.persona.category"] == "corporate"
         assert update_doc["profile.persona.user_type"] == "hr"
         assert "updated_at" in update_doc
+        assert collection.find_one.await_args.args[0] == {
+            "_id": user_id,
+            "status": {"$ne": "deleted"},
+        }
 
     @pytest.mark.asyncio
     async def test_leaves_persona_untouched_when_not_supplied(self):
@@ -284,3 +288,29 @@ class TestUpdatePersonaService:
         assert update_doc["profile.persona.user_type"] == "employee"
         assert update_doc["profile.persona.source"] == "inferred"
         assert isinstance(update_doc["profile.persona.set_at"], datetime)
+        assert collection.find_one.await_args.args[0] == {
+            "_id": user_id,
+            "status": {"$ne": "deleted"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_treats_deleted_user_between_update_and_fetch_as_not_found(self):
+        user_id = ObjectId()
+        collection = AsyncMock()
+        collection.update_one.return_value = AsyncMock(modified_count=1)
+        collection.find_one.return_value = None
+
+        current_user = type("CurrentUser", (), {"id": str(user_id)})()
+
+        with pytest.raises(Exception) as exc:
+            await update_user_persona_service(
+                UpdatePersonaRequest(
+                    persona_category="school",
+                    persona_user_type="teacher",
+                ),
+                current_user,
+                collection,
+            )
+
+        assert exc.value.status_code == 404
+        assert exc.value.detail == "User not found after update"

--- a/server/tests/test_user_persona.py
+++ b/server/tests/test_user_persona.py
@@ -168,6 +168,20 @@ class TestUpdatePersonaRequest:
                 persona_user_type="teacher",
             )
 
+    def test_rejects_empty_strings(self):
+        with pytest.raises(ValidationError):
+            UpdatePersonaRequest(
+                persona_category="",
+                persona_user_type="",
+            )
+
+    def test_rejects_blank_strings(self):
+        with pytest.raises(ValidationError):
+            UpdatePersonaRequest(
+                persona_category="   ",
+                persona_user_type="teacher",
+            )
+
     def test_rejects_unknown_source(self):
         with pytest.raises(ValidationError):
             UpdatePersonaRequest(


### PR DESCRIPTION
## Summary

Implements the remaining persona foundation issues:

Closes #120
Closes #121
Closes #122

This builds on the existing #119 profile persona scaffolding by making persona usable end-to-end across onboarding, guest deep-links, authenticated sessions, quiz generation, and profile settings.

## What Changed

- Added a global `PersonaOnboardingGate` that prompts authenticated users without a saved persona to choose their category and user type.
- Added skippable onboarding, scoped per user, so users can defer persona setup without being repeatedly blocked.
- Preserved persona deep-link state from URLs like `/generate?persona=&category=&topic=` through guest and auth flows.
- Added automatic persistence of carried guest/query persona after login using an `inferred` source.
- Added persona editing to Profile Settings using the same shared two-step `PersonaPicker`.
- Updated quiz generation to resolve persona from profile, query, or guest storage instead of only reading the URL.
- Added a dedicated `PUT /auth/profile/persona` endpoint so authenticated unverified users can save persona without unlocking full profile edits.
- Kept full profile updates behind verified-user access.
- Fixed persona localStorage behavior so authenticated profile persona does not leak after logout.
- Fixed SSR hydration risk by avoiding localStorage reads during initial render.
- Fixed guest persona deep-link navigation staleness by making query-persona persistence idempotent.

## Security / Policy Notes

- Persona updates are authenticated-only when persisted to the backend.
- Persona values are validated against the allowed taxonomy on both client and server.
- Full profile updates still require verified users.
- The persona-only endpoint only updates `profile.persona.*` and `updated_at`, limiting write scope.
- Guest persona remains local-only until login.
- Existing saved profile persona takes precedence over guest/query persona and is not silently overwritten.

## Testing

- `cd client && pnpm lint`
- `cd client && pnpm exec tsc --noEmit`
- `cd client && pnpm test -- --runTestsByPath __tests__/PersonaProvider.test.tsx __tests__/resolvePersona.test.ts __tests__/PersonaOnboardingGate.test.tsx __tests__/QuizForm.test.tsx __tests__/QuizwerkHomePage.test.tsx`
- `cd server && pipenv run pytest -q tests/test_user_persona.py tests/test_persona_taxonomy.py tests/test_progressive_email_verification.py`

## How To Test

1. Start the app and log in with a user that has no saved persona.
2. Confirm the persona onboarding modal appears on a non-auth page.
3. Select `School -> Teacher` and confirm it saves, closes, and does not appear again after refresh.
4. Log out and confirm the selected profile persona does not remain visible as a guest persona.
5. Visit a persona deep-link as a guest, for example:
   `/generate?persona=teacher&category=school&topic=Photosynthesis`
6. Confirm the quiz generation form shows the carried guest persona/topic.
7. From that guest deep-link page, click `Quizwerk` or `Home` and confirm the landing page renders immediately.
8. Log in with a user that has no saved persona and confirm the carried persona is saved to the profile without reopening the picker.
9. Log in with a user that already has a saved persona and confirm the saved profile persona wins over any carried guest persona.
10. Go to Profile Settings, open the Persona section, change the persona, and confirm the change persists after refresh/navigation.
11. Test with an unverified user: persona save should work, but full profile edits should still require verification.

Also verified:
- No persona onboarding when profile persona already exists.
- Skipped onboarding does not keep reopening for the same user.
- Guest persona survives deep-link flow.
- Carried persona is persisted after login.
- Logging out after setting profile persona does not leave stale persona in localStorage.
- Guest persona query persistence is idempotent and does not cause stale client navigation.