### PR TITLE
Feature/category dashboard shells

### DIFF
--- a/PERSONA_SCAFFOLDING.md
+++ b/PERSONA_SCAFFOLDING.md
@@ -21,7 +21,7 @@ profile.persona {category, user_type}      ← server/app/users/persona.py
         ▼
 usePersona()                                ← features/persona/context
         │  profile > ?persona= > localStorage > none
-        ├──► useTerms()   "students" vs "employees"
+        ├──► useTerms()   "students" vs "team members"
         └──► /dashboard   category dispatch → user-type view
 ```
 
@@ -58,8 +58,9 @@ usePersona()                                ← features/persona/context
 | Issue | Story | Landed as |
 |---|---|---|
 | #119 | Persona on the user profile | `server/app/users/{persona,models,repository,services,validators,identity}.py` |
-| #123 | Terminology + nav shell | `shared/config/terminology.ts`, `features/quiz/components/NavBar.tsx` |
+| #123 | Terminology + nav shell | `shared/config/terminology.ts`, `features/quiz/components/{NavBar,Sidebar,Footer}.tsx` |
 | #124 | School dashboard shell | `features/dashboard/school/SchoolDashboard.tsx` |
+| #125 | Corporate dashboard shell | `features/dashboard/corporate/CorporateDashboard.tsx` |
 
 ### Ready to pick up
 
@@ -68,7 +69,6 @@ usePersona()                                ← features/persona/context
 | #120 | Onboarding picker after signup | new `features/auth` wiring | `PersonaPicker` is built — you own where/when it appears and the show-once rule |
 | #121 | Carry home persona through signup | `features/auth/components/SignUpModal.tsx` | Storage + query resolution already exist; carry the value across the auth hop |
 | #122 | Edit persona in settings | `features/profile/pages/ProfilePage.tsx` | Drop in `PersonaPicker`, save via `updatePersona` |
-| #125 | Corporate dashboard shell | `features/dashboard/corporate/CorporateDashboard.tsx` | Mirror `SchoolDashboard.tsx` |
 | #126 | Teacher view | `features/dashboard/school/views/TeacherDashboard.tsx` | |
 | #127 | Lecturer view | `features/dashboard/school/views/LecturerDashboard.tsx` | |
 | #128 | Student view | `features/dashboard/school/views/StudentDashboard.tsx` | Blocked on #143 for scored history |

--- a/client/__tests__/DashboardPage.test.tsx
+++ b/client/__tests__/DashboardPage.test.tsx
@@ -48,6 +48,11 @@ jest.mock("@features/quiz-history/api/quizHistoryApi", () => ({
   getUserQuizHistory: jest.fn().mockResolvedValue([]),
 }));
 
+jest.mock("@features/dashboard/components/RecentQuizzes", () => ({
+  __esModule: true,
+  default: ({ heading }: { heading: string }) => <section>{heading}</section>,
+}));
+
 jest.mock("@features/persona/components/PersonaPicker", () => ({
   __esModule: true,
   default: () => <div>persona-picker</div>,
@@ -94,7 +99,27 @@ describe("DashboardPage dispatch", () => {
 
     render(<DashboardPage />);
 
-    expect(screen.getByText("Welcome back, Casey")).toBeInTheDocument();
-    expect(screen.getByText(/New homework/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Welcome back, Casey\. Plan your next class quiz\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText("New class quiz")).toBeInTheDocument();
+    expect(screen.getByText("Join live class quiz")).toBeInTheDocument();
+    expect(screen.getByText("Revision practice")).toBeInTheDocument();
+  });
+
+  test("corporate dashboard uses training actions and employee-aware copy", () => {
+    mockPersona = { category: "corporate", userType: "employee" };
+
+    render(<DashboardPage />);
+
+    expect(
+      screen.getByText(/Welcome back, Casey\. Keep your learning moving\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText("New training quiz")).toBeInTheDocument();
+    expect(screen.getByText("Run live training session")).toBeInTheDocument();
+    expect(screen.getByText("Assigned to me")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /assigned to me/i }),
+    ).toBeDisabled();
   });
 });

--- a/client/__tests__/NavBar.test.ts
+++ b/client/__tests__/NavBar.test.ts
@@ -1,0 +1,11 @@
+import { navigationItems } from "@features/quiz/components/NavBar";
+
+describe("navigationItems", () => {
+  test("keeps quiz creation as the dedicated navigation CTA", () => {
+    const items = navigationItems();
+
+    expect(items).not.toContainEqual(
+      expect.objectContaining({ href: "/generate" }),
+    );
+  });
+});

--- a/client/__tests__/PersonaProvider.test.tsx
+++ b/client/__tests__/PersonaProvider.test.tsx
@@ -1,0 +1,185 @@
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import {
+  PersonaProvider,
+  usePersona,
+} from "@features/persona/context/personaContext";
+import { updatePersona } from "@features/persona/api/personaApi";
+
+const authState: {
+  user: any;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  refreshUser: jest.Mock;
+} = {
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  refreshUser: jest.fn(),
+};
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ query: {} }),
+}));
+
+jest.mock("@features/auth/context/authContext", () => ({
+  useAuth: () => authState,
+}));
+
+jest.mock("@features/persona/api/personaApi", () => ({
+  updatePersona: jest.fn(),
+}));
+
+function Probe() {
+  const { persona, source, isLoading, setPersona } = usePersona();
+  return (
+    <>
+      <output data-testid="persona">
+        {persona ? `${persona.category}:${persona.userType}:${source}` : "none"}
+      </output>
+      <output data-testid="loading">{String(isLoading)}</output>
+      <button
+        type="button"
+        onClick={() => {
+          void setPersona({ category: "school", userType: "teacher" }).catch(
+            () => undefined,
+          );
+        }}
+      >
+        Set teacher
+      </button>
+    </>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <PersonaProvider>
+      <Probe />
+    </PersonaProvider>,
+  );
+}
+
+describe("PersonaProvider", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    authState.user = null;
+    authState.isAuthenticated = false;
+    authState.isLoading = false;
+    authState.refreshUser.mockReset();
+    jest.mocked(updatePersona).mockReset();
+  });
+
+  test("does not read browser storage during server rendering", () => {
+    window.localStorage.setItem(
+      "quizwerk.persona",
+      JSON.stringify({ v: 1, category: "school", userType: "teacher" }),
+    );
+
+    const html = renderToString(
+      <PersonaProvider>
+        <Probe />
+      </PersonaProvider>,
+    );
+
+    // Server markup must stay neutral even when a browser preference exists.
+    // The client only reads storage from useEffect after hydration.
+    expect(html).toContain("none");
+  });
+
+  test("hydrates a guest persona after mount", async () => {
+    window.localStorage.setItem(
+      "quizwerk.persona",
+      JSON.stringify({ v: 1, category: "school", userType: "teacher" }),
+    );
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona")).toHaveTextContent(
+        "school:teacher:storage",
+      );
+    });
+  });
+
+  test("does not use guest storage as an authenticated fallback", async () => {
+    window.localStorage.setItem(
+      "quizwerk.persona",
+      JSON.stringify({ v: 1, category: "school", userType: "teacher" }),
+    );
+    authState.user = {
+      id: "user-b",
+      username: "b",
+      email: "b@example.com",
+      is_verified: false,
+    };
+    authState.isAuthenticated = true;
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona")).toHaveTextContent("none");
+    });
+  });
+
+  test("does not create local persona state when authenticated persistence fails", async () => {
+    authState.user = {
+      id: "user-a",
+      username: "a",
+      email: "a@example.com",
+      is_verified: false,
+    };
+    authState.isAuthenticated = true;
+    jest.mocked(updatePersona).mockRejectedValueOnce(new Error("network"));
+
+    renderProvider();
+
+    await act(async () => {
+      screen.getByRole("button", { name: "Set teacher" }).click();
+    });
+
+    expect(updatePersona).toHaveBeenCalledWith({
+      category: "school",
+      userType: "teacher",
+    });
+    expect(window.localStorage.getItem("quizwerk.persona")).toBeNull();
+    expect(screen.getByTestId("persona")).toHaveTextContent("none");
+  });
+
+  test("clears guest storage after an authenticated session ends", async () => {
+    window.localStorage.setItem(
+      "quizwerk.persona",
+      JSON.stringify({ v: 1, category: "school", userType: "teacher" }),
+    );
+    authState.user = {
+      id: "user-a",
+      username: "a",
+      email: "a@example.com",
+      is_verified: true,
+      persona_category: "corporate",
+      persona_user_type: "employee",
+    };
+    authState.isAuthenticated = true;
+
+    const view = renderProvider();
+    await waitFor(() => {
+      expect(screen.getByTestId("persona")).toHaveTextContent(
+        "corporate:employee:profile",
+      );
+    });
+
+    authState.user = null;
+    authState.isAuthenticated = false;
+    view.rerender(
+      <PersonaProvider>
+        <Probe />
+      </PersonaProvider>,
+    );
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem("quizwerk.persona")).toBeNull();
+      expect(screen.getByTestId("persona")).toHaveTextContent("none");
+    });
+  });
+});

--- a/client/__tests__/QuizForm.test.tsx
+++ b/client/__tests__/QuizForm.test.tsx
@@ -93,5 +93,10 @@ describe("QuizForm", () => {
         expect.stringContaining("/quiz_display?"),
       );
     });
+
+    expect(publicApi.post).toHaveBeenCalledWith(
+      "/api/get-questions",
+      expect.objectContaining({ audience_type: "learners" }),
+    );
   });
 });

--- a/client/__tests__/RecentQuizzes.test.tsx
+++ b/client/__tests__/RecentQuizzes.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import RecentQuizzes from "@features/dashboard/components/RecentQuizzes";
+import { getUserQuizHistory } from "@features/quiz-history/api/quizHistoryApi";
+
+const authState: { user: { is_verified: boolean } | null } = {
+  user: null,
+};
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@features/auth/context/authContext", () => ({
+  useAuth: () => authState,
+}));
+
+jest.mock("@features/quiz-history/api/quizHistoryApi", () => ({
+  getUserQuizHistory: jest.fn(),
+}));
+
+describe("RecentQuizzes", () => {
+  beforeEach(() => {
+    authState.user = null;
+    jest.mocked(getUserQuizHistory).mockReset();
+  });
+
+  test("does not request verified-only history for an unverified user", async () => {
+    authState.user = { is_verified: false };
+    render(<RecentQuizzes heading="Recent activity" emptyMessage="Empty" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Verify your email to view recent activity."),
+      ).toBeInTheDocument();
+    });
+    expect(getUserQuizHistory).not.toHaveBeenCalled();
+  });
+
+  test("shows the persona-specific empty state for a verified user", async () => {
+    authState.user = { is_verified: true };
+    jest.mocked(getUserQuizHistory).mockResolvedValueOnce([]);
+    render(<RecentQuizzes heading="Recent activity" emptyMessage="Empty" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Empty")).toBeInTheDocument();
+    });
+  });
+});

--- a/client/__tests__/SignInModal.test.tsx
+++ b/client/__tests__/SignInModal.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import SignInModal from "@features/auth/components/SignInModal";
+import { ROUTES } from "@shared/config/patterns/routes";
 
 const mockRouterPush = jest.fn();
 const mockAuthLogin = jest.fn();
@@ -119,6 +120,30 @@ describe("SignInModal", () => {
 
     await waitFor(() => {
       expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("routes to the configured post-login destination", async () => {
+    render(
+      <SignInModal
+        isOpen={true}
+        onClose={mockOnClose}
+        redirectTo={ROUTES.DASHBOARD}
+        switchToSignUp={mockSwitchToSignUp}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText("email@example.com or username"),
+      { target: { value: "testuser@example.com" } },
+    );
+    fireEvent.change(screen.getByPlaceholderText("Enter your password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith(ROUTES.DASHBOARD);
     });
   });
 

--- a/client/__tests__/terminology.test.ts
+++ b/client/__tests__/terminology.test.ts
@@ -4,6 +4,9 @@ describe("resolveTerm", () => {
   test("falls back to neutral wording when persona is unset", () => {
     expect(resolveTerm("learner", null, "plural")).toBe("learners");
     expect(resolveTerm("group", null)).toBe("group");
+    expect(resolveTerm("quiz", null)).toBe("quiz");
+    expect(resolveTerm("live_quiz", null)).toBe("live quiz");
+    expect(resolveTerm("session", null)).toBe("session");
   });
 
   test("uses category wording", () => {
@@ -12,8 +15,14 @@ describe("resolveTerm", () => {
 
     expect(resolveTerm("learner", teacher, "plural")).toBe("students");
     expect(resolveTerm("group", teacher)).toBe("class");
-    expect(resolveTerm("learner", business, "plural")).toBe("employees");
+    expect(resolveTerm("quiz", teacher)).toBe("class quiz");
+    expect(resolveTerm("live_quiz", teacher)).toBe("live class quiz");
+    expect(resolveTerm("session", teacher)).toBe("class quiz");
+    expect(resolveTerm("learner", business, "plural")).toBe("team members");
     expect(resolveTerm("group", business)).toBe("team");
+    expect(resolveTerm("quiz", business)).toBe("training quiz");
+    expect(resolveTerm("live_quiz", business)).toBe("live training session");
+    expect(resolveTerm("session", business)).toBe("training session");
   });
 
   test("user-type overrides beat the category", () => {
@@ -29,6 +38,7 @@ describe("resolveTerm", () => {
 
     // lecturer overrides group/session but not learner
     expect(resolveTerm("learner", lecturer, "plural")).toBe("students");
+    expect(resolveTerm("live_quiz", lecturer)).toBe("live class quiz");
   });
 
   test("reports differ per category", () => {

--- a/client/jest.setup.ts
+++ b/client/jest.setup.ts
@@ -1,1 +1,4 @@
 import '@testing-library/jest-dom'
+import { TextDecoder, TextEncoder } from "util";
+
+Object.assign(global, { TextDecoder, TextEncoder });

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -62,7 +62,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         <SignInModal
           isOpen={showSignInModal}
           onClose={closeSignInModal}
-          redirectTo={ROUTES.HOME}
+          redirectTo={ROUTES.DASHBOARD}
           switchToSignUp={() => {
             closeSignInModal();
             router.push(ROUTES.REGISTER);

--- a/client/src/features/auth/pages/LoginPage.tsx
+++ b/client/src/features/auth/pages/LoginPage.tsx
@@ -34,7 +34,7 @@ export default function LoginPage() {
       <SignInModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        redirectTo={ROUTES.HOME}
+        redirectTo={ROUTES.DASHBOARD}
         switchToSignUp={() => {
           setIsModalOpen(false);
           router.push(ROUTES.REGISTER);

--- a/client/src/features/auth/pages/RegisterPage.tsx
+++ b/client/src/features/auth/pages/RegisterPage.tsx
@@ -31,7 +31,7 @@ const RegisterPage: React.FC = () => {
       <SignInModal
         isOpen={showLogin}
         onClose={() => setShowLogin(false)}
-        redirectTo={ROUTES.HOME}
+        redirectTo={ROUTES.DASHBOARD}
         switchToSignUp={() => {
           setShowLogin(false);
           setShowSignUp(true);

--- a/client/src/features/dashboard/README.md
+++ b/client/src/features/dashboard/README.md
@@ -7,7 +7,7 @@ dashboard, which dispatches to a **user-type** view.
 pages/DashboardPage.tsx        [SCAFFOLD-OWNED]  auth + persona gate + category dispatch
   school/SchoolDashboard.tsx   #124 (done)       category chrome + user-type dispatch map
     school/views/*.tsx         one ticket each   #126 #127 #128 #129
-  corporate/CorporateDashboard.tsx  #125         mirror SchoolDashboard
+  corporate/CorporateDashboard.tsx  #125 (done)  category chrome + user-type dispatch map
     corporate/views/*.tsx      one ticket each   #130 #131 #132
 components/                    [SCAFFOLD-OWNED]  DashboardShell, QuickActions,
                                                  RecentQuizzes, DashboardPlaceholder,

--- a/client/src/features/dashboard/components/QuickActions.tsx
+++ b/client/src/features/dashboard/components/QuickActions.tsx
@@ -3,11 +3,14 @@
 import React from "react";
 import { useRouter } from "next/router";
 
-export interface QuickAction {
+interface QuickActionBase {
   label: string;
   description: string;
-  href: string;
 }
+
+export type QuickAction =
+  | (QuickActionBase & { href: string; unavailable?: never })
+  | (QuickActionBase & { href?: never; unavailable: true });
 
 /**
  * [SCAFFOLD-OWNED] Row of primary entry points at the top of a dashboard.
@@ -23,8 +26,11 @@ export default function QuickActions({ actions }: { actions: QuickAction[] }) {
           <button
             key={action.label}
             type="button"
-            onClick={() => router.push(action.href)}
-            className="border-t-2 border-divider px-[6px] py-[20px] text-left transition hover:bg-ink/[0.05] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+            onClick={() => {
+              if (!action.unavailable) router.push(action.href);
+            }}
+            disabled={action.unavailable}
+            className="border-t-2 border-divider px-[6px] py-[20px] text-left transition hover:bg-ink/[0.05] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent"
           >
             <span className="flex items-start gap-[14px]">
               <span className="mt-[6px] h-[8px] w-[8px] flex-none bg-brand" />
@@ -35,6 +41,11 @@ export default function QuickActions({ actions }: { actions: QuickAction[] }) {
                 <span className="mt-[4px] block text-[13.5px] leading-[22px] text-ink/70">
                   {action.description}
                 </span>
+                {action.unavailable ? (
+                  <span className="mt-[8px] block text-[11px] font-extrabold uppercase tracking-[0.1em] text-ink/60">
+                    Coming soon
+                  </span>
+                ) : null}
               </span>
             </span>
           </button>

--- a/client/src/features/dashboard/components/RecentQuizzes.tsx
+++ b/client/src/features/dashboard/components/RecentQuizzes.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import { useAuth } from "@features/auth/context/authContext";
 import { getUserQuizHistory } from "@features/quiz-history/api/quizHistoryApi";
 
 interface HistoryRow {
@@ -28,9 +29,15 @@ export default function RecentQuizzes({
   limit?: number;
 }) {
   const router = useRouter();
+  const { user } = useAuth();
   const [rows, setRows] = useState<HistoryRow[] | null>(null);
 
   useEffect(() => {
+    if (!user?.is_verified) {
+      setRows([]);
+      return;
+    }
+
     let active = true;
     getUserQuizHistory().then((history) => {
       if (active) setRows(Array.isArray(history) ? history.slice(0, limit) : []);
@@ -38,7 +45,7 @@ export default function RecentQuizzes({
     return () => {
       active = false;
     };
-  }, [limit]);
+  }, [limit, user?.is_verified]);
 
   return (
     <section className="border-t-2 border-divider pt-[28px]">
@@ -48,6 +55,10 @@ export default function RecentQuizzes({
 
       {rows === null ? (
         <p className="mt-[14px] text-[14px] text-ink/60">Loading…</p>
+      ) : !user?.is_verified ? (
+        <p className="mt-[14px] max-w-[52ch] text-[15px] leading-[26px] text-ink/70">
+          Verify your email to view recent activity.
+        </p>
       ) : rows.length === 0 ? (
         <p className="mt-[14px] max-w-[52ch] text-[15px] leading-[26px] text-ink/70">
           {emptyMessage}

--- a/client/src/features/dashboard/corporate/CorporateDashboard.tsx
+++ b/client/src/features/dashboard/corporate/CorporateDashboard.tsx
@@ -1,22 +1,41 @@
 "use client";
 
-// TODO(#125): Corporate category dashboard.
-//
-// Build this to mirror school/SchoolDashboard.tsx — that file is the
-// reference implementation: DashboardShell + QuickActions + RecentQuizzes,
-// with the user-type view composed underneath, all wording via useTerms().
-// Suggested actions: New training quiz / Run live session / Assigned to me.
-//
-// The dispatch map below is [SCAFFOLD-OWNED] and already complete; the
-// user-type leaves belong to #130, #131 and #132.
 import React, { ComponentType } from "react";
-import type { CorporateUserType } from "@shared/config/persona";
+import {
+  getCategoryDefinition,
+  personaGenerateHref,
+  type CorporateUserType,
+} from "@shared/config/persona";
+import { type TerminologyResolver } from "@shared/config/terminology";
 import { useTerms } from "@features/persona/hooks/useTerms";
 import DashboardShell from "@features/dashboard/components/DashboardShell";
+import QuickActions from "@features/dashboard/components/QuickActions";
+import RecentQuizzes from "@features/dashboard/components/RecentQuizzes";
 import type { DashboardViewProps } from "@features/dashboard/types/dashboard";
 import BusinessDashboard from "./views/BusinessDashboard";
 import EmployeeDashboard from "./views/EmployeeDashboard";
 import HrDashboard from "./views/HrDashboard";
+
+const CORPORATE_COPY: Record<
+  CorporateUserType,
+  { title: string; lede: (t: TerminologyResolver) => string }
+> = {
+  business: {
+    title: "Build the next training session.",
+    lede: (t) =>
+      `Create practical training for your ${t("group", "plural")}, run it live, and keep a clear record of progress.`,
+  },
+  employee: {
+    title: "Keep your learning moving.",
+    lede: () =>
+      "Build practice quizzes and return to the training that matters to your role.",
+  },
+  hr: {
+    title: "Keep compliance training on track.",
+    lede: () =>
+      "Create focused training and maintain the records your organisation needs.",
+  },
+};
 
 const CORPORATE_VIEWS: Record<
   CorporateUserType,
@@ -33,19 +52,46 @@ export default function CorporateDashboard({
 }: DashboardViewProps) {
   const t = useTerms();
   const UserTypeView = CORPORATE_VIEWS[persona.userType as CorporateUserType];
+  const copy = CORPORATE_COPY[persona.userType as CorporateUserType];
 
   const greetingName = user.full_name?.split(" ")[0] || user.username;
 
   return (
     <DashboardShell
-      kicker="Corporate"
-      title={`Welcome back, ${greetingName}`}
-      lede={`Build and run training for your ${t(
-        "group",
-        "plural",
-      )}, and keep the ${t("report", "plural")} to prove it.`}
+      kicker={getCategoryDefinition(persona.category).label}
+      title={`Welcome back, ${greetingName}. ${copy.title}`}
+      lede={`${copy.lede(t)} Everything for your ${t("group", "plural")} is in one place.`}
     >
-      <UserTypeView persona={persona} user={user} />
+      <div className="flex flex-col gap-[36px]">
+        <QuickActions
+          actions={[
+            {
+              label: `New ${t("quiz")}`,
+              description: `Generate a ${t("quiz")} for any training topic, with the answer key included.`,
+              href: personaGenerateHref(persona.userType),
+            },
+            {
+              label: `Run ${t("live_quiz")}`,
+              description: "Manage live training and review participation from one workspace.",
+              href: "/my-live-quizzes",
+            },
+            {
+              label: "Assigned to me",
+              description: "Assigned training will appear here when assignment workflows arrive.",
+              unavailable: true,
+            },
+          ]}
+        />
+
+        <RecentQuizzes
+          heading="Recent training activity"
+          emptyMessage={`Nothing here yet. Generate your first ${t(
+            "quiz",
+          )} and it will show up here with your recent training activity.`}
+        />
+
+        <UserTypeView persona={persona} user={user} />
+      </div>
     </DashboardShell>
   );
 }

--- a/client/src/features/dashboard/school/SchoolDashboard.tsx
+++ b/client/src/features/dashboard/school/SchoolDashboard.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import React, { ComponentType } from "react";
-import { personaGenerateHref, type SchoolUserType } from "@shared/config/persona";
-import { titleCaseTerm } from "@shared/config/terminology";
+import {
+  getCategoryDefinition,
+  personaGenerateHref,
+  type SchoolUserType,
+} from "@shared/config/persona";
+import { type TerminologyResolver } from "@shared/config/terminology";
 import { useTerms } from "@features/persona/hooks/useTerms";
 import DashboardShell from "@features/dashboard/components/DashboardShell";
 import QuickActions from "@features/dashboard/components/QuickActions";
@@ -13,12 +17,38 @@ import LecturerDashboard from "./views/LecturerDashboard";
 import StudentDashboard from "./views/StudentDashboard";
 import ParentDashboard from "./views/ParentDashboard";
 
+const SCHOOL_COPY: Record<
+  SchoolUserType,
+  { title: string; lede: (t: TerminologyResolver) => string }
+> = {
+  teacher: {
+    title: "Plan your next class quiz.",
+    lede: (t) =>
+      `Set work, run it live, and see how your ${t("learner", "plural")} did.`,
+  },
+  lecturer: {
+    title: "Get your next lecture ready.",
+    lede: (t) =>
+      `Create focused checks for your ${t("group", "plural")} and review the results.`,
+  },
+  student: {
+    title: "Ready for revision?",
+    lede: (t) =>
+      `Build a practice quiz and strengthen your understanding before the next ${t("group")}.`,
+  },
+  parent: {
+    title: "Make practice time count.",
+    lede: (t) =>
+      `Create a short practice quiz to support your ${t("learner")}'s learning at home.`,
+  },
+};
+
 /**
  * [SCAFFOLD-OWNED] School category dashboard (#124).
  *
  * Reference implementation for the persona dashboards: category-level
  * chrome (quick actions, recent activity) with the user-type view composed
- * underneath. Corporate (#125) should mirror this shape.
+ * underneath.
  *
  * The dispatch map is written complete so each user-type ticket only ever
  * edits its own leaf file — do not convert it to next/dynamic, the static
@@ -34,35 +64,28 @@ const SCHOOL_VIEWS: Record<SchoolUserType, ComponentType<DashboardViewProps>> = 
 export default function SchoolDashboard({ persona, user }: DashboardViewProps) {
   const t = useTerms();
   const UserTypeView = SCHOOL_VIEWS[persona.userType as SchoolUserType];
+  const copy = SCHOOL_COPY[persona.userType as SchoolUserType];
 
   const greetingName = user.full_name?.split(" ")[0] || user.username;
 
   return (
     <DashboardShell
-      kicker="School"
-      title={`Welcome back, ${greetingName}`}
-      lede={`Set work, run it live, and see how your ${t(
-        "learner",
-        "plural",
-      )} did — everything for your ${t("group", "plural")} in one place.`}
+      kicker={getCategoryDefinition(persona.category).label}
+      title={`Welcome back, ${greetingName}. ${copy.title}`}
+      lede={`${copy.lede(t)} Everything for your ${t("group", "plural")} is in one place.`}
     >
       <div className="flex flex-col gap-[36px]">
         <QuickActions
           actions={[
             {
-              label: `New ${t("assignment")}`,
-              description: `Generate a ${t(
-                "assignment",
-              )} on any topic, with the answer key included.`,
+              label: `New ${t("quiz")}`,
+              description: `Generate a ${t("quiz")} on any topic, with the answer key included.`,
               href: personaGenerateHref(persona.userType),
             },
             {
-              label: `Run a live ${t("session")}`,
-              description: `Put a join code on the projector and score your ${t(
-                "learner",
-                "plural",
-              )} in real time.`,
-              href: "/my-live-quizzes",
+              label: `Join ${t("live_quiz")}`,
+              description: `Enter an access code to join a ${t("live_quiz")}.`,
+              href: "/quiz-access",
             },
             {
               label: "Revision practice",
@@ -73,10 +96,10 @@ export default function SchoolDashboard({ persona, user }: DashboardViewProps) {
         />
 
         <RecentQuizzes
-          heading={`${titleCaseTerm(t("assignment", "plural"))} you made recently`}
+          heading={`Recent ${t("quiz", "plural")}`}
           emptyMessage={`Nothing here yet. Generate your first ${t(
-            "assignment",
-          )} and it will show up here, ready to run with your ${t(
+            "quiz",
+          )} and it will show up here, ready to use with your ${t(
             "group",
             "plural",
           )}.`}

--- a/client/src/features/folders/components/FolderView.tsx
+++ b/client/src/features/folders/components/FolderView.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import MoveQuizModal from "./MoveQuizModal";
 import OrganizeModal from "./OrganizeModal";
+import { useTerms } from "@features/persona/hooks/useTerms";
 
 interface FolderViewProps {
   folder: {
@@ -24,6 +25,7 @@ const FolderView: React.FC<FolderViewProps> = ({ folder }) => {
   const [showMoveModal, setShowMoveModal] = useState(false);
   const [showOrganizeModal, setShowOrganizeModal] = useState(false);
   const [quizzes, setQuizzes] = useState(folder.quizzes || []);
+  const t = useTerms();
 
   return (
     <div className="p-6 bg-white rounded-2xl shadow-sm border border-gray-100">
@@ -38,7 +40,9 @@ const FolderView: React.FC<FolderViewProps> = ({ folder }) => {
       </div>
 
       {quizzes.length === 0 ? (
-        <p className="text-gray-500 text-sm">No quizzes in this folder yet.</p>
+        <p className="text-gray-500 text-sm">
+          No {t("quiz", "plural")} in this folder yet.
+        </p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {quizzes.map((quiz) => (

--- a/client/src/features/folders/pages/FoldersPage.tsx
+++ b/client/src/features/folders/pages/FoldersPage.tsx
@@ -12,6 +12,7 @@ import OrganizeModal from "@features/folders/components/OrganizeModal";
 import ConfirmDeleteModal from "@features/folders/components/ConfirmDeleteModal";
 import { useAuth } from "@features/auth/context/authContext";
 import RequireAuth from "@features/auth/components/RequireAuth";
+import { useTerms } from "@features/persona/hooks/useTerms";
 import {
   getUserFolders,
   deleteFolder,
@@ -31,6 +32,7 @@ const getFolderId = (folder: Partial<Folder>) => folder.id || "";
 const FoldersPage = () => {
   const router = useRouter();
   const { user, isAuthenticated } = useAuth();
+  const t = useTerms();
   const [folders, setFolders] = useState<Folder[]>([]);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showOrganizeModal, setShowOrganizeModal] = useState(false);
@@ -102,7 +104,7 @@ const FoldersPage = () => {
             <div className="text-center text-gray-500 mt-20">
               <p>No folders yet.</p>
               <p className="text-sm">
-                Create a folder to organize your saved quizzes.
+                Create a folder to organize your saved {t("quiz", "plural")}.
               </p>
             </div>
           ) : (

--- a/client/src/features/home/QuizwerkHomePage.tsx
+++ b/client/src/features/home/QuizwerkHomePage.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router";
 import Link from "next/link";
 import Image from "next/image";
 import SignInModal from "@features/auth/components/SignInModal";
+import { ROUTES } from "@shared/config/patterns/routes";
 import { useAuth } from "@features/auth/context/authContext";
 import {
   createCheckoutSession,
@@ -454,6 +455,7 @@ export default function QuizwerkHomePage() {
       <SignInModal
         isOpen={isLoginOpen}
         onClose={() => setIsLoginOpen(false)}
+        redirectTo={ROUTES.DASHBOARD}
         switchToSignUp={() => {}}
       />
     </div>

--- a/client/src/features/persona/README.md
+++ b/client/src/features/persona/README.md
@@ -18,7 +18,9 @@ Resolution order (`lib/resolvePersona.ts`, pure and unit-tested):
 1. **profile** — the signed-in user's saved persona
 2. **query** — `?persona=&category=` on the current URL
 3. **storage** — a guest's earlier choice (`localStorage`, survives tab close;
-   unlike `TokenService`, which uses `sessionStorage` for token security)
+   unlike `TokenService`, which uses `sessionStorage` for token security).
+   It is hydrated after mount, never used as an authenticated fallback, and is
+   cleared when an authenticated session ends on a shared browser.
 4. **none**
 
 An inconsistent pair (`?category=corporate&persona=teacher`) resolves to
@@ -31,14 +33,16 @@ const { setPersona } = usePersona();
 await setPersona({ category: "school", userType: "teacher" });
 ```
 
-Writes storage immediately, then persists to the profile and refreshes the user
-when signed in.
+For guests this writes browser storage. For authenticated users it first saves
+through `PUT /auth/profile/persona`, refreshes the profile, then removes any
+guest storage copy. A failed profile save leaves both the profile and guest
+storage unchanged.
 
 ## Wording
 
 ```tsx
 const t = useTerms();
-t("learner", "plural");   // "students" (school) · "employees" (corporate)
+t("learner", "plural");   // "students" (school) · "team members" (corporate)
 t("group");               // "class" · "team" · "cohort" for a lecturer
 ```
 

--- a/client/src/features/persona/api/personaApi.ts
+++ b/client/src/features/persona/api/personaApi.ts
@@ -1,9 +1,9 @@
 import { api } from "@shared/api/http";
 import type { Persona } from "@shared/config/persona";
 
-/** Persists persona onto the user profile (rides PUT /auth/profile). */
+/** Persists only persona fields; this is available to authenticated users. */
 export async function updatePersona(persona: Persona) {
-  const response = await api.put("/auth/profile", {
+  const response = await api.put("/auth/profile/persona", {
     persona_category: persona.category,
     persona_user_type: persona.userType,
   });

--- a/client/src/features/persona/context/personaContext.tsx
+++ b/client/src/features/persona/context/personaContext.tsx
@@ -4,6 +4,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -41,14 +42,36 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
   const { user, isAuthenticated, isLoading, refreshUser } = useAuth();
   const router = useRouter();
 
-  // Local override so a fresh pick renders immediately, before the profile
-  // round-trip completes.
-  const [override, setOverride] = useState<Persona | null>(null);
+  // Storage is hydrated only after the initial client render. Reading it in
+  // render would make SSR see no persona while the browser sees one, causing
+  // a hydration mismatch in persona-aware shell copy.
+  const [storedPersona, setStoredPersona] = useState<Persona | null>(null);
+  const [storageHydrated, setStorageHydrated] = useState(false);
+  const [hasAuthenticatedSession, setHasAuthenticatedSession] = useState(false);
+
+  useEffect(() => {
+    setStoredPersona(readStoredPersona());
+    setStorageHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (isAuthenticated) {
+      setHasAuthenticatedSession(true);
+      return;
+    }
+
+    // A browser can be shared. Never allow a guest preference that survived
+    // an authenticated session to become a later account's fallback persona.
+    if (hasAuthenticatedSession) {
+      clearStoredPersona();
+      setStoredPersona(null);
+      setHasAuthenticatedSession(false);
+    }
+  }, [hasAuthenticatedSession, isAuthenticated, isLoading]);
 
   const resolved = useMemo(() => {
-    if (override) {
-      return { persona: override, source: "profile" as const };
-    }
     return resolvePersona({
       profile: user
         ? {
@@ -60,26 +83,33 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
         persona: (router.query?.persona as string) ?? null,
         category: (router.query?.category as string) ?? null,
       },
-      stored: readStoredPersona(),
+      // Profile and explicit links remain available to signed-in users. Guest
+      // storage is intentionally never an authenticated fallback.
+      stored: isAuthenticated || hasAuthenticatedSession ? null : storedPersona,
     });
-  }, [override, user, router.query]);
+  }, [hasAuthenticatedSession, isAuthenticated, router.query, storedPersona, user]);
 
   const setPersona = useCallback(
     async (persona: Persona) => {
-      setOverride(persona);
-      writeStoredPersona(persona);
-
       if (isAuthenticated) {
         await updatePersona(persona);
         await refreshUser();
+        // A profile save is authoritative. Remove the guest copy so it
+        // cannot surface for another account on a shared browser.
+        clearStoredPersona();
+        setStoredPersona(null);
+        return;
       }
+
+      writeStoredPersona(persona);
+      setStoredPersona(persona);
     },
     [isAuthenticated, refreshUser],
   );
 
   const clearPersona = useCallback(() => {
-    setOverride(null);
     clearStoredPersona();
+    setStoredPersona(null);
   }, []);
 
   const value = useMemo<PersonaState>(() => {
@@ -93,11 +123,11 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
         ? getCategoryDefinition(persona.category)
         : null,
       source: resolved.source,
-      isLoading,
+      isLoading: isLoading || !storageHydrated,
       setPersona,
       clearPersona,
     };
-  }, [resolved, isLoading, setPersona, clearPersona]);
+  }, [resolved, isLoading, storageHydrated, setPersona, clearPersona]);
 
   return (
     <PersonaContext.Provider value={value}>{children}</PersonaContext.Provider>

--- a/client/src/features/persona/hooks/useTerms.ts
+++ b/client/src/features/persona/hooks/useTerms.ts
@@ -12,7 +12,7 @@ import {
  * Persona-bound terminology.
  *
  *   const t = useTerms();
- *   t("learner", "plural")   // "students" for a teacher, "employees" for HR
+ *   t("learner", "plural")   // "students" for a teacher, "team members" for HR
  *
  * Persona views must use this instead of hardcoding learner/class/team nouns.
  */

--- a/client/src/features/persona/hooks/useTerms.ts
+++ b/client/src/features/persona/hooks/useTerms.ts
@@ -2,7 +2,11 @@
 
 import { useCallback } from "react";
 import { usePersona } from "@features/persona/context/personaContext";
-import { resolveTerm, type TermKey } from "@shared/config/terminology";
+import {
+  resolveTerm,
+  type TermForm,
+  type TermKey,
+} from "@shared/config/terminology";
 
 /**
  * Persona-bound terminology.
@@ -16,7 +20,7 @@ export function useTerms() {
   const { persona } = usePersona();
 
   return useCallback(
-    (key: TermKey, form: "singular" | "plural" = "singular") =>
+    (key: TermKey, form: TermForm = "singular") =>
       resolveTerm(key, persona, form),
     [persona],
   );

--- a/client/src/features/persona/types/persona.ts
+++ b/client/src/features/persona/types/persona.ts
@@ -19,7 +19,8 @@ export interface PersonaState {
   categoryDefinition: PersonaCategoryDefinition | null;
   source: PersonaSource;
   isLoading: boolean;
-  /** Persists to the profile when signed in, otherwise to local storage. */
+  /** Persists to the profile when signed in, otherwise to guest local storage. */
   setPersona: (persona: Persona) => Promise<void>;
+  /** Clears guest fallback only. Profile persona is changed through setPersona. */
   clearPersona: () => void;
 }

--- a/client/src/features/quiz-history/pages/QuizHistoryPage.tsx
+++ b/client/src/features/quiz-history/pages/QuizHistoryPage.tsx
@@ -11,6 +11,7 @@ import { useAuth } from "@features/auth/context/authContext";
 import NavBar from "@features/quiz/components/NavBar";
 import Footer from "@features/quiz/components/Footer";
 import RequireAuth from "@features/auth/components/RequireAuth";
+import { useTerms } from "@features/persona/hooks/useTerms";
 
 interface QuizHistoryQuestion {
   question: string;
@@ -59,6 +60,7 @@ const DisplayQuizHistoryPage = ({
   onDelete: (historyId: string) => Promise<void>;
 }) => {
   const router = useRouter();
+  const t = useTerms();
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
@@ -81,12 +83,12 @@ const DisplayQuizHistoryPage = ({
       <main className="flex-1 px-4 sm:px-6 md:px-8 py-8">
         <div className="max-w-4xl mx-auto space-y-8">
           <h1 className="text-3xl sm:text-4xl font-bold text-[#0F2654]">
-            Quiz History
+            {t("quiz").charAt(0).toUpperCase() + t("quiz").slice(1)} history
           </h1>
 
           {quizHistory.length === 0 ? (
             <p className="text-center text-gray-600">
-              No quiz history available.
+              No {t("quiz")} history available.
             </p>
           ) : (
             quizHistory.map((quizItem, idx) => (
@@ -272,6 +274,7 @@ export default function DisplayQuizHistory({
   openLoginModal: () => void;
 }) {
   const { isAuthenticated, isLoading } = useAuth();
+  const t = useTerms();
   const [quizHistory, setQuizHistory] = useState<QuizHistoryItem[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -309,12 +312,12 @@ export default function DisplayQuizHistory({
 
   return (
     <RequireAuth
-      title="Quiz History"
-      description="Sign in to see your quiz history."
+      title={`${t("quiz").charAt(0).toUpperCase() + t("quiz").slice(1)} history`}
+      description={`Sign in to see your ${t("quiz")} history.`}
     >
       <Suspense
         fallback={
-          <div className="p-8 text-center">Loading quiz history...</div>
+          <div className="p-8 text-center">Loading {t("quiz")} history...</div>
         }
       >
         <DisplayQuizHistoryPage

--- a/client/src/features/quiz/components/Footer.tsx
+++ b/client/src/features/quiz/components/Footer.tsx
@@ -3,25 +3,8 @@
 import React from "react";
 import Link from "next/link";
 import { FaGithub, FaTwitter, FaLinkedin } from "react-icons/fa";
-
-const footerSections = [
-  {
-    title: "Explore",
-    links: [
-      { label: "Generate Quiz", href: "/generate" },
-      { label: "Popular Quizzes", href: "/popular" },
-      { label: "Join Live Quiz", href: "/quiz-access" },
-    ],
-  },
-  {
-    title: "Workspace",
-    links: [
-      { label: "Saved Quizzes", href: "/saved_quiz" },
-      { label: "Quiz History", href: "/quiz_history" },
-      { label: "Folders", href: "/folders" },
-    ],
-  },
-];
+import { useTerms } from "@features/persona/hooks/useTerms";
+import { titleCaseTerm } from "@shared/config/terminology";
 
 const socialLinks = [
   {
@@ -43,6 +26,25 @@ const socialLinks = [
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
+  const t = useTerms();
+  const footerSections = [
+    {
+      title: "Explore",
+      links: [
+        { label: `Create ${t("quiz")}`, href: "/generate" },
+        { label: `Popular ${t("quiz", "plural")}`, href: "/popular" },
+        { label: `Join ${t("live_quiz")}`, href: "/quiz-access" },
+      ],
+    },
+    {
+      title: "Workspace",
+      links: [
+        { label: `Saved ${t("quiz", "plural")}`, href: "/saved_quiz" },
+        { label: `${titleCaseTerm(t("quiz"))} history`, href: "/quiz_history" },
+        { label: "Folders", href: "/folders" },
+      ],
+    },
+  ];
 
   return (
     <footer className="mt-8 bg-gray-900 text-white">

--- a/client/src/features/quiz/components/NavBar.tsx
+++ b/client/src/features/quiz/components/NavBar.tsx
@@ -13,6 +13,11 @@ import Sidebar from "./Sidebar";
 import BrowseModal from "./modals/BrowseModal";
 import { useAuth } from "@features/auth/context/authContext";
 import { usePersona } from "@features/persona/context/personaContext";
+import { useTerms } from "@features/persona/hooks/useTerms";
+import {
+  titleCaseTerm,
+  type TerminologyResolver,
+} from "@shared/config/terminology";
 import NotificationBell from "@features/notifications/components/NotificationBell";
 import { archivo, BTN_PRIMARY } from "@shared/ui/quizwerk";
 
@@ -26,22 +31,25 @@ type NavItem =
   | { kind: "link"; label: string; href: string; authOnly?: boolean }
   | { kind: "action"; label: string; action: "browse" };
 
-const NAV_ITEMS: NavItem[] = [
-  { kind: "link", label: "Home", href: "/" },
-  { kind: "link", label: "Dashboard", href: "/dashboard", authOnly: true },
-  { kind: "link", label: "Generate Quiz", href: "/generate" },
-  { kind: "action", label: "Categories", action: "browse" },
-  { kind: "link", label: "Pricing", href: "/#pricing" },
-];
+function navigationItems(t: TerminologyResolver): NavItem[] {
+  return [
+    { kind: "link", label: "Home", href: "/" },
+    { kind: "link", label: "Dashboard", href: "/dashboard", authOnly: true },
+    { kind: "link", label: `Create ${t("quiz")}`, href: "/generate" },
+    { kind: "action", label: "Categories", action: "browse" },
+    { kind: "link", label: "Pricing", href: "/#pricing" },
+  ];
+}
 
-/** Signed-in shortcuts, shown only in the mobile drawer. */
-const MOBILE_WORKSPACE_LINKS = [
-  { label: "My Profile", href: "/profile" },
-  { label: "Saved Quizzes", href: "/saved_quiz" },
-  { label: "Popular Quizzes", href: "/popular" },
-  { label: "Folders", href: "/folders" },
-  { label: "Quiz History", href: "/quiz_history" },
-];
+function mobileWorkspaceLinks(t: TerminologyResolver) {
+  return [
+    { label: "My Profile", href: "/profile" },
+    { label: `Saved ${t("quiz", "plural")}`, href: "/saved_quiz" },
+    { label: `Popular ${t("quiz", "plural")}`, href: "/popular" },
+    { label: "Folders", href: "/folders" },
+    { label: `${titleCaseTerm(t("quiz"))} history`, href: "/quiz_history" },
+  ];
+}
 
 const NavBar: React.FC = () => {
   const [isSignUpOpen, setIsSignUpOpen] = useState(false);
@@ -51,6 +59,7 @@ const NavBar: React.FC = () => {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
   const { user, isAuthenticated, logout, isLoading } = useAuth();
   const { definition: personaDefinition } = usePersona();
+  const t = useTerms();
 
   const router = useRouter();
 
@@ -74,9 +83,10 @@ const NavBar: React.FC = () => {
     return router.pathname === href;
   };
 
-  const visibleItems = NAV_ITEMS.filter(
+  const visibleItems = navigationItems(t).filter(
     (item) => !("authOnly" in item && item.authOnly) || isAuthenticated,
   );
+  const workspaceLinks = mobileWorkspaceLinks(t);
 
   return (
     <div className={archivo.className}>
@@ -220,7 +230,7 @@ const NavBar: React.FC = () => {
               <p className="mb-1 mt-4 px-3 text-[11px] font-extrabold uppercase tracking-[0.1em] text-ink/60">
                 Workspace
               </p>
-              {MOBILE_WORKSPACE_LINKS.map((link) => (
+              {workspaceLinks.map((link) => (
                 <Link
                   key={link.href}
                   href={link.href}

--- a/client/src/features/quiz/components/NavBar.tsx
+++ b/client/src/features/quiz/components/NavBar.tsx
@@ -18,6 +18,7 @@ import {
   titleCaseTerm,
   type TerminologyResolver,
 } from "@shared/config/terminology";
+import { ROUTES } from "@shared/config/patterns/routes";
 import NotificationBell from "@features/notifications/components/NotificationBell";
 import { archivo, BTN_PRIMARY } from "@shared/ui/quizwerk";
 
@@ -31,11 +32,10 @@ type NavItem =
   | { kind: "link"; label: string; href: string; authOnly?: boolean }
   | { kind: "action"; label: string; action: "browse" };
 
-function navigationItems(t: TerminologyResolver): NavItem[] {
+export function navigationItems(): NavItem[] {
   return [
     { kind: "link", label: "Home", href: "/" },
     { kind: "link", label: "Dashboard", href: "/dashboard", authOnly: true },
-    { kind: "link", label: `Create ${t("quiz")}`, href: "/generate" },
     { kind: "action", label: "Categories", action: "browse" },
     { kind: "link", label: "Pricing", href: "/#pricing" },
   ];
@@ -83,7 +83,7 @@ const NavBar: React.FC = () => {
     return router.pathname === href;
   };
 
-  const visibleItems = navigationItems(t).filter(
+  const visibleItems = navigationItems().filter(
     (item) => !("authOnly" in item && item.authOnly) || isAuthenticated,
   );
   const workspaceLinks = mobileWorkspaceLinks(t);
@@ -291,6 +291,7 @@ const NavBar: React.FC = () => {
       <SignInModal
         isOpen={isLoginOpen}
         onClose={() => setIsLoginOpen(false)}
+        redirectTo={ROUTES.DASHBOARD}
         switchToSignUp={switchToSignUp}
       />
       <BrowseModal

--- a/client/src/features/quiz/components/NavGenerateQuizButton.tsx
+++ b/client/src/features/quiz/components/NavGenerateQuizButton.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { useRouter } from "next/router";
+import { useTerms } from "@features/persona/hooks/useTerms";
 interface NavGenerateQuizButtonProps {
   className?: string;
 }
@@ -10,6 +11,7 @@ const NavGenerateQuizButton: React.FC<NavGenerateQuizButtonProps> = ({
   className = "",
 }) => {
   const router = useRouter();
+  const t = useTerms();
 
   return (
     <button
@@ -22,7 +24,7 @@ const NavGenerateQuizButton: React.FC<NavGenerateQuizButtonProps> = ({
         ${className}
       `}
     >
-      Generate a Quiz
+      Create {t("quiz")}
     </button>
   );
 };

--- a/client/src/features/quiz/components/QuizForm.tsx
+++ b/client/src/features/quiz/components/QuizForm.tsx
@@ -16,6 +16,7 @@ import publicApi from "@shared/api/publicHttp";
 import { saveQuizToHistory } from "@features/quiz-history/api/saveQuizToHistoryApi";
 import PersonaBadge from "@features/persona/components/PersonaBadge";
 import { usePersona } from "@features/persona/context/personaContext";
+import { useTerms } from "@features/persona/hooks/useTerms";
 import { readStoredPersonaTopic } from "@features/persona/lib/personaStorage";
 
 type ApiErrorLike = {
@@ -127,6 +128,7 @@ export default function QuizForm() {
   // entry points and post-auth carry-through use the same app-wide rule.
   const searchParams = useSearchParams();
   const { persona } = usePersona();
+  const t = useTerms();
 
   useEffect(() => {
     const personaTopic =
@@ -175,6 +177,8 @@ export default function QuizForm() {
   }, [user, isAuthenticated]);
 
   const handleGenerateQuiz = async () => {
+    const resolvedAudienceType = audienceType || t("learner", "plural");
+
     if (generationMode === "topic" && !profession) {
       setErrorMessage("Please enter a profession or topic for your quiz.");
       return;
@@ -280,7 +284,7 @@ export default function QuizForm() {
         payload.append("question_type", questionType);
         payload.append("num_questions", numQuestions.toString());
         payload.append("difficulty_level", difficultyLevel);
-        payload.append("audience_type", audienceType || "students");
+        payload.append("audience_type", resolvedAudienceType);
         payload.append("custom_instruction", customInstruction);
         payload.append("token", token);
         payload.append("document_title", documentTitle);
@@ -321,7 +325,7 @@ export default function QuizForm() {
               num_questions: numQuestions,
               difficulty_level: difficultyLevel,
               profession: response.title,
-              audience_type: audienceType || "students",
+              audience_type: resolvedAudienceType,
               custom_instruction:
                 customInstruction ||
                 `Generated from ${response.source_document_type.toUpperCase()} material.`,
@@ -338,7 +342,7 @@ export default function QuizForm() {
           customInstruction:
             customInstruction ||
             `Generated from ${response.source_document_type.toUpperCase()} material.`,
-          audienceType: audienceType || "students",
+          audienceType: resolvedAudienceType,
           difficultyLevel,
         }).toString();
 
@@ -358,7 +362,7 @@ export default function QuizForm() {
         num_questions: numQuestions,
         profession,
         custom_instruction: customInstruction,
-        audience_type: audienceType,
+        audience_type: resolvedAudienceType,
         difficulty_level: difficultyLevel,
         token,
         live_quiz_enabled: enableLiveQuiz,
@@ -390,7 +394,7 @@ export default function QuizForm() {
               num_questions: numQuestions,
               difficulty_level: difficultyLevel,
               profession,
-              audience_type: audienceType,
+              audience_type: resolvedAudienceType,
               custom_instruction: customInstruction,
             },
             questions,
@@ -407,7 +411,7 @@ export default function QuizForm() {
         title: profession || `${questionType} Quiz`,
         description:
           customInstruction ||
-          `A ${difficultyLevel} ${questionType} quiz for ${audienceType || "students"}.`,
+          `A ${difficultyLevel} ${questionType} quiz for ${resolvedAudienceType}.`,
         question_type: questionType,
         questions,
         live_quiz_enabled: data?.live_quiz_enabled,
@@ -425,7 +429,7 @@ export default function QuizForm() {
         numQuestions: numQuestions.toString(),
         profession,
         customInstruction,
-        audienceType,
+        audienceType: resolvedAudienceType,
         difficultyLevel,
         token,
         liveQuiz: enableLiveQuiz ? "true" : "false",

--- a/client/src/features/quiz/components/Sidebar.tsx
+++ b/client/src/features/quiz/components/Sidebar.tsx
@@ -7,23 +7,27 @@ import UpgradePlanButton from "./sidebar/UpgradePlanButton";
 import QuizHistoryButton from "./sidebar/QuizHistoryButton";
 import ProfileButton from "./sidebar/ProfileButton";
 import LiveQuizzesButton from "./sidebar/LiveQuizzesButton";
+import { useTerms } from "@features/persona/hooks/useTerms";
+import { titleCaseTerm } from "@shared/config/terminology";
 
 interface SidebarProps {
   onBrowseClick: () => void;
 }
 
 export default function Sidebar({ onBrowseClick }: SidebarProps) {
+  const t = useTerms();
+
   return (
     <div className="flex h-full flex-col justify-between bg-paper p-4">
       <div className="flex flex-col gap-3">
         <ProfileButton />
-        <GenerateQuizButton />
-        <SavedQuizzesButton />
+        <GenerateQuizButton label={`Create ${t("quiz")}`} />
+        <SavedQuizzesButton label={`Saved ${t("quiz", "plural")}`} />
         <BrowseByCategoryButton onBrowseClick={onBrowseClick} />
-        <PopularQuizzesButton />
+        <PopularQuizzesButton label={`Popular ${t("quiz", "plural")}`} />
         <FoldersButton />
-        <LiveQuizzesButton />
-        <QuizHistoryButton />
+        <LiveQuizzesButton label={t("live_quiz", "plural")} />
+        <QuizHistoryButton label={`${titleCaseTerm(t("quiz"))} history`} />
       </div>
 
       <div className="mt-10">

--- a/client/src/features/quiz/components/modals/BrowseModal.tsx
+++ b/client/src/features/quiz/components/modals/BrowseModal.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { Dialog } from "@headlessui/react";
 import { X } from "lucide-react";
 import publicApi from "@shared/api/publicHttp";
+import { useTerms } from "@features/persona/hooks/useTerms";
 
 interface Quiz {
   question: string;
@@ -19,6 +20,7 @@ interface BrowseModalProps {
 }
 
 const BrowseModal: React.FC<BrowseModalProps> = ({ isOpen, onClose }) => {
+  const t = useTerms();
   const [categories, setCategories] = useState<string[]>([]);
   const [subcategories, setSubcategories] = useState<string[]>([]);
   const [quizTypes, setQuizTypes] = useState<string[]>([]);
@@ -307,7 +309,7 @@ const BrowseModal: React.FC<BrowseModalProps> = ({ isOpen, onClose }) => {
                 </div>
               ) : (
                 <p className="text-sm text-gray-600 mt-4">
-                  No quizzes available.
+                  No {t("quiz", "plural")} available.
                 </p>
               )}
             </>

--- a/client/src/features/quiz/components/sidebar/GenerateQuizButton.tsx
+++ b/client/src/features/quiz/components/sidebar/GenerateQuizButton.tsx
@@ -4,14 +4,14 @@ import React from "react";
 import { useRouter, usePathname } from "next/navigation";
 import SidebarButton from "./SidebarButton";
 
-const GenerateQuizButton: React.FC = () => {
+const GenerateQuizButton: React.FC<{ label: string }> = ({ label }) => {
   const router = useRouter();
   const pathname = usePathname();
   const isActive = pathname === "/generate";
 
   return (
     <SidebarButton
-      label="Generate Quiz"
+      label={label}
       icon="🧠"
       onClick={() => router.push("/generate")}
       isActive={isActive}

--- a/client/src/features/quiz/components/sidebar/LiveQuizzesButton.tsx
+++ b/client/src/features/quiz/components/sidebar/LiveQuizzesButton.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "@features/auth/context/authContext";
 import SignInModal from "@features/auth/components/SignInModal";
 import SidebarButton from "./SidebarButton";
 
-const LiveQuizzesButton: React.FC = () => {
+const LiveQuizzesButton: React.FC<{ label: string }> = ({ label }) => {
   const router = useRouter();
   const pathname = usePathname();
   const { isAuthenticated, isLoading } = useAuth();
@@ -26,7 +26,7 @@ const LiveQuizzesButton: React.FC = () => {
   return (
     <>
       <SidebarButton
-        label="Live Quizzes"
+        label={label}
         icon={<Radio size={20} />}
         onClick={handleClick}
         isActive={isActive}

--- a/client/src/features/quiz/components/sidebar/PopularQuizzesButton.tsx
+++ b/client/src/features/quiz/components/sidebar/PopularQuizzesButton.tsx
@@ -4,14 +4,14 @@ import React from "react";
 import { usePathname, useRouter } from "next/navigation";
 import SidebarButton from "./SidebarButton";
 
-const PopularQuizzesButton = () => {
+const PopularQuizzesButton = ({ label }: { label: string }) => {
   const router = useRouter();
   const pathname = usePathname();
   const isActive = pathname?.startsWith("/popular") ?? false;
 
   return (
     <SidebarButton
-      label="Popular Quizzes"
+      label={label}
       icon="🌟"
       onClick={() => router.push("/popular")}
       isActive={isActive}

--- a/client/src/features/quiz/components/sidebar/QuizHistoryButton.tsx
+++ b/client/src/features/quiz/components/sidebar/QuizHistoryButton.tsx
@@ -6,7 +6,7 @@ import SidebarButton from "./SidebarButton";
 import { useAuth } from "@features/auth/context/authContext";
 import SignInModal from "@features/auth/components/SignInModal";
 
-const QuizHistoryButton: React.FC = () => {
+const QuizHistoryButton: React.FC<{ label: string }> = ({ label }) => {
   const router = useRouter();
   const pathname = usePathname();
   const { isAuthenticated, isLoading } = useAuth();
@@ -25,7 +25,7 @@ const QuizHistoryButton: React.FC = () => {
   return (
     <>
       <SidebarButton
-        label="Quiz History"
+        label={label}
         icon="🕘"
         onClick={handleClick}
         isActive={isActive}

--- a/client/src/features/quiz/components/sidebar/SavedQuizzesButton.tsx
+++ b/client/src/features/quiz/components/sidebar/SavedQuizzesButton.tsx
@@ -6,7 +6,7 @@ import SidebarButton from "./SidebarButton";
 import { useAuth } from "@features/auth/context/authContext";
 import SignInModal from "@features/auth/components/SignInModal";
 
-const SavedQuizzesButton = () => {
+const SavedQuizzesButton = ({ label }: { label: string }) => {
   const router = useRouter();
   const pathname = usePathname();
   const { isAuthenticated, isLoading } = useAuth();
@@ -25,7 +25,7 @@ const SavedQuizzesButton = () => {
   return (
     <>
       <SidebarButton
-        label="Saved Quizzes"
+        label={label}
         icon="💾"
         isActive={isActive}
         onClick={handleClick}

--- a/client/src/features/saved-quizzes/pages/SavedQuizzesPage.tsx
+++ b/client/src/features/saved-quizzes/pages/SavedQuizzesPage.tsx
@@ -17,6 +17,7 @@ import NavBar from "@features/quiz/components/NavBar";
 import Footer from "@features/quiz/components/Footer";
 import { useAuth } from "@features/auth/context/authContext";
 import RequireAuth from "@features/auth/components/RequireAuth";
+import { useTerms } from "@features/persona/hooks/useTerms";
 
 interface QuizQuestion {
   question: string;
@@ -248,6 +249,7 @@ const DisplaySavedQuizzesPage: React.FC<{
   const [renameTitle, setRenameTitle] = useState("");
   const [isRenaming, setIsRenaming] = useState(false);
   const router = useRouter();
+  const t = useTerms();
 
   const toggleSelectQuiz = (quizId: string) => {
     setSelectedQuizIds((prev) =>
@@ -312,7 +314,7 @@ const DisplaySavedQuizzesPage: React.FC<{
         <div className="max-w-4xl mx-auto space-y-8">
           <div className="flex justify-between items-center">
             <h1 className="text-3xl sm:text-4xl font-bold text-[#0F2654]">
-              Saved Quizzes
+              Saved {t("quiz", "plural")}
             </h1>
 
             {selectedQuizIds.length > 0 && (
@@ -327,7 +329,7 @@ const DisplaySavedQuizzesPage: React.FC<{
 
           {savedQuizzes.length === 0 ? (
             <p className="text-center text-gray-600">
-              You haven’t saved any quizzes yet.
+              You haven’t saved any {t("quiz", "plural")} yet.
             </p>
           ) : (
             savedQuizzes.map((quiz) => (

--- a/client/src/shared/config/terminology.ts
+++ b/client/src/shared/config/terminology.ts
@@ -2,7 +2,7 @@
  * Category-aware terminology.
  *
  * A School user should read "students" and "class" where a Corporate user
- * reads "employees" and "team". Persona views must never hardcode those
+ * reads "team members" and "team". Persona views must never hardcode those
  * nouns — call `t(...)` from `useTerms()` instead.
  *
  * Resolution order: user-type override -> category -> neutral default, so an
@@ -16,10 +16,15 @@ import type { Persona, PersonaCategory, PersonaUserType } from "./persona";
 export type TermKey =
   | "learner"
   | "group"
+  | "quiz"
+  | "live_quiz"
   | "assignment"
   | "library"
   | "report"
   | "session";
+
+export type TermForm = "singular" | "plural";
+export type TerminologyResolver = (key: TermKey, form?: TermForm) => string;
 
 export interface TermDefinition {
   singular: string;
@@ -31,6 +36,8 @@ export type TerminologyMap = Partial<Record<TermKey, TermDefinition>>;
 export const DEFAULT_TERMS: Record<TermKey, TermDefinition> = {
   learner: { singular: "learner", plural: "learners" },
   group: { singular: "group", plural: "groups" },
+  quiz: { singular: "quiz", plural: "quizzes" },
+  live_quiz: { singular: "live quiz", plural: "live quizzes" },
   assignment: { singular: "quiz", plural: "quizzes" },
   library: { singular: "library", plural: "libraries" },
   report: { singular: "report", plural: "reports" },
@@ -41,14 +48,21 @@ export const CATEGORY_TERMS: Record<PersonaCategory, TerminologyMap> = {
   school: {
     learner: { singular: "student", plural: "students" },
     group: { singular: "class", plural: "classes" },
+    quiz: { singular: "class quiz", plural: "class quizzes" },
+    live_quiz: { singular: "live class quiz", plural: "live class quizzes" },
     assignment: { singular: "homework", plural: "homework" },
     library: { singular: "resources", plural: "resources" },
     report: { singular: "gradebook", plural: "gradebooks" },
-    session: { singular: "lesson", plural: "lessons" },
+    session: { singular: "class quiz", plural: "class quizzes" },
   },
   corporate: {
-    learner: { singular: "employee", plural: "employees" },
+    learner: { singular: "team member", plural: "team members" },
     group: { singular: "team", plural: "teams" },
+    quiz: { singular: "training quiz", plural: "training quizzes" },
+    live_quiz: {
+      singular: "live training session",
+      plural: "live training sessions",
+    },
     assignment: { singular: "course", plural: "courses" },
     library: { singular: "training catalogue", plural: "training catalogues" },
     report: { singular: "compliance record", plural: "compliance records" },
@@ -79,7 +93,7 @@ export const USER_TYPE_TERMS: Partial<
 export function resolveTerm(
   key: TermKey,
   persona: Persona | null,
-  form: "singular" | "plural" = "singular",
+  form: TermForm = "singular",
 ): string {
   const fromUserType = persona
     ? USER_TYPE_TERMS[persona.userType]?.[key]

--- a/server/app/users/models.py
+++ b/server/app/users/models.py
@@ -210,6 +210,21 @@ class UpdateProfileRequest(BaseModel):
         return v
 
 
+class UpdatePersonaRequest(BaseModel):
+    """The only profile fields an authenticated user may change pre-verification."""
+
+    persona_category: PersonaCategoryField
+    persona_user_type: PersonaUserTypeField
+
+    @model_validator(mode="after")
+    def validate_persona(self):
+        if not persona_pair_is_valid(
+            self.persona_category, self.persona_user_type
+        ):
+            raise ValueError("persona_user_type must belong to persona_category")
+        return self
+
+
 class UpdateProfileResponse(BaseModel):
     message: str
     user: UserOut

--- a/server/app/users/routes.py
+++ b/server/app/users/routes.py
@@ -21,7 +21,6 @@ from server.app.users.services import (
     get_user_profile_service,
     update_user_persona_service,
     request_email_change_service,
-    update_user_persona_service,
     update_user_profile_service,
     verify_email_change_service,
 )

--- a/server/app/users/routes.py
+++ b/server/app/users/routes.py
@@ -5,7 +5,12 @@ from server.app.core.dependencies import get_current_user, get_verified_user
 from server.app.core.rate_limiter import RateLimits, limiter
 from server.app.email_platform.deps import get_email_service
 from server.app.email_platform.service import EmailService
-from server.app.users.models import UpdateProfileRequest, UpdateProfileResponse, UserOut
+from server.app.users.models import (
+    UpdatePersonaRequest,
+    UpdateProfileRequest,
+    UpdateProfileResponse,
+    UserOut,
+)
 from server.app.users.schemas import (
     EmailChangeRequest,
     EmailChangeVerifyRequest,
@@ -15,6 +20,7 @@ from server.app.users.services import (
     delete_account_service,
     get_user_profile_service,
     request_email_change_service,
+    update_user_persona_service,
     update_user_profile_service,
     verify_email_change_service,
 )
@@ -62,6 +68,21 @@ async def update_profile(
 ):
     return await update_user_profile_service(
         profile_data,
+        current_user,
+        request.app.state.users_collection,
+    )
+
+
+@router.put("/auth/profile/persona", response_model=UpdateProfileResponse)
+@limiter.limit(RateLimits.API_WRITE)
+async def update_persona(
+    request: Request,
+    response: Response,
+    persona_data: UpdatePersonaRequest,
+    current_user: UserOut = Depends(get_current_user),
+):
+    return await update_user_persona_service(
+        persona_data,
         current_user,
         request.app.state.users_collection,
     )

--- a/server/app/users/services.py
+++ b/server/app/users/services.py
@@ -10,7 +10,12 @@ from server.app.db.core.connection import get_auth_events_collection, get_user_s
 from server.app.db.core.redis import get_redis_client
 from server.app.email_platform.service import EmailService
 from server.app.users.identity import normalize_email, now_utc
-from server.app.users.models import UpdateProfileRequest, UpdateProfileResponse, UserOut
+from server.app.users.models import (
+    UpdatePersonaRequest,
+    UpdateProfileRequest,
+    UpdateProfileResponse,
+    UserOut,
+)
 from server.app.users.persona import persona_update_fields
 from server.app.users.repository import (
     build_user_out_payload,
@@ -89,7 +94,9 @@ async def update_user_profile_service(
         if not user_exists:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    updated_user = await users_collection.find_one({"_id": user_object_id})
+    updated_user = await users_collection.find_one(
+        {"_id": user_object_id, "status": {"$ne": "deleted"}}
+    )
     if not updated_user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -106,6 +113,72 @@ async def update_user_profile_service(
 
     return UpdateProfileResponse(
         message="Profile updated successfully",
+        user=UserOut(
+            **{
+                **build_user_out_payload(updated_user),
+                "created_at": created_at,
+                "updated_at": updated_at_value,
+            }
+        ),
+    )
+
+
+async def update_user_persona_service(
+    persona_data: UpdatePersonaRequest,
+    current_user: UserOut,
+    users_collection: AsyncIOMotorCollection,
+) -> UpdateProfileResponse:
+    """Persist only persona fields for an authenticated user.
+
+    Full profile updates remain verification-gated. This separate operation
+    lets unverified users complete basic workspace setup without widening
+    their ability to edit unrelated account data.
+    """
+    try:
+        user_object_id = ObjectId(current_user.id)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid user ID format: {str(exc)}",
+        ) from exc
+
+    update_data = persona_update_fields(
+        persona_data.persona_category,
+        persona_data.persona_user_type,
+        source="profile",
+    )
+    update_data["updated_at"] = now_utc()
+
+    result = await users_collection.update_one(
+        {"_id": user_object_id, "status": {"$ne": "deleted"}},
+        {"$set": update_data},
+    )
+    if result.modified_count == 0:
+        user_exists = await users_collection.find_one(
+            {"_id": user_object_id, "status": {"$ne": "deleted"}}
+        )
+        if not user_exists:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    updated_user = await users_collection.find_one(
+        {"_id": user_object_id, "status": {"$ne": "deleted"}}
+    )
+    if not updated_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found after update",
+        )
+
+    created_at = updated_user.get("created_at")
+    if isinstance(created_at, datetime):
+        created_at = created_at.isoformat()
+
+    updated_at_value = updated_user.get("updated_at")
+    if isinstance(updated_at_value, datetime):
+        updated_at_value = updated_at_value.isoformat()
+
+    return UpdateProfileResponse(
+        message="Persona updated successfully",
         user=UserOut(
             **{
                 **build_user_out_payload(updated_user),

--- a/server/tests/test_progressive_email_verification.py
+++ b/server/tests/test_progressive_email_verification.py
@@ -9,8 +9,8 @@ from fastapi.params import Depends
 from server.app.auth import routes as auth_routes
 from server.app.auth.services import login_service
 from server.app.users import routes as user_routes
-from server.app.users.models import UserOut
-from server.app.core.dependencies import get_verified_user
+from server.app.users.models import UpdatePersonaRequest, UserOut
+from server.app.core.dependencies import get_current_user, get_verified_user
 from server.app.quiz.models.quiz_models import QuizRequest
 from server.app.quiz.routes.generation import get_quiz
 from server.app.quiz.routes.downloads import download_quiz_handler, limiter
@@ -132,6 +132,44 @@ def test_sensitive_auth_routes_require_verified_user():
     _assert_uses_verified_dependency(user_routes.update_profile)
     _assert_uses_verified_dependency(user_routes.request_email_change)
     _assert_uses_verified_dependency(user_routes.verify_email_change)
+
+
+def test_persona_route_requires_authentication_but_not_verification():
+    dependency = inspect.signature(user_routes.update_persona).parameters[
+        "current_user"
+    ].default
+    assert isinstance(dependency, Depends)
+    assert dependency.dependency is get_current_user
+
+
+@pytest.mark.asyncio
+async def test_unverified_user_can_update_persona_through_persona_route():
+    current_user = _user(is_verified=False)
+    collection = AsyncMock()
+    collection.update_one.return_value = AsyncMock(modified_count=1)
+    collection.find_one.return_value = {
+        "_id": ObjectId(current_user.id),
+        "username": current_user.username,
+        "email": current_user.email,
+        "is_verified": False,
+        "is_active": True,
+        "status": "pending_verification",
+    }
+    request = MagicMock()
+    request.app.state.users_collection = collection
+
+    response = await user_routes.update_persona(
+        request=request,
+        response=Response(),
+        persona_data=UpdatePersonaRequest(
+            persona_category="school", persona_user_type="teacher"
+        ),
+        current_user=current_user,
+    )
+
+    assert response.message == "Persona updated successfully"
+    update_doc = collection.update_one.await_args.args[1]["$set"]
+    assert update_doc["profile.persona.user_type"] == "teacher"
 
 
 def test_login_password_reset_and_verification_routes_do_not_require_verified_user():

--- a/server/tests/test_user_persona.py
+++ b/server/tests/test_user_persona.py
@@ -3,9 +3,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 from bson import ObjectId
+from fastapi import HTTPException
 from pydantic import ValidationError
 
-from server.app.users.models import UpdateProfileRequest, UserPersona
+from server.app.users.models import (
+    UpdatePersonaRequest,
+    UpdateProfileRequest,
+    UserPersona,
+)
 from server.app.users.persona import (
     PERSONA_CATEGORIES,
     PERSONA_USER_TYPES,
@@ -18,7 +23,10 @@ from server.app.users.persona import (
     persona_update_fields,
 )
 from server.app.users.repository import build_user_out_payload
-from server.app.users.services import update_user_profile_service
+from server.app.users.services import (
+    update_user_persona_service,
+    update_user_profile_service,
+)
 
 
 def _user_doc(**overrides):
@@ -146,6 +154,25 @@ class TestUpdateProfileRequest:
             UpdateProfileRequest(persona_user_type="teacher")
 
 
+class TestUpdatePersonaRequest:
+    def test_accepts_matching_required_pair(self):
+        request = UpdatePersonaRequest(
+            persona_category="school", persona_user_type="teacher"
+        )
+        assert request.persona_category == "school"
+
+    @pytest.mark.parametrize(
+        "category,user_type",
+        [("", ""), ("school", ""), ("corporate", "teacher")],
+    )
+    def test_rejects_empty_or_invalid_pairs(self, category, user_type):
+        with pytest.raises(ValidationError):
+            UpdatePersonaRequest(
+                persona_category=category,
+                persona_user_type=user_type,
+            )
+
+
 class TestUserPersonaModel:
     def test_rejects_user_type_outside_category(self):
         with pytest.raises(ValidationError):
@@ -210,3 +237,67 @@ class TestUpdateProfileService:
         update_doc = collection.update_one.await_args.args[1]["$set"]
         assert not any(key.startswith("profile.persona") for key in update_doc)
         assert update_doc["profile.full_name"] == "Ada"
+
+
+class TestUpdatePersonaService:
+    @pytest.mark.asyncio
+    async def test_updates_only_persona_fields(self):
+        user_id = ObjectId()
+        collection = AsyncMock()
+        collection.update_one.return_value = AsyncMock(modified_count=1)
+        collection.find_one.return_value = _user_doc(_id=user_id)
+        current_user = type("CurrentUser", (), {"id": str(user_id)})()
+
+        await update_user_persona_service(
+            UpdatePersonaRequest(
+                persona_category="corporate", persona_user_type="employee"
+            ),
+            current_user,
+            collection,
+        )
+
+        update_doc = collection.update_one.await_args.args[1]["$set"]
+        assert set(update_doc) == {
+            "profile.persona.category",
+            "profile.persona.user_type",
+            "profile.persona.set_at",
+            "profile.persona.source",
+            "updated_at",
+        }
+        assert update_doc["profile.persona.source"] == "profile"
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_missing_or_deleted_user(self):
+        user_id = ObjectId()
+        collection = AsyncMock()
+        collection.update_one.return_value = AsyncMock(modified_count=0)
+        collection.find_one.return_value = None
+        current_user = type("CurrentUser", (), {"id": str(user_id)})()
+
+        with pytest.raises(HTTPException) as exc:
+            await update_user_persona_service(
+                UpdatePersonaRequest(
+                    persona_category="school", persona_user_type="teacher"
+                ),
+                current_user,
+                collection,
+            )
+
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_current_user_id(self):
+        collection = AsyncMock()
+        current_user = type("CurrentUser", (), {"id": "not-an-object-id"})()
+
+        with pytest.raises(HTTPException) as exc:
+            await update_user_persona_service(
+                UpdatePersonaRequest(
+                    persona_category="school", persona_user_type="teacher"
+                ),
+                current_user,
+                collection,
+            )
+
+        assert exc.value.status_code == 400
+        collection.update_one.assert_not_awaited()


### PR DESCRIPTION
## Summary

Implements the category-aware application shell and authenticated dashboard experience.

Closes #123
Closes #124
Closes #125

School and Corporate users now receive terminology, navigation, quick actions, recent activity, and empty states aligned with their saved persona.

## What Changed

- Added a central terminology resolver with neutral, School, Corporate, and user-type overrides.
- Updated shared navigation and workspace surfaces to resolve persona-aware terms instead of embedding category-specific nouns.
- Added School dashboard flows for teachers, lecturers, students, and parents.
- Added Corporate dashboard flows for business users, employees, and HR users.
- Added persona-specific dashboard headlines, quick actions, recent activity, and empty states.
- Made `/dashboard` the default destination for dedicated sign-in flows.
- Preserved contextual login behavior for actions such as saving or downloading a quiz, so users remain on their current flow.
- Updated quiz generation audience fallbacks to use resolved terminology:
  - Neutral: `learners`
  - School: `students`
  - Corporate: `team members`
- Removed the duplicated Generate link from the navbar; quiz creation remains the dedicated CTA.
- Added regression tests for terminology, dashboard rendering, navbar CTA behavior, login routing, and quiz audience fallback.


## How To Test

1. Log in with a School persona, such as `School -> Teacher`.
2. Confirm login redirects to `/dashboard`.
3. Confirm School wording appears across the dashboard and navigation:
   - `Create class quiz`
   - `Join live class quiz`
   - `Revision practice`
   - School-specific recent-activity empty state.
4. Change to another School role, such as Student or Lecturer, and confirm the dashboard headline adapts.
5. Log in with a Corporate persona, such as `Corporate -> Employee` or `HR`.
6. Confirm the Corporate dashboard shows:
   - `Create training quiz`
   - `Run live training session`
   - `Assigned to me` as disabled `Coming soon`
   - Corporate-specific recent-activity empty state.
7. Generate a quiz without entering an audience type:
   - School users should generate for `students`.
   - Corporate users should generate for `team members`.
   - Users without a persona should generate for `learners`.
8. Confirm the navbar shows one quiz-creation CTA only, with no duplicate `Create class quiz` or `Create training quiz` navigation item.
9. Open a generated quiz as a guest and use Save or Download:
   - Sign in when prompted.
   - Confirm the page remains on the current quiz flow rather than redirecting to the dashboard.


## Scope Note

`Assigned to me` is displayed as a disabled “Coming soon” Corporate quick action. Assignment persistence and delivery remain intentionally deferred to a dedicated full-stack issue.