### PR TITLE
feat(dashboard): build student persona view

### DIFF
--- a/client/__tests__/StudentDashboard.test.tsx
+++ b/client/__tests__/StudentDashboard.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import StudentDashboard from "@features/dashboard/school/views/StudentDashboard";
+import type { Persona } from "@shared/config/persona";
+
+const mockPush = jest.fn();
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    pathname: "/dashboard",
+    query: {},
+  }),
+}));
+
+const mockStudentPersona: Persona = {
+  category: "school",
+  userType: "student",
+};
+
+jest.mock("@features/persona/context/personaContext", () => ({
+  usePersona: () => ({
+    persona: mockStudentPersona,
+    isLoading: false,
+  }),
+}));
+
+const mockUser = {
+  id: "u789",
+  username: "sam_student",
+  email: "sam@school.edu",
+  is_verified: true,
+  full_name: "Sam Rivers",
+};
+
+describe("StudentDashboard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("renders practice, history, presets and live-quiz sections", () => {
+    render(<StudentDashboard persona={mockStudentPersona} user={mockUser} />);
+
+    expect(screen.getByText("Practise by subject")).toBeInTheDocument();
+    expect(screen.getByText("My gradebook history")).toBeInTheDocument();
+    expect(screen.getByText("Retry weak areas")).toBeInTheDocument();
+    expect(screen.getByText("Quick-create presets")).toBeInTheDocument();
+    expect(screen.getByText("Self-test")).toBeInTheDocument();
+    expect(screen.getByText("Joining a live lesson?")).toBeInTheDocument();
+  });
+
+  test("navigates to the persona-aware generate page when practising a topic", () => {
+    render(<StudentDashboard persona={mockStudentPersona} user={mockUser} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Practise a topic/i }));
+    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining("/generate?"));
+    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining("persona=student"));
+  });
+
+  test("navigates to quiz history from the history and retry cards", () => {
+    render(<StudentDashboard persona={mockStudentPersona} user={mockUser} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /My gradebook history/i }));
+    expect(mockPush).toHaveBeenCalledWith("/quiz_history");
+
+    fireEvent.click(screen.getByRole("button", { name: /Retry weak areas/i }));
+    expect(mockPush).toHaveBeenCalledWith("/quiz_history");
+  });
+
+  test("navigates to the self-test preset with the preset query param", () => {
+    render(<StudentDashboard persona={mockStudentPersona} user={mockUser} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Create Self-test/i }));
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.stringContaining("preset=self-test"),
+    );
+  });
+
+  test("navigates to the live quiz access page", () => {
+    render(<StudentDashboard persona={mockStudentPersona} user={mockUser} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Join a live quiz/i }));
+    expect(mockPush).toHaveBeenCalledWith("/quiz-access");
+  });
+});

--- a/client/src/features/dashboard/school/views/StudentDashboard.tsx
+++ b/client/src/features/dashboard/school/views/StudentDashboard.tsx
@@ -4,7 +4,6 @@ import React from "react";
 import { useRouter } from "next/router";
 import { useTerms } from "@features/persona/hooks/useTerms";
 import { personaGenerateHref } from "@shared/config/persona";
-import { titleCaseTerm } from "@shared/config/terminology";
 import { BTN_GHOST, BTN_PRIMARY, Kicker } from "@shared/ui/quizwerk";
 import type { DashboardViewProps } from "@features/dashboard/types/dashboard";
 

--- a/client/src/features/dashboard/school/views/StudentDashboard.tsx
+++ b/client/src/features/dashboard/school/views/StudentDashboard.tsx
@@ -1,26 +1,190 @@
 "use client";
 
-// TODO(#128): Student dashboard view.
-//
-// Contract for this file (see features/dashboard/README.md):
-//   * It is rendered inside <DashboardShell> by the category dispatcher —
-//     render sections, not page chrome.
-//   * Every learner/class/team noun comes from useTerms(), never a literal.
-//   * Buttons, containers and rules come from @shared/ui/quizwerk.
-//   * Edit ONLY this file. Anything marked [SCAFFOLD-OWNED] is shared —
-//     raise it in your PR instead of changing it.
-//
-// Acceptance criteria live on the issue.
 import React from "react";
-import DashboardPlaceholder from "@features/dashboard/components/DashboardPlaceholder";
+import { useRouter } from "next/router";
+import { useTerms } from "@features/persona/hooks/useTerms";
+import { personaGenerateHref } from "@shared/config/persona";
+import { titleCaseTerm } from "@shared/config/terminology";
+import { BTN_GHOST, BTN_PRIMARY, Kicker } from "@shared/ui/quizwerk";
 import type { DashboardViewProps } from "@features/dashboard/types/dashboard";
 
+interface StudentPreset {
+  id: string;
+  title: string;
+  badge: string;
+  description: string;
+  href: string;
+}
+
+function studentPresetHref(
+  persona: DashboardViewProps["persona"],
+  preset: string,
+) {
+  return `${personaGenerateHref(persona.userType)}&preset=${preset}`;
+}
+
 export default function StudentDashboard({ persona }: DashboardViewProps) {
+  const router = useRouter();
+  const t = useTerms();
+
+  const presets: StudentPreset[] = [
+    {
+      id: "self-test",
+      title: "Self-test",
+      badge: "Auto-marked / Immediate feedback",
+      description: `Practise any topic with an auto-marked ${t(
+        "assignment",
+      )} that scores itself the moment you finish, so you know straight
+      away what to revise next.`,
+      href: studentPresetHref(persona, "self-test"),
+    },
+  ];
+
   return (
-    <DashboardPlaceholder
-      issue={128}
-      title="Student dashboard"
-      persona={persona}
-    />
+    <div className="flex flex-col gap-[36px]">
+      <section
+        className="border-t-2 border-divider pt-[28px]"
+        aria-labelledby="student-practice-heading"
+      >
+        <Kicker>Practice</Kicker>
+        <div className="flex flex-wrap items-end justify-between gap-[16px]">
+          <div>
+            <h2
+              id="student-practice-heading"
+              className="text-[20px] font-extrabold tracking-[-0.015em] text-ink"
+            >
+              Practise by subject
+            </h2>
+            <p className="mt-[6px] max-w-[58ch] text-[14.5px] leading-[24px] text-ink/70">
+              Pick a topic and get a fresh {t("assignment")} to work through —
+              every attempt is saved to your {t("report")} so you can see how
+              you are doing over time.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => router.push(personaGenerateHref(persona.userType))}
+            className={`${BTN_PRIMARY} px-[28px] py-[14px] text-[16px]`}
+            aria-label="Practise a topic"
+          >
+            Practise a topic
+          </button>
+        </div>
+
+        <div className="mt-[20px] grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] gap-[16px]">
+          <button
+            type="button"
+            onClick={() => router.push("/quiz_history")}
+            className="flex flex-col items-start gap-[6px] border-2 border-divider bg-paper p-[20px] text-left transition hover:border-ink/60 hover:bg-ink/[0.02]"
+            aria-label={`My ${t("report")} history`}
+          >
+            <p className="text-[12px] font-extrabold uppercase tracking-[0.14em] text-brand">
+              History
+            </p>
+            <p className="text-[15px] font-extrabold text-ink">
+              My {t("report")} history
+            </p>
+            <p className="text-[13.5px] leading-[20px] text-ink/70">
+              See every {t("assignment")} you have taken and your score on each
+              one.
+            </p>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => router.push("/quiz_history")}
+            className="flex flex-col items-start gap-[6px] border-2 border-divider bg-paper p-[20px] text-left transition hover:border-ink/60 hover:bg-ink/[0.02]"
+            aria-label="Retry weak areas"
+          >
+            <p className="text-[12px] font-extrabold uppercase tracking-[0.14em] text-brand">
+              Retry
+            </p>
+            <p className="text-[15px] font-extrabold text-ink">
+              Retry weak areas
+            </p>
+            <p className="text-[13.5px] leading-[20px] text-ink/70">
+              Jump back into topics where your scores were lowest and try again.
+            </p>
+          </button>
+        </div>
+      </section>
+
+      <section
+        className="border-t-2 border-divider pt-[28px]"
+        aria-labelledby="student-presets-heading"
+      >
+        <Kicker>Student dashboard</Kicker>
+        <h2
+          id="student-presets-heading"
+          className="text-[20px] font-extrabold tracking-[-0.015em] text-ink"
+        >
+          Quick-create presets
+        </h2>
+        <p className="mt-[6px] max-w-[58ch] text-[14.5px] leading-[24px] text-ink/70">
+          Jumpstart your revision without generic configuration.
+        </p>
+
+        <div className="mt-[20px] grid grid-cols-[repeat(auto-fit,minmax(260px,1fr))] gap-[20px]">
+          {presets.map((preset) => (
+            <article
+              key={preset.id}
+              className="flex flex-col justify-between border-2 border-divider bg-paper p-[20px] text-left transition hover:border-ink/60 hover:bg-ink/[0.02]"
+            >
+              <div>
+                <p className="text-[12px] font-extrabold uppercase tracking-[0.14em] text-brand">
+                  {preset.badge}
+                </p>
+                <h3 className="mt-[10px] text-[17px] font-extrabold text-ink">
+                  {preset.title}
+                </h3>
+                <p className="mt-[8px] text-[13.5px] leading-[22px] text-ink/70">
+                  {preset.description}
+                </p>
+              </div>
+
+              <button
+                type="button"
+                onClick={() => router.push(preset.href)}
+                className={`${BTN_PRIMARY} mt-[20px] w-full`}
+                aria-label={`Create ${preset.title}`}
+              >
+                Create {preset.title}
+              </button>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      <section
+        className="border-t-2 border-divider pt-[28px]"
+        aria-labelledby="student-live-heading"
+      >
+        <Kicker>Live quiz</Kicker>
+        <div className="flex flex-wrap items-end justify-between gap-[16px]">
+          <div>
+            <h2
+              id="student-live-heading"
+              className="text-[20px] font-extrabold tracking-[-0.015em] text-ink"
+            >
+              Joining a live {t("session")}?
+            </h2>
+            <p className="mt-[6px] max-w-[56ch] text-[14.5px] leading-[24px] text-ink/70">
+              Got a code? Enter it to join a live {t("session")} and see your
+              results as soon as it ends.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => router.push("/quiz-access")}
+            className={BTN_GHOST}
+            aria-label="Join a live quiz"
+          >
+            Join a live quiz
+          </button>
+        </div>
+      </section>
+    </div>
   );
 }


### PR DESCRIPTION
Summary
Implements the Student user-type dashboard view inside the School category shell.

Closes #128
Part of Epic: User-type views #140

Acceptance Criteria Verified
[x] Student home surfaces: practice by subject/category entry point,
    "My gradebook history" and "Retry weak areas" cards linking to
    /quiz_history
[x] Self-test generation preset (auto-marked, immediate feedback framing)
[x] Join-a-live-quiz prominent, links to existing /quiz-access flow

How to Test
1. Log in with a user whose persona is set to
   { category: "school", userType: "student" }.
2. Visit /dashboard and confirm the practice section, presets section,
   and live-quiz section all render.
3. Click "Practise a topic" and confirm it navigates to
   /generate?persona=student&category=school&topic=...
4. Click "My gradebook history" or "Retry weak areas" and confirm both
   navigate to /quiz_history.
5. Click "Create Self-test" and confirm it navigates to
   /generate?...&preset=self-test.
6. Click "Join a live quiz" and confirm it opens /quiz-access.

Automated Tests
- cd client && pnpm exec tsc --noEmit (0 errors)
- cd client && pnpm lint (no new warnings)
- cd client && pnpm test (68 passed — this branch predates #154/Lecturer
  merging, so the baseline here is 63 + 5 new Student tests, not the same
  63 baseline #154 reported)

Notes for reviewers
- Same as #126/#127: the preset query param isn't consumed downstream
  yet (GenerationPage.tsx/QuizForm.tsx only read topic/persona/category),
  so "auto-marked, immediate feedback" is the intended framing but not
  functionally wired up yet, pending #133 (Persona-aware generation
  defaults).
- /quiz_history and /quiz-access are hardcoded rather than added to
  ROUTES, matching the existing pattern already used for
  /my-live-quizzes in SchoolDashboard.tsx and TeacherDashboard.tsx/
  LecturerDashboard.tsx.
- Checked LiveQuizAccessCodePanel.tsx, QuizAccessPage.tsx, and
  QuizAccessCodePage.tsx before writing this view — none use the
  quizwerk design tokens (raw Tailwind/hex colours instead), so this
  PR links out to the existing /quiz-access flow rather than embedding
  any of those components directly.
- All aria-labels were checked to contain their visible button text
  (WCAG 2.5.3), following the pattern fixed in #154 after review
  feedback there.