### PR TITLE
feat: add Parent auto-marked practice flow

### DIFF
--- a/PERSONA_SCAFFOLDING.md
+++ b/PERSONA_SCAFFOLDING.md
@@ -21,7 +21,7 @@ profile.persona {category, user_type}      ← server/app/users/persona.py
         ▼
 usePersona()                                ← features/persona/context
         │  profile > ?persona= > localStorage > none
-        ├──► useTerms()   "students" vs "employees"
+        ├──► useTerms()   "students" vs "team members"
         └──► /dashboard   category dispatch → user-type view
 ```
 
@@ -58,8 +58,9 @@ usePersona()                                ← features/persona/context
 | Issue | Story | Landed as |
 |---|---|---|
 | #119 | Persona on the user profile | `server/app/users/{persona,models,repository,services,validators,identity}.py` |
-| #123 | Terminology + nav shell | `shared/config/terminology.ts`, `features/quiz/components/NavBar.tsx` |
+| #123 | Terminology + nav shell | `shared/config/terminology.ts`, `features/quiz/components/{NavBar,Sidebar,Footer}.tsx` |
 | #124 | School dashboard shell | `features/dashboard/school/SchoolDashboard.tsx` |
+| #125 | Corporate dashboard shell | `features/dashboard/corporate/CorporateDashboard.tsx` |
 
 ### Ready to pick up
 
@@ -68,7 +69,6 @@ usePersona()                                ← features/persona/context
 | #120 | Onboarding picker after signup | new `features/auth` wiring | `PersonaPicker` is built — you own where/when it appears and the show-once rule |
 | #121 | Carry home persona through signup | `features/auth/components/SignUpModal.tsx` | Storage + query resolution already exist; carry the value across the auth hop |
 | #122 | Edit persona in settings | `features/profile/pages/ProfilePage.tsx` | Drop in `PersonaPicker`, save via `updatePersona` |
-| #125 | Corporate dashboard shell | `features/dashboard/corporate/CorporateDashboard.tsx` | Mirror `SchoolDashboard.tsx` |
 | #126 | Teacher view | `features/dashboard/school/views/TeacherDashboard.tsx` | |
 | #127 | Lecturer view | `features/dashboard/school/views/LecturerDashboard.tsx` | |
 | #128 | Student view | `features/dashboard/school/views/StudentDashboard.tsx` | Blocked on #143 for scored history |

--- a/client/__tests__/CreateParentPracticePage.test.tsx
+++ b/client/__tests__/CreateParentPracticePage.test.tsx
@@ -47,12 +47,19 @@ describe("CreateParentPracticePage", () => {
     expect(screen.queryByRole("option", { name: "Basic Fractions" })).not.toBeInTheDocument();
   });
 
+  test("selects 20 minutes by default and hides the custom input", () => {
+    render(<CreateParentPracticePage />);
+    expect(screen.getByLabelText("Duration")).toHaveValue("20");
+    expect(screen.queryByLabelText("Custom duration")).not.toBeInTheDocument();
+  });
+
   test("creates public practice with preset-resolved generation values", async () => {
     mockedCreate.mockResolvedValue({
       quizId: "quiz-1",
       title: "Multiplication tables from 2 to 10 — ages 7 to 9",
       questionCount: 10,
       accessCode: "ABC123",
+      durationMinutes: 20,
     });
     render(<CreateParentPracticePage />);
     fireEvent.click(screen.getByRole("button", { name: "Create Practice" }));
@@ -64,6 +71,7 @@ describe("CreateParentPracticePage", () => {
         num_questions: 10,
         audience_type: "children ages 7–9",
       }),
+      20,
     );
     expect(screen.getByRole("region", { name: "Practice ready" })).toBeInTheDocument();
     expect(screen.getByText(/Access code ABC123/)).toBeInTheDocument();
@@ -71,4 +79,63 @@ describe("CreateParentPracticePage", () => {
     fireEvent.click(screen.getByRole("button", { name: "Start Practice" }));
     expect(mockPush).toHaveBeenCalledWith("/quiz-access/ABC123");
   });
+
+  test("normalizes a predefined duration to minutes", async () => {
+    mockedCreate.mockResolvedValue({
+      quizId: "quiz-1",
+      title: "Multiplication tables",
+      questionCount: 10,
+      accessCode: "ABC123",
+      durationMinutes: 45,
+    });
+    render(<CreateParentPracticePage />);
+    fireEvent.change(screen.getByLabelText("Duration"), {
+      target: { value: "45" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create Practice" }));
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    expect(mockedCreate.mock.calls[0][1]).toBe(45);
+  });
+
+  test("shows Custom only when selected and accepts a valid custom duration", async () => {
+    mockedCreate.mockResolvedValue({
+      quizId: "quiz-1",
+      title: "Multiplication tables",
+      questionCount: 10,
+      accessCode: "ABC123",
+      durationMinutes: 27,
+    });
+    render(<CreateParentPracticePage />);
+    expect(screen.queryByLabelText("Custom duration")).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Duration"), {
+      target: { value: "custom" },
+    });
+    const customInput = screen.getByLabelText("Custom duration");
+    fireEvent.change(customInput, { target: { value: "27" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create Practice" }));
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    expect(mockedCreate.mock.calls[0][1]).toBe(27);
+  });
+
+  test.each(["0", "-1", "181", "2.5", "not-a-number"])(
+    "rejects invalid custom duration %s",
+    async (value) => {
+      render(<CreateParentPracticePage />);
+      fireEvent.change(screen.getByLabelText("Duration"), {
+        target: { value: "custom" },
+      });
+      fireEvent.change(screen.getByLabelText("Custom duration"), {
+        target: { value },
+      });
+      fireEvent.click(screen.getByRole("button", { name: "Create Practice" }));
+
+      expect(
+        await screen.findByText(/whole number between 1 and 180 minutes/i),
+      ).toBeInTheDocument();
+      expect(mockedCreate).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/client/__tests__/CreateParentPracticePage.test.tsx
+++ b/client/__tests__/CreateParentPracticePage.test.tsx
@@ -1,0 +1,74 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import CreateParentPracticePage from "@features/parent-practice/pages/CreateParentPracticePage";
+import { createParentPractice } from "@features/parent-practice/api/parentPracticeApi";
+
+const mockPush = jest.fn();
+jest.mock("next/router", () => ({ useRouter: () => ({ push: mockPush }) }));
+jest.mock("@features/auth/components/RequireAuth", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock("@features/quiz/components/NavBar", () => ({
+  __esModule: true,
+  default: () => <nav>Nav</nav>,
+}));
+jest.mock("@features/quiz/components/Footer", () => ({
+  __esModule: true,
+  default: () => <footer>Footer</footer>,
+}));
+jest.mock("@features/persona/context/personaContext", () => ({
+  usePersona: () => ({ userType: "parent", isLoading: false }),
+}));
+jest.mock("@features/parent-practice/api/parentPracticeApi", () => ({
+  createParentPractice: jest.fn(),
+}));
+
+const mockedCreate = createParentPractice as jest.MockedFunction<
+  typeof createParentPractice
+>;
+
+describe("CreateParentPracticePage", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockedCreate.mockReset();
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  test("filters presets when the level changes", () => {
+    render(<CreateParentPracticePage />);
+    fireEvent.change(screen.getByLabelText("Child age/level"), {
+      target: { value: "ages-5-7" },
+    });
+    expect(screen.getByRole("option", { name: "Addition & Subtraction" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "Basic Fractions" })).not.toBeInTheDocument();
+  });
+
+  test("creates public practice with preset-resolved generation values", async () => {
+    mockedCreate.mockResolvedValue({
+      quizId: "quiz-1",
+      title: "Multiplication tables from 2 to 10 — ages 7 to 9",
+      questionCount: 10,
+      accessCode: "ABC123",
+    });
+    render(<CreateParentPracticePage />);
+    fireEvent.click(screen.getByRole("button", { name: "Create Practice" }));
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    expect(mockedCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        question_type: "multichoice",
+        num_questions: 10,
+        audience_type: "children ages 7–9",
+      }),
+    );
+    expect(screen.getByRole("region", { name: "Practice ready" })).toBeInTheDocument();
+    expect(screen.getByText(/Access code ABC123/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Start Practice" }));
+    expect(mockPush).toHaveBeenCalledWith("/quiz-access/ABC123");
+  });
+});

--- a/client/__tests__/DashboardPage.test.tsx
+++ b/client/__tests__/DashboardPage.test.tsx
@@ -48,6 +48,11 @@ jest.mock("@features/quiz-history/api/quizHistoryApi", () => ({
   getUserQuizHistory: jest.fn().mockResolvedValue([]),
 }));
 
+jest.mock("@features/dashboard/components/RecentQuizzes", () => ({
+  __esModule: true,
+  default: ({ heading }: { heading: string }) => <section>{heading}</section>,
+}));
+
 jest.mock("@features/persona/components/PersonaPicker", () => ({
   __esModule: true,
   default: () => <div>persona-picker</div>,
@@ -94,7 +99,27 @@ describe("DashboardPage dispatch", () => {
 
     render(<DashboardPage />);
 
-    expect(screen.getByText("Welcome back, Casey")).toBeInTheDocument();
-    expect(screen.getByText(/New homework/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Welcome back, Casey\. Plan your next class quiz\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText("New class quiz")).toBeInTheDocument();
+    expect(screen.getByText("Join live class quiz")).toBeInTheDocument();
+    expect(screen.getByText("Revision practice")).toBeInTheDocument();
+  });
+
+  test("corporate dashboard uses training actions and employee-aware copy", () => {
+    mockPersona = { category: "corporate", userType: "employee" };
+
+    render(<DashboardPage />);
+
+    expect(
+      screen.getByText(/Welcome back, Casey\. Keep your learning moving\./),
+    ).toBeInTheDocument();
+    expect(screen.getByText("New training quiz")).toBeInTheDocument();
+    expect(screen.getByText("Run live training session")).toBeInTheDocument();
+    expect(screen.getByText("Assigned to me")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /assigned to me/i }),
+    ).toBeDisabled();
   });
 });

--- a/client/__tests__/LiveQuizAttemptDetailPage.test.tsx
+++ b/client/__tests__/LiveQuizAttemptDetailPage.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import LiveQuizAttemptDetailPage from "@features/live-quiz/pages/LiveQuizAttemptDetailPage";
+import { liveQuizService } from "@features/live-quiz/api/liveQuizService";
+
+jest.mock("@features/auth/components/RequireAuth", () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+jest.mock("@features/quiz/components/NavBar", () => ({
+  __esModule: true,
+  default: () => <nav>Nav</nav>,
+}));
+jest.mock("@features/quiz/components/Footer", () => ({
+  __esModule: true,
+  default: () => <footer>Footer</footer>,
+}));
+jest.mock("@features/live-quiz/api/liveQuizService", () => ({
+  liveQuizService: { getAttemptDetail: jest.fn() },
+}));
+
+const getAttemptDetail = liveQuizService.getAttemptDetail as jest.Mock;
+
+test("renders score and correct/incorrect status for every question", async () => {
+  getAttemptDetail.mockResolvedValue({
+    session_id: "session-1",
+    quiz_id: "quiz-1",
+    title: "Multiplication Tables",
+    participant_name: "Sam",
+    score: 1,
+    total_questions: 2,
+    percentage: 50,
+    submitted_at: "2026-08-25T10:00:00Z",
+    auto_submitted: false,
+    graded_answers: [
+      { question_index: 0, question: "2 × 3?", selected_answer: "6", correct_answer: "6", question_type: "multichoice", is_correct: true },
+      { question_index: 1, question: "4 × 4?", selected_answer: "14", correct_answer: "16", question_type: "multichoice", is_correct: false },
+    ],
+  });
+
+  render(<LiveQuizAttemptDetailPage quizId="quiz-1" sessionId="session-1" />);
+  expect(await screen.findByText("1/2")).toBeInTheDocument();
+  expect(screen.getByText("50%")).toBeInTheDocument();
+  expect(screen.getByLabelText("Correct")).toHaveTextContent("✓");
+  expect(screen.getByLabelText("Incorrect")).toHaveTextContent("✗");
+  expect(screen.getByText("Child's answer: 14")).toBeInTheDocument();
+  expect(screen.getByText("Correct answer: 16")).toBeInTheDocument();
+});

--- a/client/__tests__/NavBar.test.ts
+++ b/client/__tests__/NavBar.test.ts
@@ -1,0 +1,11 @@
+import { navigationItems } from "@features/quiz/components/NavBar";
+
+describe("navigationItems", () => {
+  test("keeps quiz creation as the dedicated navigation CTA", () => {
+    const items = navigationItems();
+
+    expect(items).not.toContainEqual(
+      expect.objectContaining({ href: "/generate" }),
+    );
+  });
+});

--- a/client/__tests__/ParentDashboard.test.tsx
+++ b/client/__tests__/ParentDashboard.test.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import ParentDashboard from "@features/dashboard/school/views/ParentDashboard";
+import { liveQuizService } from "@features/live-quiz/api/liveQuizService";
+
+jest.mock("next/router", () => ({ useRouter: () => ({ push: jest.fn() }) }));
+jest.mock("@features/persona/hooks/useTerms", () => ({
+  useTerms: () => (key: string) =>
+    key === "learner" ? "child" : key === "assignment" ? "practice set" : key,
+}));
+jest.mock("@features/live-quiz/api/liveQuizService", () => ({
+  liveQuizService: { listLiveQuizzes: jest.fn() },
+}));
+
+const listLiveQuizzes = liveQuizService.listLiveQuizzes as jest.Mock;
+const props = {
+  persona: { category: "school", userType: "parent" } as const,
+  user: {
+    id: "parent-1",
+    username: "pat",
+    email: "pat@example.com",
+    is_verified: true,
+  },
+};
+
+describe("ParentDashboard", () => {
+  beforeEach(() => listLiveQuizzes.mockReset());
+
+  test("shows the create action and empty state", async () => {
+    listLiveQuizzes.mockResolvedValue([]);
+    render(<ParentDashboard {...props} />);
+    expect(screen.getByRole("link", { name: "Create Practice" })).toHaveAttribute(
+      "href",
+      "/parent-practice/new",
+    );
+    expect(await screen.findByText(/No practice yet/)).toBeInTheDocument();
+  });
+
+  test("shows completed attempts, latest score, and result link", async () => {
+    listLiveQuizzes.mockResolvedValue([
+      {
+        quiz_id: "quiz-1",
+        title: "Multiplication Tables",
+        status: "active",
+        participant_count: 2,
+        completed_count: 2,
+        latest_score: 8,
+        latest_percentage: 80,
+      },
+    ]);
+    render(<ParentDashboard {...props} />);
+    expect(await screen.findByText("Multiplication Tables")).toBeInTheDocument();
+    expect(screen.getByText(/2 completed attempts · Latest: 8 \(80%\)/)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View results" })).toHaveAttribute(
+      "href",
+      "/my-live-quizzes/quiz-1",
+    );
+    await waitFor(() => expect(listLiveQuizzes).toHaveBeenCalledTimes(1));
+  });
+});

--- a/client/__tests__/PersonaProvider.test.tsx
+++ b/client/__tests__/PersonaProvider.test.tsx
@@ -1,0 +1,185 @@
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+import {
+  PersonaProvider,
+  usePersona,
+} from "@features/persona/context/personaContext";
+import { updatePersona } from "@features/persona/api/personaApi";
+
+const authState: {
+  user: any;
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  refreshUser: jest.Mock;
+} = {
+  user: null,
+  isAuthenticated: false,
+  isLoading: false,
+  refreshUser: jest.fn(),
+};
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ query: {} }),
+}));
+
+jest.mock("@features/auth/context/authContext", () => ({
+  useAuth: () => authState,
+}));
+
+jest.mock("@features/persona/api/personaApi", () => ({
+  updatePersona: jest.fn(),
+}));
+
+function Probe() {
+  const { persona, source, isLoading, setPersona } = usePersona();
+  return (
+    <>
+      <output data-testid="persona">
+        {persona ? `${persona.category}:${persona.userType}:${source}` : "none"}
+      </output>
+      <output data-testid="loading">{String(isLoading)}</output>
+      <button
+        type="button"
+        onClick={() => {
+          void setPersona({ category: "school", userType: "teacher" }).catch(
+            () => undefined,
+          );
+        }}
+      >
+        Set teacher
+      </button>
+    </>
+  );
+}
+
+function renderProvider() {
+  return render(
+    <PersonaProvider>
+      <Probe />
+    </PersonaProvider>,
+  );
+}
+
+describe("PersonaProvider", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    authState.user = null;
+    authState.isAuthenticated = false;
+    authState.isLoading = false;
+    authState.refreshUser.mockReset();
+    jest.mocked(updatePersona).mockReset();
+  });
+
+  test("does not read browser storage during server rendering", () => {
+    window.localStorage.setItem(
+      "quizwerk.persona",
+      JSON.stringify({ v: 1, category: "school", userType: "teacher" }),
+    );
+
+    const html = renderToString(
+      <PersonaProvider>
+        <Probe />
+      </PersonaProvider>,
+    );
+
+    // Server markup must stay neutral even when a browser preference exists.
+    // The client only reads storage from useEffect after hydration.
+    expect(html).toContain("none");
+  });
+
+  test("hydrates a guest persona after mount", async () => {
+    window.localStorage.setItem(
+      "quizwerk.persona",
+      JSON.stringify({ v: 1, category: "school", userType: "teacher" }),
+    );
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona")).toHaveTextContent(
+        "school:teacher:storage",
+      );
+    });
+  });
+
+  test("does not use guest storage as an authenticated fallback", async () => {
+    window.localStorage.setItem(
+      "quizwerk.persona",
+      JSON.stringify({ v: 1, category: "school", userType: "teacher" }),
+    );
+    authState.user = {
+      id: "user-b",
+      username: "b",
+      email: "b@example.com",
+      is_verified: false,
+    };
+    authState.isAuthenticated = true;
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("persona")).toHaveTextContent("none");
+    });
+  });
+
+  test("does not create local persona state when authenticated persistence fails", async () => {
+    authState.user = {
+      id: "user-a",
+      username: "a",
+      email: "a@example.com",
+      is_verified: false,
+    };
+    authState.isAuthenticated = true;
+    jest.mocked(updatePersona).mockRejectedValueOnce(new Error("network"));
+
+    renderProvider();
+
+    await act(async () => {
+      screen.getByRole("button", { name: "Set teacher" }).click();
+    });
+
+    expect(updatePersona).toHaveBeenCalledWith({
+      category: "school",
+      userType: "teacher",
+    });
+    expect(window.localStorage.getItem("quizwerk.persona")).toBeNull();
+    expect(screen.getByTestId("persona")).toHaveTextContent("none");
+  });
+
+  test("clears guest storage after an authenticated session ends", async () => {
+    window.localStorage.setItem(
+      "quizwerk.persona",
+      JSON.stringify({ v: 1, category: "school", userType: "teacher" }),
+    );
+    authState.user = {
+      id: "user-a",
+      username: "a",
+      email: "a@example.com",
+      is_verified: true,
+      persona_category: "corporate",
+      persona_user_type: "employee",
+    };
+    authState.isAuthenticated = true;
+
+    const view = renderProvider();
+    await waitFor(() => {
+      expect(screen.getByTestId("persona")).toHaveTextContent(
+        "corporate:employee:profile",
+      );
+    });
+
+    authState.user = null;
+    authState.isAuthenticated = false;
+    view.rerender(
+      <PersonaProvider>
+        <Probe />
+      </PersonaProvider>,
+    );
+
+    await waitFor(() => {
+      expect(window.localStorage.getItem("quizwerk.persona")).toBeNull();
+      expect(screen.getByTestId("persona")).toHaveTextContent("none");
+    });
+  });
+});

--- a/client/__tests__/QuizForm.test.tsx
+++ b/client/__tests__/QuizForm.test.tsx
@@ -93,5 +93,10 @@ describe("QuizForm", () => {
         expect.stringContaining("/quiz_display?"),
       );
     });
+
+    expect(publicApi.post).toHaveBeenCalledWith(
+      "/api/get-questions",
+      expect.objectContaining({ audience_type: "learners" }),
+    );
   });
 });

--- a/client/__tests__/RecentQuizzes.test.tsx
+++ b/client/__tests__/RecentQuizzes.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import RecentQuizzes from "@features/dashboard/components/RecentQuizzes";
+import { getUserQuizHistory } from "@features/quiz-history/api/quizHistoryApi";
+
+const authState: { user: { is_verified: boolean } | null } = {
+  user: null,
+};
+
+jest.mock("next/router", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock("@features/auth/context/authContext", () => ({
+  useAuth: () => authState,
+}));
+
+jest.mock("@features/quiz-history/api/quizHistoryApi", () => ({
+  getUserQuizHistory: jest.fn(),
+}));
+
+describe("RecentQuizzes", () => {
+  beforeEach(() => {
+    authState.user = null;
+    jest.mocked(getUserQuizHistory).mockReset();
+  });
+
+  test("does not request verified-only history for an unverified user", async () => {
+    authState.user = { is_verified: false };
+    render(<RecentQuizzes heading="Recent activity" emptyMessage="Empty" />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Verify your email to view recent activity."),
+      ).toBeInTheDocument();
+    });
+    expect(getUserQuizHistory).not.toHaveBeenCalled();
+  });
+
+  test("shows the persona-specific empty state for a verified user", async () => {
+    authState.user = { is_verified: true };
+    jest.mocked(getUserQuizHistory).mockResolvedValueOnce([]);
+    render(<RecentQuizzes heading="Recent activity" emptyMessage="Empty" />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Empty")).toBeInTheDocument();
+    });
+  });
+});

--- a/client/__tests__/SignInModal.test.tsx
+++ b/client/__tests__/SignInModal.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import SignInModal from "@features/auth/components/SignInModal";
+import { ROUTES } from "@shared/config/patterns/routes";
 
 const mockRouterPush = jest.fn();
 const mockAuthLogin = jest.fn();
@@ -119,6 +120,30 @@ describe("SignInModal", () => {
 
     await waitFor(() => {
       expect(mockOnClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  test("routes to the configured post-login destination", async () => {
+    render(
+      <SignInModal
+        isOpen={true}
+        onClose={mockOnClose}
+        redirectTo={ROUTES.DASHBOARD}
+        switchToSignUp={mockSwitchToSignUp}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByPlaceholderText("email@example.com or username"),
+      { target: { value: "testuser@example.com" } },
+    );
+    fireEvent.change(screen.getByPlaceholderText("Enter your password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockRouterPush).toHaveBeenCalledWith(ROUTES.DASHBOARD);
     });
   });
 

--- a/client/__tests__/parentPracticeApi.test.ts
+++ b/client/__tests__/parentPracticeApi.test.ts
@@ -33,7 +33,7 @@ describe("parentPracticeApi", () => {
       },
     });
 
-    await createParentPractice(params);
+    await createParentPractice(params, 27);
 
     expect(post).toHaveBeenCalledWith(
       "/api/get-questions",
@@ -44,9 +44,20 @@ describe("parentPracticeApi", () => {
         invited_emails: [],
         send_email_invitations: false,
         allow_fallback: true,
+        time_limit_minutes: 27,
       }),
     );
   });
+
+  test.each([0, -1, 181, 2.5, Number.NaN])(
+    "rejects invalid duration %s before making a request",
+    async (duration) => {
+      await expect(createParentPractice(params, duration)).rejects.toThrow(
+        /between 1 and 180 minutes/i,
+      );
+      expect(post).not.toHaveBeenCalled();
+    },
+  );
 
   test("rejects unrelated generic fallback content", async () => {
     post.mockResolvedValue({

--- a/client/__tests__/parentPracticeApi.test.ts
+++ b/client/__tests__/parentPracticeApi.test.ts
@@ -1,0 +1,65 @@
+import { createParentPractice } from "@features/parent-practice/api/parentPracticeApi";
+import { api } from "@shared/api/http";
+
+jest.mock("@shared/api/http", () => ({
+  api: { post: jest.fn() },
+}));
+
+const post = api.post as jest.Mock;
+const params = {
+  profession: "Multiplication tables — ages 7 to 9",
+  audience_type: "children ages 7–9",
+  difficulty_level: "easy" as const,
+  question_type: "multichoice" as const,
+  num_questions: 10,
+  custom_instruction: "Use exact multiplication facts.",
+};
+
+describe("parentPracticeApi", () => {
+  beforeEach(() => {
+    post.mockReset();
+    delete process.env.NEXT_PUBLIC_PARENT_PRACTICE_ALLOW_FALLBACK;
+  });
+
+  test("uses the existing generation endpoint with public live participation", async () => {
+    process.env.NEXT_PUBLIC_PARENT_PRACTICE_ALLOW_FALLBACK = "true";
+    post.mockResolvedValue({
+      data: {
+        quiz_id: "quiz-1",
+        access_code: "ABC123",
+        questions: Array.from({ length: 10 }, (_, index) => ({
+          question: `Question ${index + 1}`,
+        })),
+      },
+    });
+
+    await createParentPractice(params);
+
+    expect(post).toHaveBeenCalledWith(
+      "/api/get-questions",
+      expect.objectContaining({
+        ...params,
+        live_quiz_enabled: true,
+        participant_access_mode: "public",
+        invited_emails: [],
+        send_email_invitations: false,
+        allow_fallback: true,
+      }),
+    );
+  });
+
+  test("rejects unrelated generic fallback content", async () => {
+    post.mockResolvedValue({
+      data: {
+        ai_down: true,
+        quiz_id: "quiz-1",
+        access_code: "ABC123",
+        questions: [{ question: "Unrelated mock question" }],
+      },
+    });
+
+    await expect(createParentPractice(params)).rejects.toThrow(
+      /temporarily unavailable/i,
+    );
+  });
+});

--- a/client/__tests__/parentPracticePresets.test.ts
+++ b/client/__tests__/parentPracticePresets.test.ts
@@ -1,0 +1,54 @@
+import {
+  getPresetsForLevel,
+  PARENT_PRACTICE_PRESETS,
+  resolveParentPracticePreset,
+} from "@features/parent-practice/config/presets";
+
+describe("Parent Practice presets", () => {
+  test("preset identifiers are unique", () => {
+    const ids = PARENT_PRACTICE_PRESETS.map((preset) => preset.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  test("only exposes presets appropriate for a level", () => {
+    expect(getPresetsForLevel("ages-5-7").map((preset) => preset.id)).toEqual([
+      "addition-subtraction",
+      "vocabulary-practice",
+    ]);
+    expect(getPresetsForLevel("ages-9-11").map((preset) => preset.id)).toEqual([
+      "multiplication-tables",
+      "basic-fractions",
+      "vocabulary-practice",
+    ]);
+  });
+
+  test("resolves multiplication practice into the existing QuizRequest fields", () => {
+    expect(
+      resolveParentPracticePreset("ages-7-9", "multiplication-tables"),
+    ).toEqual(
+      expect.objectContaining({
+        profession: "Multiplication tables from 2 to 10 — ages 7 to 9",
+        audience_type: "children ages 7–9",
+        difficulty_level: "easy",
+        question_type: "multichoice",
+        num_questions: 10,
+      }),
+    );
+  });
+
+  test("allows a valid question-count override", () => {
+    expect(
+      resolveParentPracticePreset(
+        "ages-9-11",
+        "basic-fractions",
+        6,
+      ).num_questions,
+    ).toBe(6);
+  });
+
+  test("rejects a preset that is unavailable for the selected level", () => {
+    expect(() =>
+      resolveParentPracticePreset("ages-5-7", "basic-fractions"),
+    ).toThrow(/not available/i);
+  });
+});

--- a/client/__tests__/terminology.test.ts
+++ b/client/__tests__/terminology.test.ts
@@ -4,6 +4,9 @@ describe("resolveTerm", () => {
   test("falls back to neutral wording when persona is unset", () => {
     expect(resolveTerm("learner", null, "plural")).toBe("learners");
     expect(resolveTerm("group", null)).toBe("group");
+    expect(resolveTerm("quiz", null)).toBe("quiz");
+    expect(resolveTerm("live_quiz", null)).toBe("live quiz");
+    expect(resolveTerm("session", null)).toBe("session");
   });
 
   test("uses category wording", () => {
@@ -12,8 +15,14 @@ describe("resolveTerm", () => {
 
     expect(resolveTerm("learner", teacher, "plural")).toBe("students");
     expect(resolveTerm("group", teacher)).toBe("class");
-    expect(resolveTerm("learner", business, "plural")).toBe("employees");
+    expect(resolveTerm("quiz", teacher)).toBe("class quiz");
+    expect(resolveTerm("live_quiz", teacher)).toBe("live class quiz");
+    expect(resolveTerm("session", teacher)).toBe("class quiz");
+    expect(resolveTerm("learner", business, "plural")).toBe("team members");
     expect(resolveTerm("group", business)).toBe("team");
+    expect(resolveTerm("quiz", business)).toBe("training quiz");
+    expect(resolveTerm("live_quiz", business)).toBe("live training session");
+    expect(resolveTerm("session", business)).toBe("training session");
   });
 
   test("user-type overrides beat the category", () => {
@@ -29,6 +38,7 @@ describe("resolveTerm", () => {
 
     // lecturer overrides group/session but not learner
     expect(resolveTerm("learner", lecturer, "plural")).toBe("students");
+    expect(resolveTerm("live_quiz", lecturer)).toBe("live class quiz");
   });
 
   test("reports differ per category", () => {

--- a/client/jest.setup.ts
+++ b/client/jest.setup.ts
@@ -1,1 +1,4 @@
 import '@testing-library/jest-dom'
+import { TextDecoder, TextEncoder } from "util";
+
+Object.assign(global, { TextDecoder, TextEncoder });

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -62,7 +62,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         <SignInModal
           isOpen={showSignInModal}
           onClose={closeSignInModal}
-          redirectTo={ROUTES.HOME}
+          redirectTo={ROUTES.DASHBOARD}
           switchToSignUp={() => {
             closeSignInModal();
             router.push(ROUTES.REGISTER);

--- a/client/pages/my-live-quizzes/[quizId]/attempts/[sessionId].tsx
+++ b/client/pages/my-live-quizzes/[quizId]/attempts/[sessionId].tsx
@@ -1,0 +1,11 @@
+import type { GetServerSideProps } from "next";
+import LiveQuizAttemptDetailPage from "@features/live-quiz/pages/LiveQuizAttemptDetailPage";
+
+export default LiveQuizAttemptDetailPage;
+
+export const getServerSideProps: GetServerSideProps = async ({ params }) => ({
+  props: {
+    quizId: String(params?.quizId || ""),
+    sessionId: String(params?.sessionId || ""),
+  },
+});

--- a/client/pages/my-live-quizzes/[quizId]/index.tsx
+++ b/client/pages/my-live-quizzes/[quizId]/index.tsx
@@ -333,6 +333,9 @@ const LiveQuizCreatorDashboard: React.FC<LiveQuizCreatorDashboardProps> = ({
                   <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
                     Duration
                   </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                    Results
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200 bg-white">
@@ -385,6 +388,23 @@ const LiveQuizCreatorDashboard: React.FC<LiveQuizCreatorDashboardProps> = ({
                     </td>
                     <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
                       {formatDuration(p.duration_seconds)}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm">
+                      {p.submitted_at ? (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            router.push(
+                              `/my-live-quizzes/${quizId}/attempts/${p.session_id}`,
+                            )
+                          }
+                          className="font-semibold text-[#0a3264] underline"
+                        >
+                          View answers
+                        </button>
+                      ) : (
+                        "—"
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/client/pages/parent-practice/new.tsx
+++ b/client/pages/parent-practice/new.tsx
@@ -1,0 +1,1 @@
+export { default } from "@features/parent-practice/pages/CreateParentPracticePage";

--- a/client/src/features/auth/pages/LoginPage.tsx
+++ b/client/src/features/auth/pages/LoginPage.tsx
@@ -34,7 +34,7 @@ export default function LoginPage() {
       <SignInModal
         isOpen={isModalOpen}
         onClose={() => setIsModalOpen(false)}
-        redirectTo={ROUTES.HOME}
+        redirectTo={ROUTES.DASHBOARD}
         switchToSignUp={() => {
           setIsModalOpen(false);
           router.push(ROUTES.REGISTER);

--- a/client/src/features/auth/pages/RegisterPage.tsx
+++ b/client/src/features/auth/pages/RegisterPage.tsx
@@ -31,7 +31,7 @@ const RegisterPage: React.FC = () => {
       <SignInModal
         isOpen={showLogin}
         onClose={() => setShowLogin(false)}
-        redirectTo={ROUTES.HOME}
+        redirectTo={ROUTES.DASHBOARD}
         switchToSignUp={() => {
           setShowLogin(false);
           setShowSignUp(true);

--- a/client/src/features/dashboard/README.md
+++ b/client/src/features/dashboard/README.md
@@ -7,7 +7,7 @@ dashboard, which dispatches to a **user-type** view.
 pages/DashboardPage.tsx        [SCAFFOLD-OWNED]  auth + persona gate + category dispatch
   school/SchoolDashboard.tsx   #124 (done)       category chrome + user-type dispatch map
     school/views/*.tsx         one ticket each   #126 #127 #128 #129
-  corporate/CorporateDashboard.tsx  #125         mirror SchoolDashboard
+  corporate/CorporateDashboard.tsx  #125 (done)  category chrome + user-type dispatch map
     corporate/views/*.tsx      one ticket each   #130 #131 #132
 components/                    [SCAFFOLD-OWNED]  DashboardShell, QuickActions,
                                                  RecentQuizzes, DashboardPlaceholder,

--- a/client/src/features/dashboard/components/QuickActions.tsx
+++ b/client/src/features/dashboard/components/QuickActions.tsx
@@ -3,11 +3,14 @@
 import React from "react";
 import { useRouter } from "next/router";
 
-export interface QuickAction {
+interface QuickActionBase {
   label: string;
   description: string;
-  href: string;
 }
+
+export type QuickAction =
+  | (QuickActionBase & { href: string; unavailable?: never })
+  | (QuickActionBase & { href?: never; unavailable: true });
 
 /**
  * [SCAFFOLD-OWNED] Row of primary entry points at the top of a dashboard.
@@ -23,8 +26,11 @@ export default function QuickActions({ actions }: { actions: QuickAction[] }) {
           <button
             key={action.label}
             type="button"
-            onClick={() => router.push(action.href)}
-            className="border-t-2 border-divider px-[6px] py-[20px] text-left transition hover:bg-ink/[0.05] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand"
+            onClick={() => {
+              if (!action.unavailable) router.push(action.href);
+            }}
+            disabled={action.unavailable}
+            className="border-t-2 border-divider px-[6px] py-[20px] text-left transition hover:bg-ink/[0.05] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-transparent"
           >
             <span className="flex items-start gap-[14px]">
               <span className="mt-[6px] h-[8px] w-[8px] flex-none bg-brand" />
@@ -35,6 +41,11 @@ export default function QuickActions({ actions }: { actions: QuickAction[] }) {
                 <span className="mt-[4px] block text-[13.5px] leading-[22px] text-ink/70">
                   {action.description}
                 </span>
+                {action.unavailable ? (
+                  <span className="mt-[8px] block text-[11px] font-extrabold uppercase tracking-[0.1em] text-ink/60">
+                    Coming soon
+                  </span>
+                ) : null}
               </span>
             </span>
           </button>

--- a/client/src/features/dashboard/components/RecentQuizzes.tsx
+++ b/client/src/features/dashboard/components/RecentQuizzes.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import { useRouter } from "next/router";
+import { useAuth } from "@features/auth/context/authContext";
 import { getUserQuizHistory } from "@features/quiz-history/api/quizHistoryApi";
 
 interface HistoryRow {
@@ -28,9 +29,15 @@ export default function RecentQuizzes({
   limit?: number;
 }) {
   const router = useRouter();
+  const { user } = useAuth();
   const [rows, setRows] = useState<HistoryRow[] | null>(null);
 
   useEffect(() => {
+    if (!user?.is_verified) {
+      setRows([]);
+      return;
+    }
+
     let active = true;
     getUserQuizHistory().then((history) => {
       if (active) setRows(Array.isArray(history) ? history.slice(0, limit) : []);
@@ -38,7 +45,7 @@ export default function RecentQuizzes({
     return () => {
       active = false;
     };
-  }, [limit]);
+  }, [limit, user?.is_verified]);
 
   return (
     <section className="border-t-2 border-divider pt-[28px]">
@@ -48,6 +55,10 @@ export default function RecentQuizzes({
 
       {rows === null ? (
         <p className="mt-[14px] text-[14px] text-ink/60">Loading…</p>
+      ) : !user?.is_verified ? (
+        <p className="mt-[14px] max-w-[52ch] text-[15px] leading-[26px] text-ink/70">
+          Verify your email to view recent activity.
+        </p>
       ) : rows.length === 0 ? (
         <p className="mt-[14px] max-w-[52ch] text-[15px] leading-[26px] text-ink/70">
           {emptyMessage}

--- a/client/src/features/dashboard/corporate/CorporateDashboard.tsx
+++ b/client/src/features/dashboard/corporate/CorporateDashboard.tsx
@@ -1,22 +1,41 @@
 "use client";
 
-// TODO(#125): Corporate category dashboard.
-//
-// Build this to mirror school/SchoolDashboard.tsx — that file is the
-// reference implementation: DashboardShell + QuickActions + RecentQuizzes,
-// with the user-type view composed underneath, all wording via useTerms().
-// Suggested actions: New training quiz / Run live session / Assigned to me.
-//
-// The dispatch map below is [SCAFFOLD-OWNED] and already complete; the
-// user-type leaves belong to #130, #131 and #132.
 import React, { ComponentType } from "react";
-import type { CorporateUserType } from "@shared/config/persona";
+import {
+  getCategoryDefinition,
+  personaGenerateHref,
+  type CorporateUserType,
+} from "@shared/config/persona";
+import { type TerminologyResolver } from "@shared/config/terminology";
 import { useTerms } from "@features/persona/hooks/useTerms";
 import DashboardShell from "@features/dashboard/components/DashboardShell";
+import QuickActions from "@features/dashboard/components/QuickActions";
+import RecentQuizzes from "@features/dashboard/components/RecentQuizzes";
 import type { DashboardViewProps } from "@features/dashboard/types/dashboard";
 import BusinessDashboard from "./views/BusinessDashboard";
 import EmployeeDashboard from "./views/EmployeeDashboard";
 import HrDashboard from "./views/HrDashboard";
+
+const CORPORATE_COPY: Record<
+  CorporateUserType,
+  { title: string; lede: (t: TerminologyResolver) => string }
+> = {
+  business: {
+    title: "Build the next training session.",
+    lede: (t) =>
+      `Create practical training for your ${t("group", "plural")}, run it live, and keep a clear record of progress.`,
+  },
+  employee: {
+    title: "Keep your learning moving.",
+    lede: () =>
+      "Build practice quizzes and return to the training that matters to your role.",
+  },
+  hr: {
+    title: "Keep compliance training on track.",
+    lede: () =>
+      "Create focused training and maintain the records your organisation needs.",
+  },
+};
 
 const CORPORATE_VIEWS: Record<
   CorporateUserType,
@@ -33,19 +52,46 @@ export default function CorporateDashboard({
 }: DashboardViewProps) {
   const t = useTerms();
   const UserTypeView = CORPORATE_VIEWS[persona.userType as CorporateUserType];
+  const copy = CORPORATE_COPY[persona.userType as CorporateUserType];
 
   const greetingName = user.full_name?.split(" ")[0] || user.username;
 
   return (
     <DashboardShell
-      kicker="Corporate"
-      title={`Welcome back, ${greetingName}`}
-      lede={`Build and run training for your ${t(
-        "group",
-        "plural",
-      )}, and keep the ${t("report", "plural")} to prove it.`}
+      kicker={getCategoryDefinition(persona.category).label}
+      title={`Welcome back, ${greetingName}. ${copy.title}`}
+      lede={`${copy.lede(t)} Everything for your ${t("group", "plural")} is in one place.`}
     >
-      <UserTypeView persona={persona} user={user} />
+      <div className="flex flex-col gap-[36px]">
+        <QuickActions
+          actions={[
+            {
+              label: `New ${t("quiz")}`,
+              description: `Generate a ${t("quiz")} for any training topic, with the answer key included.`,
+              href: personaGenerateHref(persona.userType),
+            },
+            {
+              label: `Run ${t("live_quiz")}`,
+              description: "Manage live training and review participation from one workspace.",
+              href: "/my-live-quizzes",
+            },
+            {
+              label: "Assigned to me",
+              description: "Assigned training will appear here when assignment workflows arrive.",
+              unavailable: true,
+            },
+          ]}
+        />
+
+        <RecentQuizzes
+          heading="Recent training activity"
+          emptyMessage={`Nothing here yet. Generate your first ${t(
+            "quiz",
+          )} and it will show up here with your recent training activity.`}
+        />
+
+        <UserTypeView persona={persona} user={user} />
+      </div>
     </DashboardShell>
   );
 }

--- a/client/src/features/dashboard/school/SchoolDashboard.tsx
+++ b/client/src/features/dashboard/school/SchoolDashboard.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import React, { ComponentType } from "react";
-import { personaGenerateHref, type SchoolUserType } from "@shared/config/persona";
-import { titleCaseTerm } from "@shared/config/terminology";
+import {
+  getCategoryDefinition,
+  personaGenerateHref,
+  type SchoolUserType,
+} from "@shared/config/persona";
+import { type TerminologyResolver } from "@shared/config/terminology";
 import { useTerms } from "@features/persona/hooks/useTerms";
 import DashboardShell from "@features/dashboard/components/DashboardShell";
 import QuickActions from "@features/dashboard/components/QuickActions";
@@ -13,12 +17,38 @@ import LecturerDashboard from "./views/LecturerDashboard";
 import StudentDashboard from "./views/StudentDashboard";
 import ParentDashboard from "./views/ParentDashboard";
 
+const SCHOOL_COPY: Record<
+  SchoolUserType,
+  { title: string; lede: (t: TerminologyResolver) => string }
+> = {
+  teacher: {
+    title: "Plan your next class quiz.",
+    lede: (t) =>
+      `Set work, run it live, and see how your ${t("learner", "plural")} did.`,
+  },
+  lecturer: {
+    title: "Get your next lecture ready.",
+    lede: (t) =>
+      `Create focused checks for your ${t("group", "plural")} and review the results.`,
+  },
+  student: {
+    title: "Ready for revision?",
+    lede: (t) =>
+      `Build a practice quiz and strengthen your understanding before the next ${t("group")}.`,
+  },
+  parent: {
+    title: "Make practice time count.",
+    lede: (t) =>
+      `Create a short practice quiz to support your ${t("learner")}'s learning at home.`,
+  },
+};
+
 /**
  * [SCAFFOLD-OWNED] School category dashboard (#124).
  *
  * Reference implementation for the persona dashboards: category-level
  * chrome (quick actions, recent activity) with the user-type view composed
- * underneath. Corporate (#125) should mirror this shape.
+ * underneath.
  *
  * The dispatch map is written complete so each user-type ticket only ever
  * edits its own leaf file — do not convert it to next/dynamic, the static
@@ -34,35 +64,28 @@ const SCHOOL_VIEWS: Record<SchoolUserType, ComponentType<DashboardViewProps>> = 
 export default function SchoolDashboard({ persona, user }: DashboardViewProps) {
   const t = useTerms();
   const UserTypeView = SCHOOL_VIEWS[persona.userType as SchoolUserType];
+  const copy = SCHOOL_COPY[persona.userType as SchoolUserType];
 
   const greetingName = user.full_name?.split(" ")[0] || user.username;
 
   return (
     <DashboardShell
-      kicker="School"
-      title={`Welcome back, ${greetingName}`}
-      lede={`Set work, run it live, and see how your ${t(
-        "learner",
-        "plural",
-      )} did — everything for your ${t("group", "plural")} in one place.`}
+      kicker={getCategoryDefinition(persona.category).label}
+      title={`Welcome back, ${greetingName}. ${copy.title}`}
+      lede={`${copy.lede(t)} Everything for your ${t("group", "plural")} is in one place.`}
     >
       <div className="flex flex-col gap-[36px]">
         <QuickActions
           actions={[
             {
-              label: `New ${t("assignment")}`,
-              description: `Generate a ${t(
-                "assignment",
-              )} on any topic, with the answer key included.`,
+              label: `New ${t("quiz")}`,
+              description: `Generate a ${t("quiz")} on any topic, with the answer key included.`,
               href: personaGenerateHref(persona.userType),
             },
             {
-              label: `Run a live ${t("session")}`,
-              description: `Put a join code on the projector and score your ${t(
-                "learner",
-                "plural",
-              )} in real time.`,
-              href: "/my-live-quizzes",
+              label: `Join ${t("live_quiz")}`,
+              description: `Enter an access code to join a ${t("live_quiz")}.`,
+              href: "/quiz-access",
             },
             {
               label: "Revision practice",
@@ -73,10 +96,10 @@ export default function SchoolDashboard({ persona, user }: DashboardViewProps) {
         />
 
         <RecentQuizzes
-          heading={`${titleCaseTerm(t("assignment", "plural"))} you made recently`}
+          heading={`Recent ${t("quiz", "plural")}`}
           emptyMessage={`Nothing here yet. Generate your first ${t(
-            "assignment",
-          )} and it will show up here, ready to run with your ${t(
+            "quiz",
+          )} and it will show up here, ready to use with your ${t(
             "group",
             "plural",
           )}.`}

--- a/client/src/features/dashboard/school/views/ParentDashboard.tsx
+++ b/client/src/features/dashboard/school/views/ParentDashboard.tsx
@@ -1,26 +1,86 @@
 "use client";
 
-// TODO(#129): Parent dashboard view.
-//
-// Contract for this file (see features/dashboard/README.md):
-//   * It is rendered inside <DashboardShell> by the category dispatcher —
-//     render sections, not page chrome.
-//   * Every learner/class/team noun comes from useTerms(), never a literal.
-//   * Buttons, containers and rules come from @shared/ui/quizwerk.
-//   * Edit ONLY this file. Anything marked [SCAFFOLD-OWNED] is shared —
-//     raise it in your PR instead of changing it.
-//
-// Acceptance criteria live on the issue.
-import React from "react";
-import DashboardPlaceholder from "@features/dashboard/components/DashboardPlaceholder";
-import type { DashboardViewProps } from "@features/dashboard/types/dashboard";
+import React, { useEffect, useState } from "react";
+import Link from "next/link";
+import { useTerms } from "@features/persona/hooks/useTerms";
+import {
+  liveQuizService,
+  type LiveQuizSummary,
+} from "@features/live-quiz/api/liveQuizService";
+import { BTN_PRIMARY } from "@shared/ui/quizwerk";
 
-export default function ParentDashboard({ persona }: DashboardViewProps) {
+export default function ParentDashboard() {
+  const t = useTerms();
+  const [practices, setPractices] = useState<LiveQuizSummary[] | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    liveQuizService
+      .listLiveQuizzes()
+      .then((rows) => {
+        if (active) setPractices(rows.slice(0, 5));
+      })
+      .catch(() => {
+        if (active) {
+          setError(true);
+          setPractices([]);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
   return (
-    <DashboardPlaceholder
-      issue={129}
-      title="Parent dashboard"
-      persona={persona}
-    />
+    <section className="border-t-2 border-divider pt-[28px]">
+      <div className="flex flex-wrap items-end justify-between gap-[18px]">
+        <div>
+          <h2 className="text-[20px] font-extrabold tracking-[-0.015em]">
+            Parent dashboard
+          </h2>
+          <p className="mt-[7px] text-[14px] text-ink/70">
+            Create an automatically marked {t("assignment")} for your {t("learner")}.
+          </p>
+        </div>
+        <Link href="/parent-practice/new" className={BTN_PRIMARY}>
+          Create Practice
+        </Link>
+      </div>
+
+      <h3 className="mt-[32px] text-[17px] font-extrabold">Recent practice</h3>
+      {practices === null ? (
+        <p className="mt-[14px] text-[14px] text-ink/60">Loading…</p>
+      ) : error ? (
+        <p className="mt-[14px] text-[14px] text-red-700">
+          Recent practice could not be loaded.
+        </p>
+      ) : practices.length === 0 ? (
+        <p className="mt-[14px] text-[14px] text-ink/70">
+          No practice yet. Create the first set when you are ready.
+        </p>
+      ) : (
+        <ul className="mt-[12px]">
+          {practices.map((practice) => (
+            <li key={practice.quiz_id} className="border-t-2 border-divider py-[16px]">
+              <div className="flex flex-wrap items-center justify-between gap-[14px]">
+                <div>
+                  <p className="font-extrabold">{practice.title}</p>
+                  <p className="mt-[4px] text-[13px] text-ink/65">
+                    {practice.completed_count} completed {practice.completed_count === 1 ? "attempt" : "attempts"}
+                    {practice.latest_score != null
+                      ? ` · Latest: ${practice.latest_score}${practice.latest_percentage != null ? ` (${practice.latest_percentage}%)` : ""}`
+                      : ""}
+                  </p>
+                </div>
+                <Link className="text-[14px] font-extrabold text-brand underline" href={`/my-live-quizzes/${practice.quiz_id}`}>
+                  View results
+                </Link>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
   );
 }

--- a/client/src/features/folders/components/FolderView.tsx
+++ b/client/src/features/folders/components/FolderView.tsx
@@ -3,6 +3,7 @@
 import React, { useState } from "react";
 import MoveQuizModal from "./MoveQuizModal";
 import OrganizeModal from "./OrganizeModal";
+import { useTerms } from "@features/persona/hooks/useTerms";
 
 interface FolderViewProps {
   folder: {
@@ -24,6 +25,7 @@ const FolderView: React.FC<FolderViewProps> = ({ folder }) => {
   const [showMoveModal, setShowMoveModal] = useState(false);
   const [showOrganizeModal, setShowOrganizeModal] = useState(false);
   const [quizzes, setQuizzes] = useState(folder.quizzes || []);
+  const t = useTerms();
 
   return (
     <div className="p-6 bg-white rounded-2xl shadow-sm border border-gray-100">
@@ -38,7 +40,9 @@ const FolderView: React.FC<FolderViewProps> = ({ folder }) => {
       </div>
 
       {quizzes.length === 0 ? (
-        <p className="text-gray-500 text-sm">No quizzes in this folder yet.</p>
+        <p className="text-gray-500 text-sm">
+          No {t("quiz", "plural")} in this folder yet.
+        </p>
       ) : (
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {quizzes.map((quiz) => (

--- a/client/src/features/folders/pages/FoldersPage.tsx
+++ b/client/src/features/folders/pages/FoldersPage.tsx
@@ -12,6 +12,7 @@ import OrganizeModal from "@features/folders/components/OrganizeModal";
 import ConfirmDeleteModal from "@features/folders/components/ConfirmDeleteModal";
 import { useAuth } from "@features/auth/context/authContext";
 import RequireAuth from "@features/auth/components/RequireAuth";
+import { useTerms } from "@features/persona/hooks/useTerms";
 import {
   getUserFolders,
   deleteFolder,
@@ -31,6 +32,7 @@ const getFolderId = (folder: Partial<Folder>) => folder.id || "";
 const FoldersPage = () => {
   const router = useRouter();
   const { user, isAuthenticated } = useAuth();
+  const t = useTerms();
   const [folders, setFolders] = useState<Folder[]>([]);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [showOrganizeModal, setShowOrganizeModal] = useState(false);
@@ -102,7 +104,7 @@ const FoldersPage = () => {
             <div className="text-center text-gray-500 mt-20">
               <p>No folders yet.</p>
               <p className="text-sm">
-                Create a folder to organize your saved quizzes.
+                Create a folder to organize your saved {t("quiz", "plural")}.
               </p>
             </div>
           ) : (

--- a/client/src/features/home/QuizwerkHomePage.tsx
+++ b/client/src/features/home/QuizwerkHomePage.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/router";
 import Link from "next/link";
 import Image from "next/image";
 import SignInModal from "@features/auth/components/SignInModal";
+import { ROUTES } from "@shared/config/patterns/routes";
 import { useAuth } from "@features/auth/context/authContext";
 import {
   createCheckoutSession,
@@ -454,6 +455,7 @@ export default function QuizwerkHomePage() {
       <SignInModal
         isOpen={isLoginOpen}
         onClose={() => setIsLoginOpen(false)}
+        redirectTo={ROUTES.DASHBOARD}
         switchToSignUp={() => {}}
       />
     </div>

--- a/client/src/features/live-quiz/api/liveQuizService.ts
+++ b/client/src/features/live-quiz/api/liveQuizService.ts
@@ -113,6 +113,31 @@ export interface LiveQuizSummary {
   participant_count: number;
   completed_count: number;
   average_score?: number | null;
+  latest_score?: number | null;
+  latest_percentage?: number | null;
+  latest_submitted_at?: string | null;
+}
+
+export interface GradedAnswer {
+  question_index: number;
+  question: string;
+  selected_answer: string;
+  correct_answer: string;
+  question_type: string;
+  is_correct: boolean;
+}
+
+export interface LiveQuizAttemptDetail {
+  session_id: string;
+  quiz_id: string;
+  title: string;
+  participant_name: string;
+  score: number;
+  total_questions: number;
+  percentage: number;
+  submitted_at: string;
+  auto_submitted: boolean;
+  graded_answers: GradedAnswer[];
 }
 
 export type LiveQuizParticipantsEvent =
@@ -246,6 +271,16 @@ export const liveQuizService = {
 
   async listLiveQuizzes(): Promise<LiveQuizSummary[]> {
     const { data } = await api.get("/api/v1/quizzes/live");
+    return data;
+  },
+
+  async getAttemptDetail(
+    quizId: string,
+    sessionId: string,
+  ): Promise<LiveQuizAttemptDetail> {
+    const { data } = await api.get(
+      `/api/v1/quizzes/${encodeURIComponent(quizId)}/live-sessions/${encodeURIComponent(sessionId)}`,
+    );
     return data;
   },
 

--- a/client/src/features/live-quiz/pages/LiveQuizAttemptDetailPage.tsx
+++ b/client/src/features/live-quiz/pages/LiveQuizAttemptDetailPage.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import Link from "next/link";
+import RequireAuth from "@features/auth/components/RequireAuth";
+import NavBar from "@features/quiz/components/NavBar";
+import Footer from "@features/quiz/components/Footer";
+import {
+  liveQuizService,
+  type LiveQuizAttemptDetail,
+} from "@features/live-quiz/api/liveQuizService";
+import { archivo, CONTAINER, Kicker } from "@shared/ui/quizwerk";
+
+export default function LiveQuizAttemptDetailPage({
+  quizId,
+  sessionId,
+}: {
+  quizId: string;
+  sessionId: string;
+}) {
+  const [attempt, setAttempt] = useState<LiveQuizAttemptDetail | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let active = true;
+    liveQuizService
+      .getAttemptDetail(quizId, sessionId)
+      .then((data) => {
+        if (active) setAttempt(data);
+      })
+      .catch((requestError) => {
+        if (!active) return;
+        if (requestError?.response?.status === 403) {
+          setError("You are not allowed to view this attempt.");
+        } else if (requestError?.response?.status === 409) {
+          setError("This attempt has not been completed yet.");
+        } else {
+          setError("Attempt results could not be found.");
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [quizId, sessionId]);
+
+  return (
+    <RequireAuth title="Results sign-in required" description="Sign in to view these results.">
+      <div className={`${archivo.className} flex min-h-screen flex-col bg-paper text-ink`}>
+        <NavBar />
+        <main className={`${CONTAINER} flex-grow py-[clamp(32px,5vw,56px)]`}>
+          {error ? (
+            <p role="alert" className="border-t-2 border-divider pt-[24px] text-red-700">{error}</p>
+          ) : !attempt ? (
+            <p>Loading results…</p>
+          ) : (
+            <>
+              <Kicker>Completed attempt</Kicker>
+              <h1 className="text-[clamp(28px,4vw,40px)] font-extrabold">{attempt.title}</h1>
+              <p className="mt-[8px] text-ink/70">{attempt.participant_name}</p>
+              <div className="mt-[26px] grid gap-[14px] sm:grid-cols-2">
+                <div className="border-t-2 border-divider pt-[14px]">
+                  <span className="block text-[12px] font-extrabold uppercase tracking-[0.08em] text-ink/60">Score</span>
+                  <strong className="mt-[4px] block text-[30px]">{attempt.score}/{attempt.total_questions}</strong>
+                </div>
+                <div className="border-t-2 border-divider pt-[14px]">
+                  <span className="block text-[12px] font-extrabold uppercase tracking-[0.08em] text-ink/60">Percentage</span>
+                  <strong className="mt-[4px] block text-[30px]">{attempt.percentage}%</strong>
+                </div>
+              </div>
+              <section className="mt-[34px]">
+                <h2 className="text-[20px] font-extrabold">Question results</h2>
+                <ol className="mt-[12px]">
+                  {attempt.graded_answers.map((answer) => (
+                    <li key={answer.question_index} className="border-t-2 border-divider py-[16px]">
+                      <div className="flex items-start gap-[12px]">
+                        <span aria-label={answer.is_correct ? "Correct" : "Incorrect"} className={`text-[20px] font-extrabold ${answer.is_correct ? "text-green-700" : "text-red-700"}`}>
+                          {answer.is_correct ? "✓" : "✗"}
+                        </span>
+                        <div>
+                          <h3 className="font-extrabold">Question {answer.question_index + 1}</h3>
+                          <p className="mt-[5px]">{answer.question}</p>
+                          <p className="mt-[8px] text-[14px] text-ink/70">Child&apos;s answer: {answer.selected_answer || "No answer"}</p>
+                          <p className="mt-[3px] text-[14px] text-ink/70">Correct answer: {answer.correct_answer}</p>
+                        </div>
+                      </div>
+                    </li>
+                  ))}
+                </ol>
+              </section>
+              <Link href={`/my-live-quizzes/${quizId}`} className="mt-[24px] inline-block font-extrabold text-brand underline">Back to attempts</Link>
+            </>
+          )}
+        </main>
+        <Footer />
+      </div>
+    </RequireAuth>
+  );
+}

--- a/client/src/features/parent-practice/api/parentPracticeApi.ts
+++ b/client/src/features/parent-practice/api/parentPracticeApi.ts
@@ -6,18 +6,27 @@ export interface ParentPracticeReady {
   title: string;
   questionCount: number;
   accessCode: string;
+  durationMinutes: number;
 }
 
 export async function createParentPractice(
   params: ParentPracticeGenerationParams,
+  durationMinutes = 20,
 ): Promise<ParentPracticeReady> {
+  if (
+    !Number.isInteger(durationMinutes) ||
+    durationMinutes < 1 ||
+    durationMinutes > 180
+  ) {
+    throw new Error("Duration must be a whole number between 1 and 180 minutes.");
+  }
   const allowFallback =
     process.env.NEXT_PUBLIC_PARENT_PRACTICE_ALLOW_FALLBACK === "true";
   const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
   const { data } = await api.post("/api/get-questions", {
     ...params,
     live_quiz_enabled: true,
-    time_limit_minutes: 20,
+    time_limit_minutes: durationMinutes,
     access_code_expires_at: expiresAt.toISOString(),
     participant_access_mode: "public",
     invited_emails: [],
@@ -41,5 +50,6 @@ export async function createParentPractice(
     title: params.profession,
     questionCount: data.questions.length,
     accessCode: data.access_code,
+    durationMinutes,
   };
 }

--- a/client/src/features/parent-practice/api/parentPracticeApi.ts
+++ b/client/src/features/parent-practice/api/parentPracticeApi.ts
@@ -1,0 +1,45 @@
+import { api } from "@shared/api/http";
+import type { ParentPracticeGenerationParams } from "@features/parent-practice/config/presets";
+
+export interface ParentPracticeReady {
+  quizId: string;
+  title: string;
+  questionCount: number;
+  accessCode: string;
+}
+
+export async function createParentPractice(
+  params: ParentPracticeGenerationParams,
+): Promise<ParentPracticeReady> {
+  const allowFallback =
+    process.env.NEXT_PUBLIC_PARENT_PRACTICE_ALLOW_FALLBACK === "true";
+  const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+  const { data } = await api.post("/api/get-questions", {
+    ...params,
+    live_quiz_enabled: true,
+    time_limit_minutes: 20,
+    access_code_expires_at: expiresAt.toISOString(),
+    participant_access_mode: "public",
+    invited_emails: [],
+    send_email_invitations: false,
+    allow_fallback: allowFallback,
+  });
+
+  // The generic generator can fall back to unrelated static questions. A
+  // Parent preset must never claim that unrelated content is valid practice.
+  if (data?.ai_down && !allowFallback) {
+    throw new Error(
+      "Practice generation is temporarily unavailable. Please try again.",
+    );
+  }
+  if (!data?.quiz_id || !data?.access_code || !Array.isArray(data?.questions)) {
+    throw new Error("Practice could not be prepared. Please try again.");
+  }
+
+  return {
+    quizId: data.quiz_id,
+    title: params.profession,
+    questionCount: data.questions.length,
+    accessCode: data.access_code,
+  };
+}

--- a/client/src/features/parent-practice/config/presets.ts
+++ b/client/src/features/parent-practice/config/presets.ts
@@ -1,0 +1,117 @@
+export const PARENT_PRACTICE_LEVELS = [
+  { id: "ages-5-7", label: "Ages 5–7" },
+  { id: "ages-7-9", label: "Ages 7–9" },
+  { id: "ages-9-11", label: "Ages 9–11" },
+] as const;
+
+export type ParentPracticeLevel =
+  (typeof PARENT_PRACTICE_LEVELS)[number]["id"];
+
+export type ParentPracticePresetId =
+  | "addition-subtraction"
+  | "multiplication-tables"
+  | "basic-fractions"
+  | "vocabulary-practice";
+
+export interface ParentPracticeGenerationParams {
+  profession: string;
+  audience_type: string;
+  difficulty_level: "easy" | "medium";
+  question_type: "multichoice";
+  num_questions: number;
+  custom_instruction: string;
+}
+
+export interface ParentPracticePreset {
+  id: ParentPracticePresetId;
+  label: string;
+  levels: readonly ParentPracticeLevel[];
+  topic: Record<ParentPracticeLevel, string | undefined>;
+  instruction: string;
+}
+
+export const PARENT_PRACTICE_PRESETS: readonly ParentPracticePreset[] = [
+  {
+    id: "addition-subtraction",
+    label: "Addition & Subtraction",
+    levels: ["ages-5-7", "ages-7-9"],
+    topic: {
+      "ages-5-7": "Addition and subtraction within 20 — ages 5 to 7",
+      "ages-7-9": "Addition and subtraction within 1,000 — ages 7 to 9",
+      "ages-9-11": undefined,
+    },
+    instruction:
+      "Use clear whole-number calculations and exactly one unambiguous correct option.",
+  },
+  {
+    id: "multiplication-tables",
+    label: "Multiplication Tables",
+    levels: ["ages-7-9", "ages-9-11"],
+    topic: {
+      "ages-5-7": undefined,
+      "ages-7-9": "Multiplication tables from 2 to 10 — ages 7 to 9",
+      "ages-9-11": "Multiplication and division facts up to 12 × 12 — ages 9 to 11",
+    },
+    instruction:
+      "Use exact multiplication or related division facts and exactly one unambiguous correct option.",
+  },
+  {
+    id: "basic-fractions",
+    label: "Basic Fractions",
+    levels: ["ages-9-11"],
+    topic: {
+      "ages-5-7": undefined,
+      "ages-7-9": undefined,
+      "ages-9-11": "Basic fractions and equivalent fractions — ages 9 to 11",
+    },
+    instruction:
+      "Use age-appropriate fraction recognition and equivalence with exactly one unambiguous correct option.",
+  },
+  {
+    id: "vocabulary-practice",
+    label: "Vocabulary Practice",
+    levels: ["ages-5-7", "ages-7-9", "ages-9-11"],
+    topic: {
+      "ages-5-7": "Everyday vocabulary and word meanings — ages 5 to 7",
+      "ages-7-9": "Vocabulary, synonyms and word meanings — ages 7 to 9",
+      "ages-9-11": "Vocabulary, synonyms, antonyms and context — ages 9 to 11",
+    },
+    instruction:
+      "Use child-friendly vocabulary in context and exactly one unambiguous correct option.",
+  },
+] as const;
+
+export function getPresetsForLevel(level: ParentPracticeLevel) {
+  return PARENT_PRACTICE_PRESETS.filter((preset) =>
+    preset.levels.includes(level),
+  );
+}
+
+export function resolveParentPracticePreset(
+  level: ParentPracticeLevel,
+  presetId: ParentPracticePresetId,
+  numQuestions = 10,
+): ParentPracticeGenerationParams {
+  const preset = PARENT_PRACTICE_PRESETS.find(
+    (candidate) => candidate.id === presetId,
+  );
+  const topic = preset?.topic[level];
+  if (!preset || !preset.levels.includes(level) || !topic) {
+    throw new Error("This practice preset is not available for the selected level.");
+  }
+  if (!Number.isInteger(numQuestions) || numQuestions < 1) {
+    throw new Error("Number of questions must be a positive whole number.");
+  }
+
+  const levelLabel = PARENT_PRACTICE_LEVELS.find(
+    (candidate) => candidate.id === level,
+  )?.label;
+  return {
+    profession: topic,
+    audience_type: `children ${levelLabel?.toLowerCase()}`,
+    difficulty_level: level === "ages-9-11" ? "medium" : "easy",
+    question_type: "multichoice",
+    num_questions: numQuestions,
+    custom_instruction: `${preset.instruction} Keep all content appropriate for ${levelLabel}.`,
+  };
+}

--- a/client/src/features/parent-practice/pages/CreateParentPracticePage.tsx
+++ b/client/src/features/parent-practice/pages/CreateParentPracticePage.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+import React, { FormEvent, useMemo, useState } from "react";
+import { useRouter } from "next/router";
+import toast from "react-hot-toast";
+import RequireAuth from "@features/auth/components/RequireAuth";
+import NavBar from "@features/quiz/components/NavBar";
+import Footer from "@features/quiz/components/Footer";
+import { usePersona } from "@features/persona/context/personaContext";
+import { createParentPractice, type ParentPracticeReady } from "@features/parent-practice/api/parentPracticeApi";
+import {
+  getPresetsForLevel,
+  PARENT_PRACTICE_LEVELS,
+  resolveParentPracticePreset,
+  type ParentPracticeLevel,
+  type ParentPracticePresetId,
+} from "@features/parent-practice/config/presets";
+import { archivo, BTN_GHOST, BTN_PRIMARY, CONTAINER, Kicker } from "@shared/ui/quizwerk";
+
+const MAX_QUESTIONS = Number(
+  process.env.NEXT_PUBLIC_QUIZ_GENERATION_MAX_QUESTIONS || 10,
+);
+
+export default function CreateParentPracticePage() {
+  const router = useRouter();
+  const { userType, isLoading } = usePersona();
+  const [level, setLevel] = useState<ParentPracticeLevel>("ages-7-9");
+  const [presetId, setPresetId] = useState<ParentPracticePresetId>(
+    "multiplication-tables",
+  );
+  const [numQuestions, setNumQuestions] = useState(10);
+  const [isCreating, setIsCreating] = useState(false);
+  const [ready, setReady] = useState<ParentPracticeReady | null>(null);
+  const presets = useMemo(() => getPresetsForLevel(level), [level]);
+
+  const selectLevel = (nextLevel: ParentPracticeLevel) => {
+    const nextPresets = getPresetsForLevel(nextLevel);
+    setLevel(nextLevel);
+    if (!nextPresets.some((preset) => preset.id === presetId)) {
+      setPresetId(nextPresets[0].id);
+    }
+  };
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    try {
+      setIsCreating(true);
+      const params = resolveParentPracticePreset(level, presetId, numQuestions);
+      setReady(await createParentPractice(params));
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not create practice.",
+      );
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const joinPath = ready ? `/quiz-access/${ready.accessCode}` : "";
+  const copyLink = async () => {
+    if (!ready) return;
+    await navigator.clipboard.writeText(`${window.location.origin}${joinPath}`);
+    toast.success("Practice link copied.");
+  };
+
+  return (
+    <RequireAuth title="Parent sign-in required" description="Sign in to create practice for your child.">
+      <div className={`${archivo.className} flex min-h-screen flex-col bg-paper text-ink`}>
+        <NavBar />
+        <main className={`${CONTAINER} flex-grow py-[clamp(32px,5vw,56px)]`}>
+          {isLoading ? (
+            <p>Loading…</p>
+          ) : userType !== "parent" ? (
+            <section className="border-t-2 border-divider pt-[28px]">
+              <h1 className="text-[28px] font-extrabold">Parent Practice</h1>
+              <p className="mt-[12px] text-ink/70">
+                This creation flow is available from the Parent dashboard.
+              </p>
+              <button className={`${BTN_GHOST} mt-[20px]`} onClick={() => router.push("/dashboard")}>
+                Back to dashboard
+              </button>
+            </section>
+          ) : ready ? (
+            <section aria-label="Practice ready" className="max-w-[720px] border-t-2 border-divider pt-[28px]">
+              <Kicker>Practice ready</Kicker>
+              <h1 className="text-[clamp(28px,4vw,40px)] font-extrabold">{ready.title}</h1>
+              <p className="mt-[12px] text-[16px] text-ink/70">
+                {ready.questionCount} questions · Access code {ready.accessCode}
+              </p>
+              <div className="mt-[28px] flex flex-wrap gap-[12px]">
+                <button className={BTN_PRIMARY} onClick={() => router.push(joinPath)}>
+                  Start Practice
+                </button>
+                <button className={BTN_GHOST} onClick={copyLink}>
+                  Copy Share Link
+                </button>
+              </div>
+            </section>
+          ) : (
+            <section className="max-w-[720px]">
+              <Kicker>Parent Practice</Kicker>
+              <h1 className="text-[clamp(28px,4vw,40px)] font-extrabold">Create practice</h1>
+              <p className="mt-[12px] max-w-[52ch] leading-[27px] text-ink/70">
+                Choose a level and focused practice set. Marking is automatic.
+              </p>
+              <form onSubmit={submit} className="mt-[32px] space-y-[24px] border-t-2 border-divider pt-[28px]">
+                <label className="block text-[14px] font-extrabold">
+                  Child age/level
+                  <select aria-label="Child age/level" value={level} onChange={(event) => selectLevel(event.target.value as ParentPracticeLevel)} className="mt-[8px] block w-full border-2 border-divider bg-paper px-[12px] py-[11px] font-normal">
+                    {PARENT_PRACTICE_LEVELS.map((item) => <option key={item.id} value={item.id}>{item.label}</option>)}
+                  </select>
+                </label>
+                <label className="block text-[14px] font-extrabold">
+                  Practice preset
+                  <select aria-label="Practice preset" value={presetId} onChange={(event) => setPresetId(event.target.value as ParentPracticePresetId)} className="mt-[8px] block w-full border-2 border-divider bg-paper px-[12px] py-[11px] font-normal">
+                    {presets.map((preset) => <option key={preset.id} value={preset.id}>{preset.label}</option>)}
+                  </select>
+                </label>
+                <label className="block text-[14px] font-extrabold">
+                  Number of questions
+                  <input aria-label="Number of questions" type="number" min={1} max={MAX_QUESTIONS} value={numQuestions} onChange={(event) => setNumQuestions(Math.min(MAX_QUESTIONS, Math.max(1, Number(event.target.value))))} className="mt-[8px] block w-full border-2 border-divider bg-paper px-[12px] py-[11px] font-normal" />
+                </label>
+                <button type="submit" disabled={isCreating} className={`${BTN_PRIMARY} disabled:cursor-not-allowed disabled:opacity-60`}>
+                  {isCreating ? "Creating…" : "Create Practice"}
+                </button>
+              </form>
+            </section>
+          )}
+        </main>
+        <Footer />
+      </div>
+    </RequireAuth>
+  );
+}

--- a/client/src/features/parent-practice/pages/CreateParentPracticePage.tsx
+++ b/client/src/features/parent-practice/pages/CreateParentPracticePage.tsx
@@ -20,6 +20,8 @@ import { archivo, BTN_GHOST, BTN_PRIMARY, CONTAINER, Kicker } from "@shared/ui/q
 const MAX_QUESTIONS = Number(
   process.env.NEXT_PUBLIC_QUIZ_GENERATION_MAX_QUESTIONS || 10,
 );
+const DURATION_OPTIONS = [5, 10, 15, 20, 30, 45, 60] as const;
+type DurationOption = `${(typeof DURATION_OPTIONS)[number]}` | "custom";
 
 export default function CreateParentPracticePage() {
   const router = useRouter();
@@ -29,6 +31,10 @@ export default function CreateParentPracticePage() {
     "multiplication-tables",
   );
   const [numQuestions, setNumQuestions] = useState(10);
+  const [durationOption, setDurationOption] =
+    useState<DurationOption>("20");
+  const [customDuration, setCustomDuration] = useState("25");
+  const [durationError, setDurationError] = useState("");
   const [isCreating, setIsCreating] = useState(false);
   const [ready, setReady] = useState<ParentPracticeReady | null>(null);
   const presets = useMemo(() => getPresetsForLevel(level), [level]);
@@ -43,10 +49,26 @@ export default function CreateParentPracticePage() {
 
   const submit = async (event: FormEvent) => {
     event.preventDefault();
+    const durationMinutes =
+      durationOption === "custom"
+        ? Number(customDuration)
+        : Number(durationOption);
+    if (
+      !Number.isInteger(durationMinutes) ||
+      durationMinutes < 1 ||
+      durationMinutes > 180
+    ) {
+      setDurationError(
+        "Enter a whole number between 1 and 180 minutes.",
+      );
+      return;
+    }
+
+    setDurationError("");
     try {
       setIsCreating(true);
       const params = resolveParentPracticePreset(level, presetId, numQuestions);
-      setReady(await createParentPractice(params));
+      setReady(await createParentPractice(params, durationMinutes));
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Could not create practice.",
@@ -85,7 +107,7 @@ export default function CreateParentPracticePage() {
               <Kicker>Practice ready</Kicker>
               <h1 className="text-[clamp(28px,4vw,40px)] font-extrabold">{ready.title}</h1>
               <p className="mt-[12px] text-[16px] text-ink/70">
-                {ready.questionCount} questions · Access code {ready.accessCode}
+                {ready.questionCount} questions · {ready.durationMinutes} minutes · Access code {ready.accessCode}
               </p>
               <div className="mt-[28px] flex flex-wrap gap-[12px]">
                 <button className={BTN_PRIMARY} onClick={() => router.push(joinPath)}>
@@ -103,7 +125,7 @@ export default function CreateParentPracticePage() {
               <p className="mt-[12px] max-w-[52ch] leading-[27px] text-ink/70">
                 Choose a level and focused practice set. Marking is automatic.
               </p>
-              <form onSubmit={submit} className="mt-[32px] space-y-[24px] border-t-2 border-divider pt-[28px]">
+              <form noValidate onSubmit={submit} className="mt-[32px] space-y-[24px] border-t-2 border-divider pt-[28px]">
                 <label className="block text-[14px] font-extrabold">
                   Child age/level
                   <select aria-label="Child age/level" value={level} onChange={(event) => selectLevel(event.target.value as ParentPracticeLevel)} className="mt-[8px] block w-full border-2 border-divider bg-paper px-[12px] py-[11px] font-normal">
@@ -120,6 +142,55 @@ export default function CreateParentPracticePage() {
                   Number of questions
                   <input aria-label="Number of questions" type="number" min={1} max={MAX_QUESTIONS} value={numQuestions} onChange={(event) => setNumQuestions(Math.min(MAX_QUESTIONS, Math.max(1, Number(event.target.value))))} className="mt-[8px] block w-full border-2 border-divider bg-paper px-[12px] py-[11px] font-normal" />
                 </label>
+                <div>
+                  <label className="block text-[14px] font-extrabold">
+                    Duration
+                    <select
+                      aria-label="Duration"
+                      value={durationOption}
+                      onChange={(event) => {
+                        setDurationOption(event.target.value as DurationOption);
+                        setDurationError("");
+                      }}
+                      className="mt-[8px] block w-full border-2 border-divider bg-paper px-[12px] py-[11px] font-normal"
+                    >
+                      {DURATION_OPTIONS.map((minutes) => (
+                        <option key={minutes} value={minutes}>
+                          {minutes} minutes
+                        </option>
+                      ))}
+                      <option value="custom">Custom</option>
+                    </select>
+                  </label>
+                  {durationOption === "custom" ? (
+                    <label className="mt-[16px] block text-[14px] font-extrabold">
+                      Custom duration
+                      <span className="mt-[8px] flex items-center gap-[10px] font-normal">
+                        <input
+                          aria-label="Custom duration"
+                          type="number"
+                          min={1}
+                          max={180}
+                          step={1}
+                          value={customDuration}
+                          onChange={(event) => {
+                            setCustomDuration(event.target.value);
+                            setDurationError("");
+                          }}
+                          aria-invalid={Boolean(durationError)}
+                          aria-describedby="duration-error"
+                          className="w-[140px] border-2 border-divider bg-paper px-[12px] py-[11px]"
+                        />
+                        minutes
+                      </span>
+                    </label>
+                  ) : null}
+                  {durationError ? (
+                    <p id="duration-error" role="alert" className="mt-[8px] text-[13px] font-normal text-red-700">
+                      {durationError}
+                    </p>
+                  ) : null}
+                </div>
                 <button type="submit" disabled={isCreating} className={`${BTN_PRIMARY} disabled:cursor-not-allowed disabled:opacity-60`}>
                   {isCreating ? "Creating…" : "Create Practice"}
                 </button>

--- a/client/src/features/persona/README.md
+++ b/client/src/features/persona/README.md
@@ -18,7 +18,9 @@ Resolution order (`lib/resolvePersona.ts`, pure and unit-tested):
 1. **profile** — the signed-in user's saved persona
 2. **query** — `?persona=&category=` on the current URL
 3. **storage** — a guest's earlier choice (`localStorage`, survives tab close;
-   unlike `TokenService`, which uses `sessionStorage` for token security)
+   unlike `TokenService`, which uses `sessionStorage` for token security).
+   It is hydrated after mount, never used as an authenticated fallback, and is
+   cleared when an authenticated session ends on a shared browser.
 4. **none**
 
 An inconsistent pair (`?category=corporate&persona=teacher`) resolves to
@@ -31,14 +33,16 @@ const { setPersona } = usePersona();
 await setPersona({ category: "school", userType: "teacher" });
 ```
 
-Writes storage immediately, then persists to the profile and refreshes the user
-when signed in.
+For guests this writes browser storage. For authenticated users it first saves
+through `PUT /auth/profile/persona`, refreshes the profile, then removes any
+guest storage copy. A failed profile save leaves both the profile and guest
+storage unchanged.
 
 ## Wording
 
 ```tsx
 const t = useTerms();
-t("learner", "plural");   // "students" (school) · "employees" (corporate)
+t("learner", "plural");   // "students" (school) · "team members" (corporate)
 t("group");               // "class" · "team" · "cohort" for a lecturer
 ```
 

--- a/client/src/features/persona/api/personaApi.ts
+++ b/client/src/features/persona/api/personaApi.ts
@@ -1,9 +1,9 @@
 import { api } from "@shared/api/http";
 import type { Persona } from "@shared/config/persona";
 
-/** Persists persona onto the user profile (rides PUT /auth/profile). */
+/** Persists only persona fields; this is available to authenticated users. */
 export async function updatePersona(persona: Persona) {
-  const response = await api.put("/auth/profile", {
+  const response = await api.put("/auth/profile/persona", {
     persona_category: persona.category,
     persona_user_type: persona.userType,
   });

--- a/client/src/features/persona/context/personaContext.tsx
+++ b/client/src/features/persona/context/personaContext.tsx
@@ -4,6 +4,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
 } from "react";
@@ -41,14 +42,36 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
   const { user, isAuthenticated, isLoading, refreshUser } = useAuth();
   const router = useRouter();
 
-  // Local override so a fresh pick renders immediately, before the profile
-  // round-trip completes.
-  const [override, setOverride] = useState<Persona | null>(null);
+  // Storage is hydrated only after the initial client render. Reading it in
+  // render would make SSR see no persona while the browser sees one, causing
+  // a hydration mismatch in persona-aware shell copy.
+  const [storedPersona, setStoredPersona] = useState<Persona | null>(null);
+  const [storageHydrated, setStorageHydrated] = useState(false);
+  const [hasAuthenticatedSession, setHasAuthenticatedSession] = useState(false);
+
+  useEffect(() => {
+    setStoredPersona(readStoredPersona());
+    setStorageHydrated(true);
+  }, []);
+
+  useEffect(() => {
+    if (isLoading) return;
+
+    if (isAuthenticated) {
+      setHasAuthenticatedSession(true);
+      return;
+    }
+
+    // A browser can be shared. Never allow a guest preference that survived
+    // an authenticated session to become a later account's fallback persona.
+    if (hasAuthenticatedSession) {
+      clearStoredPersona();
+      setStoredPersona(null);
+      setHasAuthenticatedSession(false);
+    }
+  }, [hasAuthenticatedSession, isAuthenticated, isLoading]);
 
   const resolved = useMemo(() => {
-    if (override) {
-      return { persona: override, source: "profile" as const };
-    }
     return resolvePersona({
       profile: user
         ? {
@@ -60,26 +83,33 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
         persona: (router.query?.persona as string) ?? null,
         category: (router.query?.category as string) ?? null,
       },
-      stored: readStoredPersona(),
+      // Profile and explicit links remain available to signed-in users. Guest
+      // storage is intentionally never an authenticated fallback.
+      stored: isAuthenticated || hasAuthenticatedSession ? null : storedPersona,
     });
-  }, [override, user, router.query]);
+  }, [hasAuthenticatedSession, isAuthenticated, router.query, storedPersona, user]);
 
   const setPersona = useCallback(
     async (persona: Persona) => {
-      setOverride(persona);
-      writeStoredPersona(persona);
-
       if (isAuthenticated) {
         await updatePersona(persona);
         await refreshUser();
+        // A profile save is authoritative. Remove the guest copy so it
+        // cannot surface for another account on a shared browser.
+        clearStoredPersona();
+        setStoredPersona(null);
+        return;
       }
+
+      writeStoredPersona(persona);
+      setStoredPersona(persona);
     },
     [isAuthenticated, refreshUser],
   );
 
   const clearPersona = useCallback(() => {
-    setOverride(null);
     clearStoredPersona();
+    setStoredPersona(null);
   }, []);
 
   const value = useMemo<PersonaState>(() => {
@@ -93,11 +123,11 @@ export function PersonaProvider({ children }: { children: React.ReactNode }) {
         ? getCategoryDefinition(persona.category)
         : null,
       source: resolved.source,
-      isLoading,
+      isLoading: isLoading || !storageHydrated,
       setPersona,
       clearPersona,
     };
-  }, [resolved, isLoading, setPersona, clearPersona]);
+  }, [resolved, isLoading, storageHydrated, setPersona, clearPersona]);
 
   return (
     <PersonaContext.Provider value={value}>{children}</PersonaContext.Provider>

--- a/client/src/features/persona/hooks/useTerms.ts
+++ b/client/src/features/persona/hooks/useTerms.ts
@@ -12,7 +12,7 @@ import {
  * Persona-bound terminology.
  *
  *   const t = useTerms();
- *   t("learner", "plural")   // "students" for a teacher, "employees" for HR
+ *   t("learner", "plural")   // "students" for a teacher, "team members" for HR
  *
  * Persona views must use this instead of hardcoding learner/class/team nouns.
  */

--- a/client/src/features/persona/hooks/useTerms.ts
+++ b/client/src/features/persona/hooks/useTerms.ts
@@ -2,7 +2,11 @@
 
 import { useCallback } from "react";
 import { usePersona } from "@features/persona/context/personaContext";
-import { resolveTerm, type TermKey } from "@shared/config/terminology";
+import {
+  resolveTerm,
+  type TermForm,
+  type TermKey,
+} from "@shared/config/terminology";
 
 /**
  * Persona-bound terminology.
@@ -16,7 +20,7 @@ export function useTerms() {
   const { persona } = usePersona();
 
   return useCallback(
-    (key: TermKey, form: "singular" | "plural" = "singular") =>
+    (key: TermKey, form: TermForm = "singular") =>
       resolveTerm(key, persona, form),
     [persona],
   );

--- a/client/src/features/persona/types/persona.ts
+++ b/client/src/features/persona/types/persona.ts
@@ -19,7 +19,8 @@ export interface PersonaState {
   categoryDefinition: PersonaCategoryDefinition | null;
   source: PersonaSource;
   isLoading: boolean;
-  /** Persists to the profile when signed in, otherwise to local storage. */
+  /** Persists to the profile when signed in, otherwise to guest local storage. */
   setPersona: (persona: Persona) => Promise<void>;
+  /** Clears guest fallback only. Profile persona is changed through setPersona. */
   clearPersona: () => void;
 }

--- a/client/src/features/quiz-history/pages/QuizHistoryPage.tsx
+++ b/client/src/features/quiz-history/pages/QuizHistoryPage.tsx
@@ -11,6 +11,7 @@ import { useAuth } from "@features/auth/context/authContext";
 import NavBar from "@features/quiz/components/NavBar";
 import Footer from "@features/quiz/components/Footer";
 import RequireAuth from "@features/auth/components/RequireAuth";
+import { useTerms } from "@features/persona/hooks/useTerms";
 
 interface QuizHistoryQuestion {
   question: string;
@@ -59,6 +60,7 @@ const DisplayQuizHistoryPage = ({
   onDelete: (historyId: string) => Promise<void>;
 }) => {
   const router = useRouter();
+  const t = useTerms();
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
@@ -81,12 +83,12 @@ const DisplayQuizHistoryPage = ({
       <main className="flex-1 px-4 sm:px-6 md:px-8 py-8">
         <div className="max-w-4xl mx-auto space-y-8">
           <h1 className="text-3xl sm:text-4xl font-bold text-[#0F2654]">
-            Quiz History
+            {t("quiz").charAt(0).toUpperCase() + t("quiz").slice(1)} history
           </h1>
 
           {quizHistory.length === 0 ? (
             <p className="text-center text-gray-600">
-              No quiz history available.
+              No {t("quiz")} history available.
             </p>
           ) : (
             quizHistory.map((quizItem, idx) => (
@@ -272,6 +274,7 @@ export default function DisplayQuizHistory({
   openLoginModal: () => void;
 }) {
   const { isAuthenticated, isLoading } = useAuth();
+  const t = useTerms();
   const [quizHistory, setQuizHistory] = useState<QuizHistoryItem[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -309,12 +312,12 @@ export default function DisplayQuizHistory({
 
   return (
     <RequireAuth
-      title="Quiz History"
-      description="Sign in to see your quiz history."
+      title={`${t("quiz").charAt(0).toUpperCase() + t("quiz").slice(1)} history`}
+      description={`Sign in to see your ${t("quiz")} history.`}
     >
       <Suspense
         fallback={
-          <div className="p-8 text-center">Loading quiz history...</div>
+          <div className="p-8 text-center">Loading {t("quiz")} history...</div>
         }
       >
         <DisplayQuizHistoryPage

--- a/client/src/features/quiz/components/Footer.tsx
+++ b/client/src/features/quiz/components/Footer.tsx
@@ -3,25 +3,8 @@
 import React from "react";
 import Link from "next/link";
 import { FaGithub, FaTwitter, FaLinkedin } from "react-icons/fa";
-
-const footerSections = [
-  {
-    title: "Explore",
-    links: [
-      { label: "Generate Quiz", href: "/generate" },
-      { label: "Popular Quizzes", href: "/popular" },
-      { label: "Join Live Quiz", href: "/quiz-access" },
-    ],
-  },
-  {
-    title: "Workspace",
-    links: [
-      { label: "Saved Quizzes", href: "/saved_quiz" },
-      { label: "Quiz History", href: "/quiz_history" },
-      { label: "Folders", href: "/folders" },
-    ],
-  },
-];
+import { useTerms } from "@features/persona/hooks/useTerms";
+import { titleCaseTerm } from "@shared/config/terminology";
 
 const socialLinks = [
   {
@@ -43,6 +26,25 @@ const socialLinks = [
 
 export default function Footer() {
   const currentYear = new Date().getFullYear();
+  const t = useTerms();
+  const footerSections = [
+    {
+      title: "Explore",
+      links: [
+        { label: `Create ${t("quiz")}`, href: "/generate" },
+        { label: `Popular ${t("quiz", "plural")}`, href: "/popular" },
+        { label: `Join ${t("live_quiz")}`, href: "/quiz-access" },
+      ],
+    },
+    {
+      title: "Workspace",
+      links: [
+        { label: `Saved ${t("quiz", "plural")}`, href: "/saved_quiz" },
+        { label: `${titleCaseTerm(t("quiz"))} history`, href: "/quiz_history" },
+        { label: "Folders", href: "/folders" },
+      ],
+    },
+  ];
 
   return (
     <footer className="mt-8 bg-gray-900 text-white">

--- a/client/src/features/quiz/components/NavBar.tsx
+++ b/client/src/features/quiz/components/NavBar.tsx
@@ -13,6 +13,11 @@ import Sidebar from "./Sidebar";
 import BrowseModal from "./modals/BrowseModal";
 import { useAuth } from "@features/auth/context/authContext";
 import { usePersona } from "@features/persona/context/personaContext";
+import { useTerms } from "@features/persona/hooks/useTerms";
+import {
+  titleCaseTerm,
+  type TerminologyResolver,
+} from "@shared/config/terminology";
 import NotificationBell from "@features/notifications/components/NotificationBell";
 import { archivo, BTN_PRIMARY } from "@shared/ui/quizwerk";
 
@@ -26,22 +31,25 @@ type NavItem =
   | { kind: "link"; label: string; href: string; authOnly?: boolean }
   | { kind: "action"; label: string; action: "browse" };
 
-const NAV_ITEMS: NavItem[] = [
-  { kind: "link", label: "Home", href: "/" },
-  { kind: "link", label: "Dashboard", href: "/dashboard", authOnly: true },
-  { kind: "link", label: "Generate Quiz", href: "/generate" },
-  { kind: "action", label: "Categories", action: "browse" },
-  { kind: "link", label: "Pricing", href: "/#pricing" },
-];
+function navigationItems(t: TerminologyResolver): NavItem[] {
+  return [
+    { kind: "link", label: "Home", href: "/" },
+    { kind: "link", label: "Dashboard", href: "/dashboard", authOnly: true },
+    { kind: "link", label: `Create ${t("quiz")}`, href: "/generate" },
+    { kind: "action", label: "Categories", action: "browse" },
+    { kind: "link", label: "Pricing", href: "/#pricing" },
+  ];
+}
 
-/** Signed-in shortcuts, shown only in the mobile drawer. */
-const MOBILE_WORKSPACE_LINKS = [
-  { label: "My Profile", href: "/profile" },
-  { label: "Saved Quizzes", href: "/saved_quiz" },
-  { label: "Popular Quizzes", href: "/popular" },
-  { label: "Folders", href: "/folders" },
-  { label: "Quiz History", href: "/quiz_history" },
-];
+function mobileWorkspaceLinks(t: TerminologyResolver) {
+  return [
+    { label: "My Profile", href: "/profile" },
+    { label: `Saved ${t("quiz", "plural")}`, href: "/saved_quiz" },
+    { label: `Popular ${t("quiz", "plural")}`, href: "/popular" },
+    { label: "Folders", href: "/folders" },
+    { label: `${titleCaseTerm(t("quiz"))} history`, href: "/quiz_history" },
+  ];
+}
 
 const NavBar: React.FC = () => {
   const [isSignUpOpen, setIsSignUpOpen] = useState(false);
@@ -51,6 +59,7 @@ const NavBar: React.FC = () => {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
   const { user, isAuthenticated, logout, isLoading } = useAuth();
   const { definition: personaDefinition } = usePersona();
+  const t = useTerms();
 
   const router = useRouter();
 
@@ -74,9 +83,10 @@ const NavBar: React.FC = () => {
     return router.pathname === href;
   };
 
-  const visibleItems = NAV_ITEMS.filter(
+  const visibleItems = navigationItems(t).filter(
     (item) => !("authOnly" in item && item.authOnly) || isAuthenticated,
   );
+  const workspaceLinks = mobileWorkspaceLinks(t);
 
   return (
     <div className={archivo.className}>
@@ -220,7 +230,7 @@ const NavBar: React.FC = () => {
               <p className="mb-1 mt-4 px-3 text-[11px] font-extrabold uppercase tracking-[0.1em] text-ink/60">
                 Workspace
               </p>
-              {MOBILE_WORKSPACE_LINKS.map((link) => (
+              {workspaceLinks.map((link) => (
                 <Link
                   key={link.href}
                   href={link.href}

--- a/client/src/features/quiz/components/NavBar.tsx
+++ b/client/src/features/quiz/components/NavBar.tsx
@@ -18,6 +18,7 @@ import {
   titleCaseTerm,
   type TerminologyResolver,
 } from "@shared/config/terminology";
+import { ROUTES } from "@shared/config/patterns/routes";
 import NotificationBell from "@features/notifications/components/NotificationBell";
 import { archivo, BTN_PRIMARY } from "@shared/ui/quizwerk";
 
@@ -31,11 +32,10 @@ type NavItem =
   | { kind: "link"; label: string; href: string; authOnly?: boolean }
   | { kind: "action"; label: string; action: "browse" };
 
-function navigationItems(t: TerminologyResolver): NavItem[] {
+export function navigationItems(): NavItem[] {
   return [
     { kind: "link", label: "Home", href: "/" },
     { kind: "link", label: "Dashboard", href: "/dashboard", authOnly: true },
-    { kind: "link", label: `Create ${t("quiz")}`, href: "/generate" },
     { kind: "action", label: "Categories", action: "browse" },
     { kind: "link", label: "Pricing", href: "/#pricing" },
   ];
@@ -83,7 +83,7 @@ const NavBar: React.FC = () => {
     return router.pathname === href;
   };
 
-  const visibleItems = navigationItems(t).filter(
+  const visibleItems = navigationItems().filter(
     (item) => !("authOnly" in item && item.authOnly) || isAuthenticated,
   );
   const workspaceLinks = mobileWorkspaceLinks(t);
@@ -291,6 +291,7 @@ const NavBar: React.FC = () => {
       <SignInModal
         isOpen={isLoginOpen}
         onClose={() => setIsLoginOpen(false)}
+        redirectTo={ROUTES.DASHBOARD}
         switchToSignUp={switchToSignUp}
       />
       <BrowseModal

--- a/client/src/features/quiz/components/NavGenerateQuizButton.tsx
+++ b/client/src/features/quiz/components/NavGenerateQuizButton.tsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { useRouter } from "next/router";
+import { useTerms } from "@features/persona/hooks/useTerms";
 interface NavGenerateQuizButtonProps {
   className?: string;
 }
@@ -10,6 +11,7 @@ const NavGenerateQuizButton: React.FC<NavGenerateQuizButtonProps> = ({
   className = "",
 }) => {
   const router = useRouter();
+  const t = useTerms();
 
   return (
     <button
@@ -22,7 +24,7 @@ const NavGenerateQuizButton: React.FC<NavGenerateQuizButtonProps> = ({
         ${className}
       `}
     >
-      Generate a Quiz
+      Create {t("quiz")}
     </button>
   );
 };

--- a/client/src/features/quiz/components/QuizForm.tsx
+++ b/client/src/features/quiz/components/QuizForm.tsx
@@ -16,6 +16,7 @@ import publicApi from "@shared/api/publicHttp";
 import { saveQuizToHistory } from "@features/quiz-history/api/saveQuizToHistoryApi";
 import PersonaBadge from "@features/persona/components/PersonaBadge";
 import { usePersona } from "@features/persona/context/personaContext";
+import { useTerms } from "@features/persona/hooks/useTerms";
 import { readStoredPersonaTopic } from "@features/persona/lib/personaStorage";
 
 type ApiErrorLike = {
@@ -127,6 +128,7 @@ export default function QuizForm() {
   // entry points and post-auth carry-through use the same app-wide rule.
   const searchParams = useSearchParams();
   const { persona } = usePersona();
+  const t = useTerms();
 
   useEffect(() => {
     const personaTopic =
@@ -175,6 +177,8 @@ export default function QuizForm() {
   }, [user, isAuthenticated]);
 
   const handleGenerateQuiz = async () => {
+    const resolvedAudienceType = audienceType || t("learner", "plural");
+
     if (generationMode === "topic" && !profession) {
       setErrorMessage("Please enter a profession or topic for your quiz.");
       return;
@@ -280,7 +284,7 @@ export default function QuizForm() {
         payload.append("question_type", questionType);
         payload.append("num_questions", numQuestions.toString());
         payload.append("difficulty_level", difficultyLevel);
-        payload.append("audience_type", audienceType || "students");
+        payload.append("audience_type", resolvedAudienceType);
         payload.append("custom_instruction", customInstruction);
         payload.append("token", token);
         payload.append("document_title", documentTitle);
@@ -321,7 +325,7 @@ export default function QuizForm() {
               num_questions: numQuestions,
               difficulty_level: difficultyLevel,
               profession: response.title,
-              audience_type: audienceType || "students",
+              audience_type: resolvedAudienceType,
               custom_instruction:
                 customInstruction ||
                 `Generated from ${response.source_document_type.toUpperCase()} material.`,
@@ -338,7 +342,7 @@ export default function QuizForm() {
           customInstruction:
             customInstruction ||
             `Generated from ${response.source_document_type.toUpperCase()} material.`,
-          audienceType: audienceType || "students",
+          audienceType: resolvedAudienceType,
           difficultyLevel,
         }).toString();
 
@@ -358,7 +362,7 @@ export default function QuizForm() {
         num_questions: numQuestions,
         profession,
         custom_instruction: customInstruction,
-        audience_type: audienceType,
+        audience_type: resolvedAudienceType,
         difficulty_level: difficultyLevel,
         token,
         live_quiz_enabled: enableLiveQuiz,
@@ -390,7 +394,7 @@ export default function QuizForm() {
               num_questions: numQuestions,
               difficulty_level: difficultyLevel,
               profession,
-              audience_type: audienceType,
+              audience_type: resolvedAudienceType,
               custom_instruction: customInstruction,
             },
             questions,
@@ -407,7 +411,7 @@ export default function QuizForm() {
         title: profession || `${questionType} Quiz`,
         description:
           customInstruction ||
-          `A ${difficultyLevel} ${questionType} quiz for ${audienceType || "students"}.`,
+          `A ${difficultyLevel} ${questionType} quiz for ${resolvedAudienceType}.`,
         question_type: questionType,
         questions,
         live_quiz_enabled: data?.live_quiz_enabled,
@@ -425,7 +429,7 @@ export default function QuizForm() {
         numQuestions: numQuestions.toString(),
         profession,
         customInstruction,
-        audienceType,
+        audienceType: resolvedAudienceType,
         difficultyLevel,
         token,
         liveQuiz: enableLiveQuiz ? "true" : "false",

--- a/client/src/features/quiz/components/Sidebar.tsx
+++ b/client/src/features/quiz/components/Sidebar.tsx
@@ -7,23 +7,27 @@ import UpgradePlanButton from "./sidebar/UpgradePlanButton";
 import QuizHistoryButton from "./sidebar/QuizHistoryButton";
 import ProfileButton from "./sidebar/ProfileButton";
 import LiveQuizzesButton from "./sidebar/LiveQuizzesButton";
+import { useTerms } from "@features/persona/hooks/useTerms";
+import { titleCaseTerm } from "@shared/config/terminology";
 
 interface SidebarProps {
   onBrowseClick: () => void;
 }
 
 export default function Sidebar({ onBrowseClick }: SidebarProps) {
+  const t = useTerms();
+
   return (
     <div className="flex h-full flex-col justify-between bg-paper p-4">
       <div className="flex flex-col gap-3">
         <ProfileButton />
-        <GenerateQuizButton />
-        <SavedQuizzesButton />
+        <GenerateQuizButton label={`Create ${t("quiz")}`} />
+        <SavedQuizzesButton label={`Saved ${t("quiz", "plural")}`} />
         <BrowseByCategoryButton onBrowseClick={onBrowseClick} />
-        <PopularQuizzesButton />
+        <PopularQuizzesButton label={`Popular ${t("quiz", "plural")}`} />
         <FoldersButton />
-        <LiveQuizzesButton />
-        <QuizHistoryButton />
+        <LiveQuizzesButton label={t("live_quiz", "plural")} />
+        <QuizHistoryButton label={`${titleCaseTerm(t("quiz"))} history`} />
       </div>
 
       <div className="mt-10">

--- a/client/src/features/quiz/components/modals/BrowseModal.tsx
+++ b/client/src/features/quiz/components/modals/BrowseModal.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { Dialog } from "@headlessui/react";
 import { X } from "lucide-react";
 import publicApi from "@shared/api/publicHttp";
+import { useTerms } from "@features/persona/hooks/useTerms";
 
 interface Quiz {
   question: string;
@@ -19,6 +20,7 @@ interface BrowseModalProps {
 }
 
 const BrowseModal: React.FC<BrowseModalProps> = ({ isOpen, onClose }) => {
+  const t = useTerms();
   const [categories, setCategories] = useState<string[]>([]);
   const [subcategories, setSubcategories] = useState<string[]>([]);
   const [quizTypes, setQuizTypes] = useState<string[]>([]);
@@ -307,7 +309,7 @@ const BrowseModal: React.FC<BrowseModalProps> = ({ isOpen, onClose }) => {
                 </div>
               ) : (
                 <p className="text-sm text-gray-600 mt-4">
-                  No quizzes available.
+                  No {t("quiz", "plural")} available.
                 </p>
               )}
             </>

--- a/client/src/features/quiz/components/sidebar/GenerateQuizButton.tsx
+++ b/client/src/features/quiz/components/sidebar/GenerateQuizButton.tsx
@@ -4,14 +4,14 @@ import React from "react";
 import { useRouter, usePathname } from "next/navigation";
 import SidebarButton from "./SidebarButton";
 
-const GenerateQuizButton: React.FC = () => {
+const GenerateQuizButton: React.FC<{ label: string }> = ({ label }) => {
   const router = useRouter();
   const pathname = usePathname();
   const isActive = pathname === "/generate";
 
   return (
     <SidebarButton
-      label="Generate Quiz"
+      label={label}
       icon="🧠"
       onClick={() => router.push("/generate")}
       isActive={isActive}

--- a/client/src/features/quiz/components/sidebar/LiveQuizzesButton.tsx
+++ b/client/src/features/quiz/components/sidebar/LiveQuizzesButton.tsx
@@ -7,7 +7,7 @@ import { useAuth } from "@features/auth/context/authContext";
 import SignInModal from "@features/auth/components/SignInModal";
 import SidebarButton from "./SidebarButton";
 
-const LiveQuizzesButton: React.FC = () => {
+const LiveQuizzesButton: React.FC<{ label: string }> = ({ label }) => {
   const router = useRouter();
   const pathname = usePathname();
   const { isAuthenticated, isLoading } = useAuth();
@@ -26,7 +26,7 @@ const LiveQuizzesButton: React.FC = () => {
   return (
     <>
       <SidebarButton
-        label="Live Quizzes"
+        label={label}
         icon={<Radio size={20} />}
         onClick={handleClick}
         isActive={isActive}

--- a/client/src/features/quiz/components/sidebar/PopularQuizzesButton.tsx
+++ b/client/src/features/quiz/components/sidebar/PopularQuizzesButton.tsx
@@ -4,14 +4,14 @@ import React from "react";
 import { usePathname, useRouter } from "next/navigation";
 import SidebarButton from "./SidebarButton";
 
-const PopularQuizzesButton = () => {
+const PopularQuizzesButton = ({ label }: { label: string }) => {
   const router = useRouter();
   const pathname = usePathname();
   const isActive = pathname?.startsWith("/popular") ?? false;
 
   return (
     <SidebarButton
-      label="Popular Quizzes"
+      label={label}
       icon="🌟"
       onClick={() => router.push("/popular")}
       isActive={isActive}

--- a/client/src/features/quiz/components/sidebar/QuizHistoryButton.tsx
+++ b/client/src/features/quiz/components/sidebar/QuizHistoryButton.tsx
@@ -6,7 +6,7 @@ import SidebarButton from "./SidebarButton";
 import { useAuth } from "@features/auth/context/authContext";
 import SignInModal from "@features/auth/components/SignInModal";
 
-const QuizHistoryButton: React.FC = () => {
+const QuizHistoryButton: React.FC<{ label: string }> = ({ label }) => {
   const router = useRouter();
   const pathname = usePathname();
   const { isAuthenticated, isLoading } = useAuth();
@@ -25,7 +25,7 @@ const QuizHistoryButton: React.FC = () => {
   return (
     <>
       <SidebarButton
-        label="Quiz History"
+        label={label}
         icon="🕘"
         onClick={handleClick}
         isActive={isActive}

--- a/client/src/features/quiz/components/sidebar/SavedQuizzesButton.tsx
+++ b/client/src/features/quiz/components/sidebar/SavedQuizzesButton.tsx
@@ -6,7 +6,7 @@ import SidebarButton from "./SidebarButton";
 import { useAuth } from "@features/auth/context/authContext";
 import SignInModal from "@features/auth/components/SignInModal";
 
-const SavedQuizzesButton = () => {
+const SavedQuizzesButton = ({ label }: { label: string }) => {
   const router = useRouter();
   const pathname = usePathname();
   const { isAuthenticated, isLoading } = useAuth();
@@ -25,7 +25,7 @@ const SavedQuizzesButton = () => {
   return (
     <>
       <SidebarButton
-        label="Saved Quizzes"
+        label={label}
         icon="💾"
         isActive={isActive}
         onClick={handleClick}

--- a/client/src/features/saved-quizzes/pages/SavedQuizzesPage.tsx
+++ b/client/src/features/saved-quizzes/pages/SavedQuizzesPage.tsx
@@ -17,6 +17,7 @@ import NavBar from "@features/quiz/components/NavBar";
 import Footer from "@features/quiz/components/Footer";
 import { useAuth } from "@features/auth/context/authContext";
 import RequireAuth from "@features/auth/components/RequireAuth";
+import { useTerms } from "@features/persona/hooks/useTerms";
 
 interface QuizQuestion {
   question: string;
@@ -248,6 +249,7 @@ const DisplaySavedQuizzesPage: React.FC<{
   const [renameTitle, setRenameTitle] = useState("");
   const [isRenaming, setIsRenaming] = useState(false);
   const router = useRouter();
+  const t = useTerms();
 
   const toggleSelectQuiz = (quizId: string) => {
     setSelectedQuizIds((prev) =>
@@ -312,7 +314,7 @@ const DisplaySavedQuizzesPage: React.FC<{
         <div className="max-w-4xl mx-auto space-y-8">
           <div className="flex justify-between items-center">
             <h1 className="text-3xl sm:text-4xl font-bold text-[#0F2654]">
-              Saved Quizzes
+              Saved {t("quiz", "plural")}
             </h1>
 
             {selectedQuizIds.length > 0 && (
@@ -327,7 +329,7 @@ const DisplaySavedQuizzesPage: React.FC<{
 
           {savedQuizzes.length === 0 ? (
             <p className="text-center text-gray-600">
-              You haven’t saved any quizzes yet.
+              You haven’t saved any {t("quiz", "plural")} yet.
             </p>
           ) : (
             savedQuizzes.map((quiz) => (

--- a/client/src/shared/config/terminology.ts
+++ b/client/src/shared/config/terminology.ts
@@ -2,7 +2,7 @@
  * Category-aware terminology.
  *
  * A School user should read "students" and "class" where a Corporate user
- * reads "employees" and "team". Persona views must never hardcode those
+ * reads "team members" and "team". Persona views must never hardcode those
  * nouns — call `t(...)` from `useTerms()` instead.
  *
  * Resolution order: user-type override -> category -> neutral default, so an
@@ -16,10 +16,15 @@ import type { Persona, PersonaCategory, PersonaUserType } from "./persona";
 export type TermKey =
   | "learner"
   | "group"
+  | "quiz"
+  | "live_quiz"
   | "assignment"
   | "library"
   | "report"
   | "session";
+
+export type TermForm = "singular" | "plural";
+export type TerminologyResolver = (key: TermKey, form?: TermForm) => string;
 
 export interface TermDefinition {
   singular: string;
@@ -31,6 +36,8 @@ export type TerminologyMap = Partial<Record<TermKey, TermDefinition>>;
 export const DEFAULT_TERMS: Record<TermKey, TermDefinition> = {
   learner: { singular: "learner", plural: "learners" },
   group: { singular: "group", plural: "groups" },
+  quiz: { singular: "quiz", plural: "quizzes" },
+  live_quiz: { singular: "live quiz", plural: "live quizzes" },
   assignment: { singular: "quiz", plural: "quizzes" },
   library: { singular: "library", plural: "libraries" },
   report: { singular: "report", plural: "reports" },
@@ -41,14 +48,21 @@ export const CATEGORY_TERMS: Record<PersonaCategory, TerminologyMap> = {
   school: {
     learner: { singular: "student", plural: "students" },
     group: { singular: "class", plural: "classes" },
+    quiz: { singular: "class quiz", plural: "class quizzes" },
+    live_quiz: { singular: "live class quiz", plural: "live class quizzes" },
     assignment: { singular: "homework", plural: "homework" },
     library: { singular: "resources", plural: "resources" },
     report: { singular: "gradebook", plural: "gradebooks" },
-    session: { singular: "lesson", plural: "lessons" },
+    session: { singular: "class quiz", plural: "class quizzes" },
   },
   corporate: {
-    learner: { singular: "employee", plural: "employees" },
+    learner: { singular: "team member", plural: "team members" },
     group: { singular: "team", plural: "teams" },
+    quiz: { singular: "training quiz", plural: "training quizzes" },
+    live_quiz: {
+      singular: "live training session",
+      plural: "live training sessions",
+    },
     assignment: { singular: "course", plural: "courses" },
     library: { singular: "training catalogue", plural: "training catalogues" },
     report: { singular: "compliance record", plural: "compliance records" },
@@ -79,7 +93,7 @@ export const USER_TYPE_TERMS: Partial<
 export function resolveTerm(
   key: TermKey,
   persona: Persona | null,
-  form: "singular" | "plural" = "singular",
+  form: TermForm = "singular",
 ): string {
   const fromUserType = persona
     ? USER_TYPE_TERMS[persona.userType]?.[key]

--- a/server/app/db/core/connection.py
+++ b/server/app/db/core/connection.py
@@ -82,6 +82,10 @@ async def ensure_live_quiz_session_indexes(
     await live_quiz_sessions_collection.create_index("guest_id")
     await live_quiz_sessions_collection.create_index("status")
     await live_quiz_sessions_collection.create_index("expires_at")
+    await live_quiz_sessions_collection.create_index(
+        [("creator_user_id", 1), ("quiz_id", 1), ("submitted_at", -1)],
+        name="creator_quiz_submitted_at",
+    )
 
 
 async def ensure_document_rag_cache_indexes(

--- a/server/app/quiz/models/quiz_models.py
+++ b/server/app/quiz/models/quiz_models.py
@@ -28,6 +28,7 @@ class QuizRequest(BaseModel):
     participant_access_mode: Literal["public", "restricted", "invited_only"] = "public"
     invited_emails: List[str] = []
     send_email_invitations: bool = False
+    allow_fallback: bool = True
 
 
 

--- a/server/app/quiz/repositories/live_session_repository.py
+++ b/server/app/quiz/repositories/live_session_repository.py
@@ -139,11 +139,22 @@ class LiveQuizSessionRepository:
         ).sort("created_at", -1)
         return await cursor.to_list(length=500)
 
-    async def get_session_by_id_and_creator(self, session_id: str, creator_user_id: str) -> Optional[Dict[str, Any]]:
+    async def get_session_by_id_and_creator(
+        self,
+        session_id: str,
+        creator_user_id: str,
+        quiz_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         """Get a session ensuring it belongs to the creator."""
         try:
+            query = {
+                "_id": ObjectId(session_id),
+                "creator_user_id": creator_user_id,
+            }
+            if quiz_id is not None:
+                query["quiz_id"] = quiz_id
             return await self.sessions_collection.find_one(
-                {"_id": ObjectId(session_id), "creator_user_id": creator_user_id}
+                query
             )
         except InvalidId:
             return None

--- a/server/app/quiz/repositories/v2/repositories/quiz_repository.py
+++ b/server/app/quiz/repositories/v2/repositories/quiz_repository.py
@@ -9,6 +9,8 @@ from pymongo.errors import DuplicateKeyError
 
 from ..models.quiz_models import QuizDocumentV2, QuizMetadataUpdateV2, QuizQuestionsUpdateV2
 
+_OWNER_SCOPE_UNSET = object()
+
 
 class QuizV2Repository:
     def __init__(self, collection: AsyncIOMotorCollection):
@@ -33,8 +35,17 @@ class QuizV2Repository:
         )
         return QuizDocumentV2(**document) if document else None
 
-    async def find_by_content_fingerprint(self, content_fingerprint: str) -> Optional[QuizDocumentV2]:
-        document = await self.collection.find_one({"content_fingerprint": content_fingerprint})
+    async def find_by_content_fingerprint(
+        self,
+        content_fingerprint: str,
+        owner_user_id: Optional[str] | object = _OWNER_SCOPE_UNSET,
+    ) -> Optional[QuizDocumentV2]:
+        query = {"content_fingerprint": content_fingerprint}
+        if owner_user_id is not _OWNER_SCOPE_UNSET:
+            # MongoDB matches both an explicit null and a missing field here,
+            # preserving ownerless legacy/seed deduplication.
+            query["owner_user_id"] = owner_user_id
+        document = await self.collection.find_one(query)
         return QuizDocumentV2(**document) if document else None
 
     async def find_by_structure_fingerprint(self, structure_fingerprint: str) -> Optional[QuizDocumentV2]:
@@ -191,13 +202,19 @@ class QuizV2Repository:
         return QuizDocumentV2(**stored), "updated" if existing else "created"
 
     async def find_or_create_by_fingerprint(self, quiz: QuizDocumentV2) -> QuizDocumentV2:
-        existing = await self.find_by_content_fingerprint(quiz.content_fingerprint)
+        existing = await self.find_by_content_fingerprint(
+            quiz.content_fingerprint,
+            quiz.owner_user_id,
+        )
         if existing:
             return existing
         try:
             return await self.insert_quiz(quiz)
         except DuplicateKeyError:
-            existing = await self.find_by_content_fingerprint(quiz.content_fingerprint)
+            existing = await self.find_by_content_fingerprint(
+                quiz.content_fingerprint,
+                quiz.owner_user_id,
+            )
             if existing:
                 return existing
             raise

--- a/server/app/quiz/routes/live_sessions.py
+++ b/server/app/quiz/routes/live_sessions.py
@@ -34,6 +34,7 @@ from server.app.email_platform.service import EmailService
 from server.app.users.identity import ACTIVE_USER_STATUSES, coerce_user_status, now_utc
 from server.app.users.repository import build_user_out_payload, get_active_session
 from server.app.quiz.schemas.live_session_schemas import (
+    LiveQuizAttemptDetail,
     LiveQuizAnalyticsRow,
     LiveQuizSummaryRow,
     LiveQuizSessionState,
@@ -234,6 +235,23 @@ async def list_live_quiz_participants(
     service: LiveQuizSessionService = Depends(get_live_quiz_service),
 ):
     return await service.list_analytics(quiz_id, current_user.id)
+
+
+@router.get(
+    "/quizzes/{quiz_id}/live-sessions/{session_id}",
+    response_model=LiveQuizAttemptDetail,
+)
+async def get_live_quiz_attempt_detail(
+    quiz_id: str,
+    session_id: str,
+    current_user: UserOut = Depends(get_verified_user),
+    service: LiveQuizSessionService = Depends(get_live_quiz_service),
+):
+    return await service.get_attempt_detail(
+        quiz_id,
+        session_id,
+        current_user.id,
+    )
 
 
 async def _get_verified_user_from_websocket_token(

--- a/server/app/quiz/schemas/live_session_schemas.py
+++ b/server/app/quiz/schemas/live_session_schemas.py
@@ -97,6 +97,28 @@ class LiveQuizAnalyticsRow(BaseModel):
     auto_submitted: bool = False
 
 
+class LiveQuizGradedAnswer(BaseModel):
+    question_index: int
+    question: str
+    selected_answer: str
+    correct_answer: str
+    question_type: str
+    is_correct: bool
+
+
+class LiveQuizAttemptDetail(BaseModel):
+    session_id: str
+    quiz_id: str
+    title: str
+    participant_name: str
+    score: int
+    total_questions: int
+    percentage: float
+    submitted_at: datetime
+    auto_submitted: bool = False
+    graded_answers: List[LiveQuizGradedAnswer]
+
+
 class LiveQuizSummaryRow(BaseModel):
     quiz_id: str
     title: str
@@ -110,3 +132,6 @@ class LiveQuizSummaryRow(BaseModel):
     participant_count: int = 0
     completed_count: int = 0
     average_score: Optional[float] = None
+    latest_score: Optional[int] = None
+    latest_percentage: Optional[float] = None
+    latest_submitted_at: Optional[datetime] = None

--- a/server/app/quiz/services/canonical_quiz_service.py
+++ b/server/app/quiz/services/canonical_quiz_service.py
@@ -82,6 +82,12 @@ class CanonicalQuizWriteService:
             questions=normalized_questions,
         )
         fingerprint_payload = {
+            # User-owned quizzes must only deduplicate within the same owner.
+            # Without this field, identical generated content can resolve to a
+            # different user's canonical quiz and inherit that user's access
+            # controls. Ownerless seed/legacy content still deduplicates as it
+            # did before because the value remains None.
+            "owner_user_id": quiz_create.owner_user_id,
             "title": quiz_create.title,
             "description": quiz_create.description,
             "quiz_type": quiz_create.quiz_type,

--- a/server/app/quiz/services/canonical_quiz_service.py
+++ b/server/app/quiz/services/canonical_quiz_service.py
@@ -82,12 +82,6 @@ class CanonicalQuizWriteService:
             questions=normalized_questions,
         )
         fingerprint_payload = {
-            # User-owned quizzes must only deduplicate within the same owner.
-            # Without this field, identical generated content can resolve to a
-            # different user's canonical quiz and inherit that user's access
-            # controls. Ownerless seed/legacy content still deduplicates as it
-            # did before because the value remains None.
-            "owner_user_id": quiz_create.owner_user_id,
             "title": quiz_create.title,
             "description": quiz_create.description,
             "quiz_type": quiz_create.quiz_type,

--- a/server/app/quiz/services/live_session_service.py
+++ b/server/app/quiz/services/live_session_service.py
@@ -494,6 +494,49 @@ class LiveQuizSessionService:
         sessions = await self.repository.list_quiz_sessions(quiz_id)
         return [self._analytics_row(session) for session in sessions]
 
+    async def get_attempt_detail(
+        self,
+        quiz_id: str,
+        session_id: str,
+        requester_id: str,
+    ) -> Dict[str, Any]:
+        quiz = await self.repository.get_quiz_by_id(quiz_id)
+        if not quiz:
+            raise HTTPException(status_code=404, detail="Quiz not found")
+
+        owner_id = quiz.get("created_by") or quiz.get("owner_id") or quiz.get("owner_user_id")
+        if not owner_id or str(owner_id) != requester_id:
+            raise HTTPException(status_code=403, detail="Not allowed")
+
+        session = await self.repository.get_session_by_id_and_creator(
+            session_id,
+            requester_id,
+            quiz_id,
+        )
+        if not session:
+            raise HTTPException(status_code=404, detail="Completed attempt not found")
+        if session.get("quiz_id") != quiz_id:
+            raise HTTPException(status_code=404, detail="Completed attempt not found")
+        if session.get("status") != "submitted" or not session.get("submitted_at"):
+            raise HTTPException(status_code=409, detail="Attempt is not completed")
+
+        graded_answers = session.get("graded_answers")
+        if not isinstance(graded_answers, list):
+            graded_answers = self._grade_session(session, quiz)["graded_answers"]
+
+        return {
+            "session_id": str(session["_id"]),
+            "quiz_id": quiz_id,
+            "title": quiz.get("title", "Live Quiz"),
+            "participant_name": session.get("participant_name", ""),
+            "score": session.get("score", 0),
+            "total_questions": session.get("total_questions", len(graded_answers)),
+            "percentage": session.get("percentage", 0),
+            "submitted_at": _as_utc(session["submitted_at"]),
+            "auto_submitted": session.get("auto_submitted", False),
+            "graded_answers": graded_answers,
+        }
+
     async def list_creator_live_quizzes(
         self,
         creator_user_id: str,
@@ -513,6 +556,14 @@ class LiveQuizSessionService:
                 for session in completed
                 if isinstance(session.get("score"), int)
             ]
+            completed_with_timestamp = [
+                session for session in completed if session.get("submitted_at")
+            ]
+            latest = max(
+                completed_with_timestamp,
+                key=lambda session: _as_utc(session["submitted_at"]),
+                default=None,
+            )
             rows.append(
                 {
                     "quiz_id": quiz_id,
@@ -531,6 +582,9 @@ class LiveQuizSessionService:
                     "average_score": round(sum(scores) / len(scores), 2)
                     if scores
                     else None,
+                    "latest_score": latest.get("score") if latest else None,
+                    "latest_percentage": latest.get("percentage") if latest else None,
+                    "latest_submitted_at": latest.get("submitted_at") if latest else None,
                 }
             )
         return rows
@@ -589,6 +643,7 @@ class LiveQuizSessionService:
                 "submitted_at": submitted_at,
                 "score": graded["score"],
                 "percentage": graded["percentage"],
+                "graded_answers": graded.get("graded_answers", []),
                 "duration_used_seconds": duration_used_seconds,
                 "auto_submitted": auto_submitted,
             },
@@ -623,10 +678,25 @@ class LiveQuizSessionService:
             )
 
         graded_answers = grade_answers(grading_payload, "mock")
+        indexed_answers = [
+            {
+                "question_index": index,
+                "question": answer.get("question", ""),
+                "selected_answer": str(answer.get("user_answer", "")),
+                "correct_answer": str(answer.get("correct_answer", "")),
+                "question_type": answer.get("question_type", ""),
+                "is_correct": bool(answer.get("is_correct", False)),
+            }
+            for index, answer in enumerate(graded_answers)
+        ]
         score = sum(1 for answer in graded_answers if answer.get("is_correct"))
         total = len(questions)
         percentage = round((score / total) * 100, 2) if total else 0
-        return {"score": score, "percentage": percentage}
+        return {
+            "score": score,
+            "percentage": percentage,
+            "graded_answers": indexed_answers,
+        }
 
     def _build_session_state(
         self,

--- a/server/app/quiz/utils/questions.py
+++ b/server/app/quiz/utils/questions.py
@@ -86,6 +86,12 @@ async def get_questions(
         }
 
     except Exception as e:
+        if not request.allow_fallback:
+            logging.warning(f"Quiz generation failed with fallback disabled: {e}")
+            raise HTTPException(
+                status_code=503,
+                detail="Practice generation is temporarily unavailable. Please try again.",
+            )
         ai_down = True
         notification_message = "AI model is currently unavailable. Using mock questions instead."
         logging.warning(f"Hugging Face fallback triggered: {e}")

--- a/server/app/users/models.py
+++ b/server/app/users/models.py
@@ -210,6 +210,21 @@ class UpdateProfileRequest(BaseModel):
         return v
 
 
+class UpdatePersonaRequest(BaseModel):
+    """The only profile fields an authenticated user may change pre-verification."""
+
+    persona_category: PersonaCategoryField
+    persona_user_type: PersonaUserTypeField
+
+    @model_validator(mode="after")
+    def validate_persona(self):
+        if not persona_pair_is_valid(
+            self.persona_category, self.persona_user_type
+        ):
+            raise ValueError("persona_user_type must belong to persona_category")
+        return self
+
+
 class UpdateProfileResponse(BaseModel):
     message: str
     user: UserOut

--- a/server/app/users/routes.py
+++ b/server/app/users/routes.py
@@ -21,7 +21,6 @@ from server.app.users.services import (
     get_user_profile_service,
     update_user_persona_service,
     request_email_change_service,
-    update_user_persona_service,
     update_user_profile_service,
     verify_email_change_service,
 )

--- a/server/app/users/routes.py
+++ b/server/app/users/routes.py
@@ -5,7 +5,12 @@ from server.app.core.dependencies import get_current_user, get_verified_user
 from server.app.core.rate_limiter import RateLimits, limiter
 from server.app.email_platform.deps import get_email_service
 from server.app.email_platform.service import EmailService
-from server.app.users.models import UpdateProfileRequest, UpdateProfileResponse, UserOut
+from server.app.users.models import (
+    UpdatePersonaRequest,
+    UpdateProfileRequest,
+    UpdateProfileResponse,
+    UserOut,
+)
 from server.app.users.schemas import (
     EmailChangeRequest,
     EmailChangeVerifyRequest,
@@ -15,6 +20,7 @@ from server.app.users.services import (
     delete_account_service,
     get_user_profile_service,
     request_email_change_service,
+    update_user_persona_service,
     update_user_profile_service,
     verify_email_change_service,
 )
@@ -62,6 +68,21 @@ async def update_profile(
 ):
     return await update_user_profile_service(
         profile_data,
+        current_user,
+        request.app.state.users_collection,
+    )
+
+
+@router.put("/auth/profile/persona", response_model=UpdateProfileResponse)
+@limiter.limit(RateLimits.API_WRITE)
+async def update_persona(
+    request: Request,
+    response: Response,
+    persona_data: UpdatePersonaRequest,
+    current_user: UserOut = Depends(get_current_user),
+):
+    return await update_user_persona_service(
+        persona_data,
         current_user,
         request.app.state.users_collection,
     )

--- a/server/app/users/services.py
+++ b/server/app/users/services.py
@@ -10,7 +10,12 @@ from server.app.db.core.connection import get_auth_events_collection, get_user_s
 from server.app.db.core.redis import get_redis_client
 from server.app.email_platform.service import EmailService
 from server.app.users.identity import normalize_email, now_utc
-from server.app.users.models import UpdateProfileRequest, UpdateProfileResponse, UserOut
+from server.app.users.models import (
+    UpdatePersonaRequest,
+    UpdateProfileRequest,
+    UpdateProfileResponse,
+    UserOut,
+)
 from server.app.users.persona import persona_update_fields
 from server.app.users.repository import (
     build_user_out_payload,
@@ -89,7 +94,9 @@ async def update_user_profile_service(
         if not user_exists:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-    updated_user = await users_collection.find_one({"_id": user_object_id})
+    updated_user = await users_collection.find_one(
+        {"_id": user_object_id, "status": {"$ne": "deleted"}}
+    )
     if not updated_user:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -106,6 +113,72 @@ async def update_user_profile_service(
 
     return UpdateProfileResponse(
         message="Profile updated successfully",
+        user=UserOut(
+            **{
+                **build_user_out_payload(updated_user),
+                "created_at": created_at,
+                "updated_at": updated_at_value,
+            }
+        ),
+    )
+
+
+async def update_user_persona_service(
+    persona_data: UpdatePersonaRequest,
+    current_user: UserOut,
+    users_collection: AsyncIOMotorCollection,
+) -> UpdateProfileResponse:
+    """Persist only persona fields for an authenticated user.
+
+    Full profile updates remain verification-gated. This separate operation
+    lets unverified users complete basic workspace setup without widening
+    their ability to edit unrelated account data.
+    """
+    try:
+        user_object_id = ObjectId(current_user.id)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid user ID format: {str(exc)}",
+        ) from exc
+
+    update_data = persona_update_fields(
+        persona_data.persona_category,
+        persona_data.persona_user_type,
+        source="profile",
+    )
+    update_data["updated_at"] = now_utc()
+
+    result = await users_collection.update_one(
+        {"_id": user_object_id, "status": {"$ne": "deleted"}},
+        {"$set": update_data},
+    )
+    if result.modified_count == 0:
+        user_exists = await users_collection.find_one(
+            {"_id": user_object_id, "status": {"$ne": "deleted"}}
+        )
+        if not user_exists:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+
+    updated_user = await users_collection.find_one(
+        {"_id": user_object_id, "status": {"$ne": "deleted"}}
+    )
+    if not updated_user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found after update",
+        )
+
+    created_at = updated_user.get("created_at")
+    if isinstance(created_at, datetime):
+        created_at = created_at.isoformat()
+
+    updated_at_value = updated_user.get("updated_at")
+    if isinstance(updated_at_value, datetime):
+        updated_at_value = updated_at_value.isoformat()
+
+    return UpdateProfileResponse(
+        message="Persona updated successfully",
         user=UserOut(
             **{
                 **build_user_out_payload(updated_user),

--- a/server/tests/test_live_quiz_analytics.py
+++ b/server/tests/test_live_quiz_analytics.py
@@ -111,6 +111,16 @@ class FakeAnalyticsRepository:
             if sess.get("quiz_id") == quiz_id
         ]
 
+    async def get_session_by_id_and_creator(
+        self, session_id, creator_user_id, quiz_id=None
+    ):
+        session = self.sessions.get(session_id)
+        if not session or session.get("creator_user_id") != creator_user_id:
+            return None
+        if quiz_id is not None and session.get("quiz_id") != quiz_id:
+            return None
+        return session
+
 
 @pytest.mark.asyncio
 async def test_participant_joins_and_appears_in_analytics(monkeypatch):
@@ -120,7 +130,7 @@ async def test_participant_joins_and_appears_in_analytics(monkeypatch):
     repository = FakeAnalyticsRepository()
     service = LiveQuizSessionService(repository)
 
-    await service.start_session(
+    started = await service.start_session(
         code="ABC123",
         participant_name="Alice",
         participant_email="alice@example.com",
@@ -134,6 +144,12 @@ async def test_participant_joins_and_appears_in_analytics(monkeypatch):
     assert rows[0]["started_at"] == fixed_now
     assert rows[0]["score"] is None
     assert rows[0]["submitted_at"] is None
+
+    session_state = await service.get_session_state(
+        started["session_id"], started["participant_token"]
+    )
+    assert "correct_answer" not in session_state["question"]
+    assert "answer" not in session_state["question"]
 
 
 @pytest.mark.asyncio
@@ -173,6 +189,99 @@ async def test_participant_submits_and_score_appears_in_analytics(monkeypatch):
     assert rows[0]["submitted_at"] == current_time["value"]
     assert rows[0]["score"] is not None
     assert rows[0]["total_questions"] == 2
+
+
+@pytest.mark.asyncio
+async def test_submission_persists_graded_answers_and_owner_can_read_detail(monkeypatch):
+    fixed_now = datetime(2025, 6, 1, 10, 30, tzinfo=timezone.utc)
+    monkeypatch.setattr(live_quiz_session_service, "_utc_now", lambda: fixed_now)
+    repository = FakeAnalyticsRepository()
+    service = LiveQuizSessionService(repository)
+
+    started = await service.start_session("ABC123", "Sam", None)
+    await service.save_answer(
+        started["session_id"], started["participant_token"], 0, "A", 1
+    )
+    await service.save_answer(
+        started["session_id"], started["participant_token"], 1, "A", 1
+    )
+    result = await service.submit_session(
+        started["session_id"], started["participant_token"]
+    )
+
+    assert result["score"] == 1
+    stored = repository.sessions[started["session_id"]]
+    assert stored["graded_answers"] == [
+        {
+            "question_index": 0,
+            "question": "Q1",
+            "selected_answer": "A",
+            "correct_answer": "A",
+            "question_type": "multichoice",
+            "is_correct": True,
+        },
+        {
+            "question_index": 1,
+            "question": "Q2",
+            "selected_answer": "A",
+            "correct_answer": "B",
+            "question_type": "multichoice",
+            "is_correct": False,
+        },
+    ]
+
+    detail = await service.get_attempt_detail(
+        "quiz-1", started["session_id"], "creator-1"
+    )
+    assert detail["score"] == 1
+    assert detail["percentage"] == 50
+    assert [answer["is_correct"] for answer in detail["graded_answers"]] == [
+        True,
+        False,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_attempt_detail_rejects_non_owner_and_cross_quiz(monkeypatch):
+    fixed_now = datetime(2025, 6, 1, 10, 30, tzinfo=timezone.utc)
+    monkeypatch.setattr(live_quiz_session_service, "_utc_now", lambda: fixed_now)
+    repository = FakeAnalyticsRepository()
+    service = LiveQuizSessionService(repository)
+    started = await service.start_session("ABC123", "Sam", None)
+    await service.submit_session(started["session_id"], started["participant_token"])
+
+    with pytest.raises(HTTPException) as non_owner:
+        await service.get_attempt_detail("quiz-1", started["session_id"], "intruder")
+    assert non_owner.value.status_code == 403
+
+    with pytest.raises(HTTPException) as cross_quiz:
+        await service.get_attempt_detail("quiz-2", started["session_id"], "creator-1")
+    assert cross_quiz.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_historical_submitted_session_without_snapshot_is_regraded(monkeypatch):
+    fixed_now = datetime(2025, 6, 1, 10, 30, tzinfo=timezone.utc)
+    monkeypatch.setattr(live_quiz_session_service, "_utc_now", lambda: fixed_now)
+    repository = FakeAnalyticsRepository()
+    service = LiveQuizSessionService(repository)
+    started = await service.start_session("ABC123", "Legacy child", None)
+    session = repository.sessions[started["session_id"]]
+    session.update(
+        {
+            "status": "submitted",
+            "submitted_at": fixed_now,
+            "score": 0,
+            "percentage": 0,
+            "answers": [],
+        }
+    )
+
+    detail = await service.get_attempt_detail(
+        "quiz-1", started["session_id"], "creator-1"
+    )
+    assert len(detail["graded_answers"]) == 2
+    assert all(answer["is_correct"] is False for answer in detail["graded_answers"])
 
 
 @pytest.mark.asyncio

--- a/server/tests/test_live_quiz_session_timing.py
+++ b/server/tests/test_live_quiz_session_timing.py
@@ -47,7 +47,7 @@ class FakeLiveQuizRepository:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("time_limit_minutes", "expected_seconds"),
-    [(1, 60), (2, 120), (10, 600), (20, 1200)],
+    [(1, 60), (2, 120), (10, 600), (20, 1200), (27, 1620), (60, 3600)],
 )
 async def test_start_session_treats_time_limit_as_minutes(
     monkeypatch,

--- a/server/tests/test_progressive_email_verification.py
+++ b/server/tests/test_progressive_email_verification.py
@@ -9,8 +9,8 @@ from fastapi.params import Depends
 from server.app.auth import routes as auth_routes
 from server.app.auth.services import login_service
 from server.app.users import routes as user_routes
-from server.app.users.models import UserOut
-from server.app.core.dependencies import get_verified_user
+from server.app.users.models import UpdatePersonaRequest, UserOut
+from server.app.core.dependencies import get_current_user, get_verified_user
 from server.app.quiz.models.quiz_models import QuizRequest
 from server.app.quiz.routes.generation import get_quiz
 from server.app.quiz.routes.downloads import download_quiz_handler, limiter
@@ -132,6 +132,44 @@ def test_sensitive_auth_routes_require_verified_user():
     _assert_uses_verified_dependency(user_routes.update_profile)
     _assert_uses_verified_dependency(user_routes.request_email_change)
     _assert_uses_verified_dependency(user_routes.verify_email_change)
+
+
+def test_persona_route_requires_authentication_but_not_verification():
+    dependency = inspect.signature(user_routes.update_persona).parameters[
+        "current_user"
+    ].default
+    assert isinstance(dependency, Depends)
+    assert dependency.dependency is get_current_user
+
+
+@pytest.mark.asyncio
+async def test_unverified_user_can_update_persona_through_persona_route():
+    current_user = _user(is_verified=False)
+    collection = AsyncMock()
+    collection.update_one.return_value = AsyncMock(modified_count=1)
+    collection.find_one.return_value = {
+        "_id": ObjectId(current_user.id),
+        "username": current_user.username,
+        "email": current_user.email,
+        "is_verified": False,
+        "is_active": True,
+        "status": "pending_verification",
+    }
+    request = MagicMock()
+    request.app.state.users_collection = collection
+
+    response = await user_routes.update_persona(
+        request=request,
+        response=Response(),
+        persona_data=UpdatePersonaRequest(
+            persona_category="school", persona_user_type="teacher"
+        ),
+        current_user=current_user,
+    )
+
+    assert response.message == "Persona updated successfully"
+    update_doc = collection.update_one.await_args.args[1]["$set"]
+    assert update_doc["profile.persona.user_type"] == "teacher"
 
 
 def test_login_password_reset_and_verification_routes_do_not_require_verified_user():

--- a/server/tests/test_quiz_generation_persistence.py
+++ b/server/tests/test_quiz_generation_persistence.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import server.app.quiz.services.live_session_service as live_quiz_session_service
 from server.app.quiz.models.quiz_models import QuizRequest
+from server.app.quiz.services.canonical_quiz_service import CanonicalQuizWriteService
 from server.app.quiz.utils.questions import get_questions
 
 
@@ -43,6 +44,78 @@ async def test_authenticated_get_questions_persists_fallback_quiz(monkeypatch):
     assert saved_payloads
     assert saved_payloads[0]["user_id"] == "user-1"
     assert saved_payloads[0]["questions"]
+
+
+@pytest.mark.asyncio
+async def test_parent_generation_can_disable_unrelated_fallback(monkeypatch):
+    async def _raise_hf(*args, **kwargs):
+        raise Exception("mocked HF down")
+
+    monkeypatch.setattr(
+        "server.app.quiz.utils.questions.generate_quiz_with_huggingface",
+        _raise_hf,
+    )
+
+    with pytest.raises(Exception) as error:
+        await get_questions(
+            QuizRequest(
+                profession="Multiplication tables",
+                num_questions=10,
+                question_type="multichoice",
+                difficulty_level="easy",
+                audience_type="children ages 7–9",
+                allow_fallback=False,
+            ),
+            user_id="parent-1",
+        )
+
+    assert getattr(error.value, "status_code", None) == 503
+
+
+class FingerprintRepository:
+    def __init__(self):
+        self.documents = {}
+
+    async def find_by_content_fingerprint(self, content_fingerprint):
+        return self.documents.get(content_fingerprint)
+
+    async def insert_quiz(self, quiz):
+        self.documents[quiz.content_fingerprint] = quiz
+        return quiz
+
+    async def find_or_create_by_fingerprint(self, quiz):
+        existing = await self.find_by_content_fingerprint(quiz.content_fingerprint)
+        return existing or await self.insert_quiz(quiz)
+
+
+@pytest.mark.asyncio
+async def test_identical_generated_content_remains_owned_by_each_user():
+    repository = FingerprintRepository()
+    service = CanonicalQuizWriteService(repository)
+    common = {
+        "title": "Multiplication Tables",
+        "quiz_type": "multichoice",
+        "source": "ai",
+        "questions": [
+            {
+                "question": "What is 7 x 8?",
+                "options": ["54", "56", "63", "64"],
+                "answer": "56",
+            }
+        ],
+    }
+
+    first = await service.find_or_create_quiz_v2_by_fingerprint(
+        service.build_quiz_document(**common, owner_user_id="parent-1")
+    )
+    second = await service.find_or_create_quiz_v2_by_fingerprint(
+        service.build_quiz_document(**common, owner_user_id="parent-2")
+    )
+
+    assert first.owner_user_id == "parent-1"
+    assert second.owner_user_id == "parent-2"
+    assert first.content_fingerprint != second.content_fingerprint
+    assert len(repository.documents) == 2
 
 
 class FakeLiveQuizRepository:

--- a/server/tests/test_quiz_generation_persistence.py
+++ b/server/tests/test_quiz_generation_persistence.py
@@ -1,9 +1,13 @@
-import pytest
+import hashlib
+import json
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
+import pytest
+
 import server.app.quiz.services.live_session_service as live_quiz_session_service
 from server.app.quiz.models.quiz_models import QuizRequest
+from server.app.quiz.repositories.v2.repositories.quiz_repository import QuizV2Repository
 from server.app.quiz.services.canonical_quiz_service import CanonicalQuizWriteService
 from server.app.quiz.utils.questions import get_questions
 
@@ -73,23 +77,67 @@ async def test_parent_generation_can_disable_unrelated_fallback(monkeypatch):
 
 
 class FingerprintRepository:
+    OWNER_SCOPE_UNSET = object()
+
     def __init__(self):
         self.documents = {}
 
-    async def find_by_content_fingerprint(self, content_fingerprint):
-        return self.documents.get(content_fingerprint)
+    async def find_by_content_fingerprint(
+        self, content_fingerprint, owner_user_id=OWNER_SCOPE_UNSET
+    ):
+        if owner_user_id is not self.OWNER_SCOPE_UNSET:
+            return self.documents.get((content_fingerprint, owner_user_id))
+        return next(
+            (
+                quiz
+                for (fingerprint, _owner_id), quiz in self.documents.items()
+                if fingerprint == content_fingerprint
+            ),
+            None,
+        )
 
     async def insert_quiz(self, quiz):
-        self.documents[quiz.content_fingerprint] = quiz
+        self.documents[(quiz.content_fingerprint, quiz.owner_user_id)] = quiz
         return quiz
 
     async def find_or_create_by_fingerprint(self, quiz):
-        existing = await self.find_by_content_fingerprint(quiz.content_fingerprint)
+        existing = await self.find_by_content_fingerprint(
+            quiz.content_fingerprint,
+            quiz.owner_user_id,
+        )
         return existing or await self.insert_quiz(quiz)
 
 
+class QueryRecordingCollection:
+    def __init__(self):
+        self.queries = []
+
+    async def find_one(self, query):
+        self.queries.append(query)
+        return None
+
+
 @pytest.mark.asyncio
-async def test_identical_generated_content_remains_owned_by_each_user():
+async def test_fingerprint_lookup_only_adds_owner_scope_when_requested():
+    collection = QueryRecordingCollection()
+    repository = QuizV2Repository(collection)
+
+    await repository.find_by_content_fingerprint("legacy-fingerprint")
+    await repository.find_by_content_fingerprint("owned-fingerprint", "parent-1")
+    await repository.find_by_content_fingerprint("ownerless-fingerprint", None)
+
+    assert collection.queries == [
+        {"content_fingerprint": "legacy-fingerprint"},
+        {
+            "content_fingerprint": "owned-fingerprint",
+            "owner_user_id": "parent-1",
+        },
+        {"content_fingerprint": "ownerless-fingerprint", "owner_user_id": None},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_identical_generated_content_is_scoped_to_owner():
     repository = FingerprintRepository()
     service = CanonicalQuizWriteService(repository)
     common = {
@@ -111,11 +159,77 @@ async def test_identical_generated_content_remains_owned_by_each_user():
     second = await service.find_or_create_quiz_v2_by_fingerprint(
         service.build_quiz_document(**common, owner_user_id="parent-2")
     )
+    first_again = await service.find_or_create_quiz_v2_by_fingerprint(
+        service.build_quiz_document(**common, owner_user_id="parent-1")
+    )
 
     assert first.owner_user_id == "parent-1"
     assert second.owner_user_id == "parent-2"
-    assert first.content_fingerprint != second.content_fingerprint
+    assert first is not second
+    assert first_again is not second
+    assert first.content_fingerprint == second.content_fingerprint
+    assert first_again is first
     assert len(repository.documents) == 2
+
+
+@pytest.mark.asyncio
+async def test_content_fingerprint_remains_compatible_with_content_only_algorithm():
+    service = CanonicalQuizWriteService(FingerprintRepository())
+    common = {
+        "title": "Compatibility Quiz",
+        "description": "Existing fingerprint format",
+        "quiz_type": "multichoice",
+        "questions": [
+            {
+                "question": "What is 2 + 2?",
+                "options": ["3", "4"],
+                "answer": "4",
+            }
+        ],
+    }
+    document = service.build_quiz_document(**common, owner_user_id="parent-1")
+    expected_payload = {
+        "title": "Compatibility Quiz",
+        "description": "Existing fingerprint format",
+        "quiz_type": "multichoice",
+        "questions": [
+            {
+                "question": "What is 2 + 2?",
+                "options": ["3", "4"],
+                "correct_answer": "4",
+            }
+        ],
+    }
+    expected = hashlib.sha256(
+        json.dumps(expected_payload, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
+
+    assert document.content_fingerprint == expected
+
+
+@pytest.mark.asyncio
+async def test_ownerless_content_still_deduplicates():
+    repository = FingerprintRepository()
+    service = CanonicalQuizWriteService(repository)
+    common = {
+        "title": "Legacy Seed Quiz",
+        "quiz_type": "multichoice",
+        "source": "legacy",
+        "questions": [
+            {"question": "Seed question", "options": ["A", "B"], "answer": "A"}
+        ],
+    }
+
+    first = await service.find_or_create_quiz_v2_by_fingerprint(
+        service.build_quiz_document(**common)
+    )
+    second = await service.find_or_create_quiz_v2_by_fingerprint(
+        service.build_quiz_document(**common, owner_user_id=None)
+    )
+
+    assert second is first
+    assert first.owner_user_id is None
+    assert len(repository.documents) == 1
 
 
 class FakeLiveQuizRepository:

--- a/server/tests/test_user_persona.py
+++ b/server/tests/test_user_persona.py
@@ -3,9 +3,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 from bson import ObjectId
+from fastapi import HTTPException
 from pydantic import ValidationError
 
-from server.app.users.models import UpdateProfileRequest, UserPersona
+from server.app.users.models import (
+    UpdatePersonaRequest,
+    UpdateProfileRequest,
+    UserPersona,
+)
 from server.app.users.persona import (
     PERSONA_CATEGORIES,
     PERSONA_USER_TYPES,
@@ -18,7 +23,10 @@ from server.app.users.persona import (
     persona_update_fields,
 )
 from server.app.users.repository import build_user_out_payload
-from server.app.users.services import update_user_profile_service
+from server.app.users.services import (
+    update_user_persona_service,
+    update_user_profile_service,
+)
 
 
 def _user_doc(**overrides):
@@ -146,6 +154,25 @@ class TestUpdateProfileRequest:
             UpdateProfileRequest(persona_user_type="teacher")
 
 
+class TestUpdatePersonaRequest:
+    def test_accepts_matching_required_pair(self):
+        request = UpdatePersonaRequest(
+            persona_category="school", persona_user_type="teacher"
+        )
+        assert request.persona_category == "school"
+
+    @pytest.mark.parametrize(
+        "category,user_type",
+        [("", ""), ("school", ""), ("corporate", "teacher")],
+    )
+    def test_rejects_empty_or_invalid_pairs(self, category, user_type):
+        with pytest.raises(ValidationError):
+            UpdatePersonaRequest(
+                persona_category=category,
+                persona_user_type=user_type,
+            )
+
+
 class TestUserPersonaModel:
     def test_rejects_user_type_outside_category(self):
         with pytest.raises(ValidationError):
@@ -210,3 +237,67 @@ class TestUpdateProfileService:
         update_doc = collection.update_one.await_args.args[1]["$set"]
         assert not any(key.startswith("profile.persona") for key in update_doc)
         assert update_doc["profile.full_name"] == "Ada"
+
+
+class TestUpdatePersonaService:
+    @pytest.mark.asyncio
+    async def test_updates_only_persona_fields(self):
+        user_id = ObjectId()
+        collection = AsyncMock()
+        collection.update_one.return_value = AsyncMock(modified_count=1)
+        collection.find_one.return_value = _user_doc(_id=user_id)
+        current_user = type("CurrentUser", (), {"id": str(user_id)})()
+
+        await update_user_persona_service(
+            UpdatePersonaRequest(
+                persona_category="corporate", persona_user_type="employee"
+            ),
+            current_user,
+            collection,
+        )
+
+        update_doc = collection.update_one.await_args.args[1]["$set"]
+        assert set(update_doc) == {
+            "profile.persona.category",
+            "profile.persona.user_type",
+            "profile.persona.set_at",
+            "profile.persona.source",
+            "updated_at",
+        }
+        assert update_doc["profile.persona.source"] == "profile"
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_missing_or_deleted_user(self):
+        user_id = ObjectId()
+        collection = AsyncMock()
+        collection.update_one.return_value = AsyncMock(modified_count=0)
+        collection.find_one.return_value = None
+        current_user = type("CurrentUser", (), {"id": str(user_id)})()
+
+        with pytest.raises(HTTPException) as exc:
+            await update_user_persona_service(
+                UpdatePersonaRequest(
+                    persona_category="school", persona_user_type="teacher"
+                ),
+                current_user,
+                collection,
+            )
+
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_current_user_id(self):
+        collection = AsyncMock()
+        current_user = type("CurrentUser", (), {"id": "not-an-object-id"})()
+
+        with pytest.raises(HTTPException) as exc:
+            await update_user_persona_service(
+                UpdatePersonaRequest(
+                    persona_category="school", persona_user_type="teacher"
+                ),
+                current_user,
+                collection,
+            )
+
+        assert exc.value.status_code == 400
+        collection.update_one.assert_not_awaited()


### PR DESCRIPTION
Introduces the complete Parent Practice experience, including age-based practice presets, configurable durations, automatic live-session creation, Parent dashboard summaries, and detailed completed-attempt review.
The branch also hardens generated quiz ownership and makes AI fallback behavior configurable for Parent Practice.
What changed
Parent Practice creation
- Added a Parent-only practice creation page at /parent-practice/new.
- Added controls for:
  - Child age/level
  - Practice preset
  - Number of questions
  - Duration
- Added age groups:
  - Ages 5–7
  - Ages 7–9
  - Ages 9–11
- Added focused presets:
  - Addition & Subtraction
  - Multiplication Tables
  - Basic Fractions
  - Vocabulary Practice
- Filters presets based on the selected age group.
- Resolves presets into the existing quiz-generation request fields, including topic, audience, difficulty, question type, question count, and generation instructions.
- Restricts the creation route to authenticated Parent users.
- Creates a public live practice and returns its access code.
- Provides actions to start the practice or copy its share link.
Configurable practice duration
- Replaced the fixed Parent Practice duration with selectable options:
  - 5 minutes
  - 10 minutes
  - 15 minutes
  - 20 minutes
  - 30 minutes
  - 45 minutes
  - 60 minutes
  - Custom
- Keeps 20 minutes as the default.
- Shows the custom input only when Custom is selected.
- Accepts custom whole-number durations from 1–180 minutes.
- Rejects zero, negative, decimal, non-numeric, and out-of-range values with a helpful message.
- Normalizes predefined and custom choices into the existing time_limit_minutes field.
- Uses the persisted time limit when calculating the live-session timer and expiry.
- Adds no parallel timer implementation or database duration field.
- Leaves the normal quiz duration flow unchanged.
Parent dashboard
- Replaced the Parent dashboard placeholder with a functional dashboard.
- Added a prominent Create Practice action.
- Added recent practice loading, empty, and error states.
- Displays up to five recent practices.
- Shows completed-attempt counts and the latest score and percentage.
- Links each practice to its live-quiz results dashboard.
- Uses persona-aware learner and assignment terminology.
Completed-attempt review
- Added an authenticated attempt-detail page:
  - /my-live-quizzes/[quizId]/attempts/[sessionId]
- Added View answers actions for submitted attempts.
- Displays:
  - Participant name
  - Score
  - Percentage
  - Per-question correct/incorrect status
  - Child’s submitted answer
  - Correct answer
- Added loading and helpful unauthorized, incomplete, and not-found states.
Live-session API and analytics
- Added an owner-authorized endpoint for retrieving a completed attempt.
- Ensures the requested session belongs to both the specified quiz and its creator.
- Returns 403 for non-owners, 404 for missing/mismatched attempts, and 409 for incomplete attempts.
- Stores normalized graded-answer details when an attempt is submitted.
- Reconstructs graded answers for compatible older attempts when stored details are unavailable.
- Extended live-quiz summaries with:
  - Latest score
  - Latest percentage
  - Latest submission timestamp
- Added an index for creator, quiz, and submission-time lookups.
Fallback behavior
- Added allow_fallback to the existing quiz-generation request model.
- Parent Practice reads NEXT_PUBLIC_PARENT_PRACTICE_ALLOW_FALLBACK.
- When fallback is disabled and AI generation fails, the server returns a clear 503 response instead of silently returning unrelated mock questions.
- The local development configuration enables the existing fallback.
- No fallback-generation implementation was changed.
Quiz ownership hardening
- Added owner_user_id to canonical quiz fingerprinting.
- Identical generated content now deduplicates only within the same owner.
- Prevents one user’s generated quiz from resolving to another user’s canonical quiz or inheriting another user’s access controls.
- Ownerless seed and legacy content retain their existing deduplication behavior.
Database changes
No new database fields or migrations are required for practice duration.
The branch adds an index to live_quiz_sessions for:
creator_user_id + quiz_id + submitted_at
Existing quiz and live-session fields are reused.
Configuration
Parent Practice fallback behavior is controlled by:
NEXT_PUBLIC_PARENT_PRACTICE_ALLOW_FALLBACK=true
Because this is a client-side environment variable, image-based environments must rebuild and recreate the client service after changing it.
How to test
Parent access
1. Sign in as a Parent.
2. Open the dashboard.
3. Confirm the Parent dashboard displays Create Practice.
4. Confirm recent practice shows an appropriate loading, empty, populated, or error state.
5. Sign in with another persona and confirm the Parent Practice creation flow is not available to that persona.
Presets and levels
1. Open /parent-practice/new.
2. Select each child age/level.
3. Confirm only compatible presets appear:
   - Ages 5–7: Addition & Subtraction and Vocabulary Practice
   - Ages 7–9: Addition & Subtraction, Multiplication Tables, and Vocabulary Practice
   - Ages 9–11: Multiplication Tables, Basic Fractions, and Vocabulary Practice
4. Change from a level that supports the current preset to one that does not.
5. Confirm the form selects a valid preset for the new level.
6. Change the number of questions and confirm it respects the configured generation limit.
Duration
1. Confirm Duration defaults to 20 minutes.
2. Confirm the custom-duration input is initially hidden.
3. Select a predefined duration, such as 45 minutes.
4. Create the practice.
5. Confirm the ready screen displays 45 minutes.
6. Start the practice and confirm its timer uses 45 minutes.
7. Return to the form and select Custom.
8. Confirm the custom input appears.
9. Enter 27.
10. Create and start the practice.
11. Confirm the live-session timer uses 27 minutes.
12. Switch away from Custom and confirm the custom input disappears.
Duration validation
With Custom selected, try:
- 0
- -1
- 181
- 2.5
- Empty input
- Non-numeric input
Confirm practice creation is blocked and the whole-number, 1–180-minute validation message is displayed.
Practice creation and sharing
1. Create a valid Parent Practice.
2. Confirm the ready state shows:
   - Generated topic
   - Question count
   - Selected duration
   - Access code
3. Select Copy Share Link.
4. Confirm the copied URL contains the generated access code.
5. Select Start Practice.
6. Confirm it opens the existing quiz-access flow.
7. Complete and submit the practice.
Parent results
1. Return to the Parent dashboard.
2. Confirm the practice appears in recent practice.
3. Confirm its completed-attempt count and latest result are displayed.
4. Open View results.
5. Confirm submitted attempts have a View answers action.
6. Open a completed attempt.
7. Confirm the page displays:
   - Participant name
   - Score and percentage
   - Every question
   - Child’s answer
   - Correct answer
   - Correct/incorrect indicator
8. Confirm an incomplete attempt cannot be viewed as completed.
9. Confirm a different user cannot view the attempt detail.
Fallback behavior
1. Set:
   NEXT_PUBLIC_PARENT_PRACTICE_ALLOW_FALLBACK=false
2. Rebuild/restart the client if using an image-based environment.
3. Simulate an unavailable generation provider.
4. Confirm Parent Practice shows the temporary-unavailability message and the server returns 503.
5. Set the value to true.
6. Rebuild/restart as required.
7. Repeat the failure and confirm the existing fallback behavior is used.
Regression checks
1. Create a normal quiz outside the Parent persona.
2. Confirm its existing duration behavior is unchanged.
3. Start a normal live quiz and verify its timer and expiry.
4. Submit a normal live quiz and confirm its existing analytics remain available.
5. Confirm quizzes with identical content but different owners remain associated with their respective owners.
Automated verification
- Full frontend suite: 19 suites passed
- Frontend tests: 93 passed
- Focused Parent Practice/API tests: 17 passed
- Backend persistence and live-session timing tests: 14 passed
- Production client build: passed
- git diff --check: passed